### PR TITLE
Update documentation with v0.5 changes

### DIFF
--- a/docs/arithmetic.md
+++ b/docs/arithmetic.md
@@ -1,12 +1,12 @@
 ## ZonedDateTime-Period Arithmetic
 
-`ZonedDateTime` uses calendrical arithmetic in a [similar manner to `DateTime`](http://julia.readthedocs.org/en/latest/manual/dates/#timetype-period-arithmetic) but with some key differences. Lets look at these differences by adding a day to March 30th 2014 in Europe/Warsaw.
+`ZonedDateTime` uses calendrical arithmetic in a [similar manner to `DateTime`](http://julia.readthedocs.io/en/latest/manual/dates/#timetype-period-arithmetic) but with some key differences. Lets look at these differences by adding a day to March 30th 2014 in Europe/Warsaw.
 
 ```julia
-julia> using Dates
+julia> using Base.Dates
 
 julia> warsaw = TimeZone("Europe/Warsaw")
-Europe/Warsaw
+Europe/Warsaw (UTC+1/UTC+2)
 
 julia> spring = ZonedDateTime(2014, 3, 30, warsaw)
 2014-03-30T00:00:00+01:00
@@ -42,10 +42,11 @@ Take particular note of the last example which ends up merging the two periods i
 
 ## Ranges
 
-Julia allows for the use of powerful [adjuster functions](http://julia.readthedocs.org/en/latest/manual/dates/#adjuster-functions) to perform certain cendrical and temporal calculations. The `recur()` function, for example, can take a `StepRange` of `TimeType`s and apply a function to produce a vector of dates that fit certain inclusion criteria (for example, "every fifth Wednesday of the month in 2014 at 09:00"):
+Julia allows for the use of powerful [adjuster functions](http://julia.readthedocs.io/en/latest/manual/dates/#adjuster-functions) to perform certain cendrical and temporal calculations. The `recur()` function, for example, can take a `StepRange` of `TimeType`s and apply a function to produce a vector of dates that fit certain inclusion criteria (for example, "every fifth Wednesday of the month in 2014 at 09:00"):
 
 ```julia
 julia> warsaw = TimeZone("Europe/Warsaw")
+Europe/Warsaw (UTC+1/UTC+2)
 
 julia> start = ZonedDateTime(2014, warsaw)
 2014-01-01T00:00:00+01:00

--- a/docs/conversions.md
+++ b/docs/conversions.md
@@ -63,6 +63,6 @@ julia> zdt = ZonedDateTime(2015,8,6,22,25,TimeZone("Europe/Warsaw"))
 julia> Dates.format(zdt, "yyyymmddzzzz")
 "20150806+02:00"
 
-julia> julia> Dates.format(zdt, "yyyy-mm-dd HH:MM ZZZ")
+julia> Dates.format(zdt, "yyyy-mm-dd HH:MM ZZZ")
 "2015-08-06 22:25 CEST"
 ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -19,18 +19,16 @@ Due to the internal representation of a `VariableTimeZone` it is infeasible to d
 
 ```julia
 julia> warsaw = TimeZone("Europe/Warsaw")
-Europe/Warsaw
+Europe/Warsaw (UTC+1/UTC+2)
 
 julia> last(warsaw.transitions)
-TimeZones.Transition(2037-10-25T01:00:00,TimeZones.FixedTimeZone(:CET,TimeZones.Offset(3600 seconds,0 seconds)))
+2037-10-25T01:00:00 UTC+1/+0 (CET)
 
 julia> warsaw.cutoff  # DateTime up until the last transition is effective
-Nullable(2038-03-28T01:00:00)
+Nullable{DateTime}(2038-03-28T01:00:00)
 
 julia> ZonedDateTime(DateTime(2039), warsaw)
 ERROR: TimeZone Europe/Warsaw does not handle dates on or after 2038-03-28T01:00:00 UTC
- in call at ~/.julia/v0.4/TimeZones/src/timezones/types.jl:146
- in ZonedDateTime at ~/.julia/v0.4/TimeZones/src/timezones/types.jl:260
 ```
 
 It is important to note that since we are taking about future time zone transitions and the rules dictating these transitions are subject to change and may not be accurate. If you still want to work with future `ZonedDateTime` past the default cutoff you can re-compile the `TimeZone` objects and specify the `max_year` keyword:

--- a/docs/rounding.md
+++ b/docs/rounding.md
@@ -3,7 +3,7 @@
 (Only supported in Julia version 0.5 and later.)
 
 Rounding operations (`floor`, `ceil`, and `round`) on `ZonedDateTime`s are performed in a
-[similar manner to `DateTime`](http://julia.readthedocs.org/en/latest/manual/dates/#rounding)
+[similar manner to `DateTime`](http://julia.readthedocs.io/en/latest/manual/dates/#rounding)
 and should generally behave as expected. When `VariableTimeZone` transitions are involved,
 however, unexpected behaviour may be encountered.
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -6,7 +6,7 @@ A `TimeZone` is an abstract type that represents information regarding a specifi
 TimeZone("Europe/Warsaw")
 ```
 
-To see all of the [currently available](/faq/#why-are-the-etc-time-zones-unsupported) time zone names:
+To see all of the [currently available](faq#why-are-the-etc-time-zones-unsupported) time zone names:
 
 ```julia
 timezone_names()
@@ -32,7 +32,7 @@ A `VariableTimeZone` is a concrete type that is a subtype of `TimeZone` that has
 
 ```julia
 julia> warsaw = TimeZone("Europe/Warsaw")
-Europe/Warsaw
+Europe/Warsaw (UTC+1/UTC+2)
 
 julia> typeof(warsaw)
 TimeZones.VariableTimeZone
@@ -52,8 +52,6 @@ julia> ZonedDateTime(DateTime(2014,3,30,1), warsaw)
 
 julia> ZonedDateTime(DateTime(2014,3,30,2), warsaw)
 ERROR: DateTime 2014-03-30T02:00:00 does not exist within Europe/Warsaw
- in ZonedDateTime at ~/.julia/v0.4/TimeZones/src/timezones/types.jl:184
- in ZonedDateTime at ~/.julia/v0.4/TimeZones/src/timezones/types.jl:177
 
 julia> ZonedDateTime(DateTime(2014,3,30,3), warsaw)
 2014-03-30T03:00:00+02:00
@@ -67,12 +65,11 @@ julia> dt = DateTime(2014,10,26,2)
 
 julia> ZonedDateTime(dt, warsaw)
 ERROR: Local DateTime 2014-10-26T02:00:00 is ambiguious
- in ZonedDateTime at ~/.julia/v0.4/TimeZones/src/timezones/types.jl:264
 
-julia> ZonedDateTime(dt, warsaw, 1)  # use the first occurrence of the duplicate hour
+julia> ZonedDateTime(dt, warsaw, 1)  # first occurrence of the duplicate hour
 2014-10-26T02:00:00+02:00
 
-julia> ZonedDateTime(dt, warsaw, 2)  # use second occurrence of the duplicate hour
+julia> ZonedDateTime(dt, warsaw, 2)  # second occurrence of the duplicate hour
 2014-10-26T02:00:00+01:00
 
 julia> ZonedDateTime(dt, warsaw, true)  # use the hour which is in daylight saving time
@@ -94,11 +91,9 @@ Alternatively, when using future dates past the year 2038 will result in an erro
 ```julia
 julia> ZonedDateTime(2039, warsaw)
 ERROR: TimeZone Europe/Warsaw does not handle dates on or after 2038-03-28T01:00:00 UTC
- in call at ~/.julia/v0.4/TimeZones/src/timezones/types.jl:146
- in ZonedDateTime at ~/.julia/v0.4/TimeZones/src/timezones/types.jl:260
 ```
 
-It is possible to have [timezones that work beyond 2038](faq/#far-future-zoneddatetime-with-variabletimezone) but it since these dates are in the future it is possible the timezone rules may change and will not be accurate.
+It is possible to have [timezones that work beyond 2038](faq#far-future-zoneddatetime-with-variabletimezone) but it since these dates are in the future it is possible the timezone rules may change and will not be accurate.
 
 
 ## FixedTimeZone

--- a/src/Olson.jl
+++ b/src/Olson.jl
@@ -3,7 +3,7 @@ module Olson
 using Base.Dates
 
 import ..TimeZones: TZDATA_DIR, COMPILED_DIR, ZERO, MIN_GMT_OFFSET, MAX_GMT_OFFSET,
-    MIN_SAVE, MAX_SAVE, ABS_DIFF_OFFSET, Time
+    MIN_SAVE, MAX_SAVE, ABS_DIFF_OFFSET, TIME_ZONES, Time
 import ..TimeZones: TimeZone, FixedTimeZone, VariableTimeZone, Transition, Time
 
 # Zone type maps to an Olson Timezone database entity
@@ -546,6 +546,7 @@ function compile(tzdata_dir::AbstractString=TZDATA_DIR, dest_dir::AbstractString
     timezones = load(tzdata_dir; max_year=max_year)
 
     isdir(dest_dir) || error("Destination directory doesn't exist")
+    empty!(TIME_ZONES)
 
     for (name, timezone) in timezones
         parts = split(name, "/")


### PR DESCRIPTION
All minor changes that include:

- Update redirecting links
- Fix imports
- Update show output for `VariableTimeZone`, `Transition`, and `Nullable`
- Empty time zone cache when `compile` is re-run
