### PR TITLE
Fix trunc when using tz with sub-hourly offset

### DIFF
--- a/src/timezones/adjusters.jl
+++ b/src/timezones/adjusters.jl
@@ -4,11 +4,14 @@ import Base.Dates: firstdayofweek, lastdayofweek, firstdayofmonth, lastdayofmont
 
 
 # Truncation
+# TODO: Just utilize floor code for truncation?
 function trunc{P<:DatePeriod}(zdt::ZonedDateTime, ::Type{P})
     ZonedDateTime(trunc(localtime(zdt), P), timezone(zdt))
 end
 function trunc{P<:TimePeriod}(zdt::ZonedDateTime, ::Type{P})
-    ZonedDateTime(trunc(utc(zdt), P), timezone(zdt), from_utc=true)
+    local_dt = trunc(localtime(zdt), P)
+    utc_dt = local_dt - zdt.zone.offset
+    ZonedDateTime(utc_dt, timezone(zdt); from_utc=true)
 end
 trunc(zdt::ZonedDateTime, ::Type{Millisecond}) = zdt
 

--- a/test/timezones/adjusters.jl
+++ b/test/timezones/adjusters.jl
@@ -18,6 +18,10 @@ dt = DateTime(2014,10,26,2)
 @test trunc(ZonedDateTime(dt + Minute(59), warsaw, 1), Hour) == ZonedDateTime(dt, warsaw, 1)
 @test trunc(ZonedDateTime(dt + Minute(59), warsaw, 2), Hour) == ZonedDateTime(dt, warsaw, 2)
 
+# Sub-hourly offsets (Issue #33)
+st_johns = resolve("America/St_Johns", tzdata["northamerica"]...)   # UTC-3:30 or UTC-2:30
+zdt = ZonedDateTime(DateTime(2016,8,18,17,57,56,513), st_johns)
+@test trunc(zdt, Hour) == ZonedDateTime(DateTime(2016,8,18,17), st_johns)
 
 # Adjuster functions
 zdt = ZonedDateTime(DateTime(2013,9,9), warsaw) # Monday


### PR DESCRIPTION
Fixes #33. Code is now the same as the `floor` for `ZonedDateTime`. Probably should make `trunc` call `floor` but for now I'll keep them separate.