### PR TITLE
Add collect method for ZDT/TimePeriod ranges

### DIFF
--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -54,3 +54,7 @@ function collect{P<:DatePeriod}(r::OrdinalRange{ZonedDateTime,P}; non_existent=:
 
     return results
 end
+
+function collect{P<:TimePeriod}(r::OrdinalRange{ZonedDateTime,P}; non_existent=:invalid, ambiguous=:invalid)
+    invoke(collect, (OrdinalRange,), r)
+end


### PR DESCRIPTION
Add a method for `collect{P<:TimePeriod}(r::OrdinalRange{ZonedDateTime,P}; non_existent=:invalid, ambiguous=:invalid)` to mirror the `collect{P<:DatePeriod}` method.