### PR TITLE
Add `zdt2unix` and `unix2zdt` for timestamp conversion

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1,5 +1,8 @@
 import Base.Dates: now, unix2datetime
 
+# UTC is an abstract type defined in Base.Dates, for some reason
+const utc_tz = FixedTimeZone("UTC")
+
 """
     DateTime(::ZonedDateTime) -> DateTime
 
@@ -41,4 +44,16 @@ end
 
 function astimezone(zdt::ZonedDateTime, tz::FixedTimeZone)
     return ZonedDateTime(zdt.utc_datetime, tz, tz)
+end
+
+function zdt2unix(zdt::ZonedDateTime)
+    Dates.datetime2unix(utc(zdt))
+end
+
+function zdt2unix{T<:Number}(t::Type{T}, zdt::ZonedDateTime)
+    floor(t, Dates.datetime2unix(utc(zdt)))
+end
+
+function unix2zdt(seconds::Integer)
+    ZonedDateTime(Dates.unix2datetime(seconds), utc_tz, from_utc=true)
 end

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -50,8 +50,12 @@ function zdt2unix(zdt::ZonedDateTime)
     Dates.datetime2unix(utc(zdt))
 end
 
-function zdt2unix{T<:Number}(t::Type{T}, zdt::ZonedDateTime)
+function zdt2unix{T<:Integer}(t::Type{T}, zdt::ZonedDateTime)
     floor(t, Dates.datetime2unix(utc(zdt)))
+end
+
+function zdt2unix{T<:Number}(t::Type{T}, zdt::ZonedDateTime)
+    convert(t, Dates.datetime2unix(utc(zdt)))
 end
 
 function unix2zdt(seconds::Integer)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -50,12 +50,12 @@ function zdt2unix(zdt::ZonedDateTime)
     Dates.datetime2unix(utc(zdt))
 end
 
-function zdt2unix{T<:Integer}(t::Type{T}, zdt::ZonedDateTime)
-    floor(t, Dates.datetime2unix(utc(zdt)))
+function zdt2unix{T<:Integer}(::Type{T}, zdt::ZonedDateTime)
+    floor(T, Dates.datetime2unix(utc(zdt)))
 end
 
-function zdt2unix{T<:Number}(t::Type{T}, zdt::ZonedDateTime)
-    convert(t, Dates.datetime2unix(utc(zdt)))
+function zdt2unix{T<:Number}(::Type{T}, zdt::ZonedDateTime)
+    convert(T, Dates.datetime2unix(utc(zdt)))
 end
 
 function unix2zdt(seconds::Integer)

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -33,15 +33,11 @@ zdt_warsaw = ZonedDateTime(dt, warsaw; from_utc=true)
 @test TimeZones.zdt2unix(ZonedDateTime(1970, utc)) == 0
 @test TimeZones.unix2zdt(0) == ZonedDateTime(1970, utc)
 
-no_dst = DateTime(2013, 2, 13)
-no_dst_zdt = ZonedDateTime(no_dst, warsaw)
-no_dst_offset = 3600
-@test TimeZones.zdt2unix(no_dst_zdt) == datetime2unix(no_dst) - no_dst_offset
-
-dst = DateTime(2016, 8, 11)
-dst_zdt = ZonedDateTime(dst, warsaw)
-dst_offset = 7200
-@test TimeZones.zdt2unix(dst_zdt) == datetime2unix(dst) - dst_offset
+for dt in (DateTime(2013, 2, 13), DateTime(2016, 8, 11))
+    zdt = ZonedDateTime(dt, warsaw)
+    offset = TimeZones.value(zdt.zone.offset)   # Total offset in seconds
+    @test TimeZones.zdt2unix(zdt) == datetime2unix(dt) - offset
+end
 
 @test isa(TimeZones.zdt2unix(ZonedDateTime(1970, utc)), Float64)
 @test isa(TimeZones.zdt2unix(Float32, ZonedDateTime(1970, utc)), Float32)

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -43,10 +43,10 @@ dst_zdt = ZonedDateTime(dst, warsaw)
 dst_offset = 7200
 @test TimeZones.zdt2unix(dst_zdt) == datetime2unix(dst) - dst_offset
 
-@test typeof(TimeZones.zdt2unix(ZonedDateTime(1970, utc))) == Float64
-@test typeof(TimeZones.zdt2unix(Float32, ZonedDateTime(1970, utc))) == Float32
-@test typeof(TimeZones.zdt2unix(Int64, ZonedDateTime(1970, utc))) == Int64
-@test typeof(TimeZones.zdt2unix(Int32, ZonedDateTime(1970, utc))) == Int32
+@test isa(TimeZones.zdt2unix(ZonedDateTime(1970, utc)), Float64)
+@test isa(TimeZones.zdt2unix(Float32, ZonedDateTime(1970, utc)), Float32)
+@test isa(TimeZones.zdt2unix(Int64, ZonedDateTime(1970, utc)), Int64)
+@test isa(TimeZones.zdt2unix(Int32, ZonedDateTime(1970, utc)), Int32)
 
 @test TimeZones.zdt2unix(ZonedDateTime(1970, 1, 1, 0, 0, 0, 750, utc)) == 0.75
 @test TimeZones.zdt2unix(Float32, ZonedDateTime(1970, 1, 1, 0, 0, 0, 750, utc)) == 0.75

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -28,3 +28,23 @@ zdt_warsaw = ZonedDateTime(dt, warsaw; from_utc=true)
 # Identical since ZonedDateTime is immutable
 @test astimezone(zdt_utc, warsaw) === zdt_warsaw
 @test astimezone(zdt_warsaw, utc) === zdt_utc
+
+# ZonedDateTime to Unix timestamp (and vice versa)
+@test TimeZones.zdt2unix(ZonedDateTime(1970, utc)) == 0
+@test TimeZones.unix2zdt(0) == ZonedDateTime(1970, utc)
+
+no_dst = DateTime(2013, 2, 13)
+no_dst_zdt = ZonedDateTime(no_dst, warsaw)
+no_dst_offset = 3600
+@test TimeZones.zdt2unix(no_dst_zdt) == datetime2unix(no_dst) - no_dst_offset
+
+dst = DateTime(2016, 8, 11)
+dst_zdt = ZonedDateTime(dst, warsaw)
+dst_offset = 7200
+@test TimeZones.zdt2unix(dst_zdt) == datetime2unix(dst) - dst_offset
+
+@test typeof(TimeZones.zdt2unix(ZonedDateTime(1970, utc))) == Float64
+@test typeof(TimeZones.zdt2unix(Int64, ZonedDateTime(1970, utc))) == Int64
+
+@test TimeZones.zdt2unix(ZonedDateTime(1970, 1, 1, 0, 0, 0, 750, utc)) == 0.75
+@test TimeZones.zdt2unix(Int64, ZonedDateTime(1970, 1, 1, 0, 0, 0, 750, utc)) == 0

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -44,7 +44,11 @@ dst_offset = 7200
 @test TimeZones.zdt2unix(dst_zdt) == datetime2unix(dst) - dst_offset
 
 @test typeof(TimeZones.zdt2unix(ZonedDateTime(1970, utc))) == Float64
+@test typeof(TimeZones.zdt2unix(Float32, ZonedDateTime(1970, utc))) == Float32
 @test typeof(TimeZones.zdt2unix(Int64, ZonedDateTime(1970, utc))) == Int64
+@test typeof(TimeZones.zdt2unix(Int32, ZonedDateTime(1970, utc))) == Int32
 
 @test TimeZones.zdt2unix(ZonedDateTime(1970, 1, 1, 0, 0, 0, 750, utc)) == 0.75
+@test TimeZones.zdt2unix(Float32, ZonedDateTime(1970, 1, 1, 0, 0, 0, 750, utc)) == 0.75
 @test TimeZones.zdt2unix(Int64, ZonedDateTime(1970, 1, 1, 0, 0, 0, 750, utc)) == 0
+@test TimeZones.zdt2unix(Int32, ZonedDateTime(1970, 1, 1, 0, 0, 0, 750, utc)) == 0


### PR DESCRIPTION
These functions allow us to easily convert `ZonedDateTime`s to Unix timestamps (in UTC).