### PR TITLE
Pin version of tzdata to 2016j for tests

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,6 @@
 import TimeZones: TZDATA_DIR, COMPILED_DIR, extract
 import TimeZones.Olson: compile
-import Compat: @static, is_windows
+import Compat: is_windows
 
 if is_windows()
     import TimeZones: WIN_TRANSLATION_FILE

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,4 @@
-import TimeZones: TZDATA_DIR, COMPILED_DIR
+import TimeZones: TZDATA_DIR, COMPILED_DIR, extract
 import TimeZones.Olson: compile
 import Compat: @static, is_windows
 
@@ -38,14 +38,6 @@ end
 isfile(archive) || error("Unable to download tz database")
 
 info("Extracting tz database archive")
-function extract(archive, directory, files)
-    @static if is_windows()
-        run(pipeline(`7z x $archive -y -so`, `7z x -si -y -ttar -o$directory $files`))
-    else
-        run(`tar xvf $archive --directory=$directory $files`)
-    end
-end
-
 extract(archive, TZDATA_DIR, REGIONS)
 rm(archive)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,5 @@
+import Compat: @static, is_windows
+
 """
     extract(archive, directory, [files]) -> Void
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,18 @@
 """
+    extract(archive, directory, [files]) -> Void
+
+Extracts files from a compressed tar `archive` to the specified `directory`. If `files` is
+specified only the files given will be extracted.
+"""
+function extract(archive, directory, files=String[])
+    @static if is_windows()
+        run(pipeline(`7z x $archive -y -so`, `7z x -si -y -ttar -o$directory $files`))
+    else
+        run(`tar xvf $archive --directory=$directory $files`)
+    end
+end
+
+"""
     @optional(expr)
 
 Creates multiple method signatures to allow optional arguments before required arguments.


### PR DESCRIPTION
Allows modifications to the tz database to not affect the tests which use `resolve`. Note that users can specify the TZDATA_DIR env variable if they which to run the tests against a different version of the tz database.

Overall the change should avoid having PackageEvaluator.jl fail when just the tzdata has been changed.