### PR TITLE
Avoid overriding the windowsZone.xml file

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -58,12 +58,12 @@ if is_windows()
     # Details on the contents of this file can be found at:
     # http://cldr.unicode.org/development/development-process/design-proposals/extended-windows-olson-zid-mapping
     xml_source = "http://unicode.org/repos/cldr/trunk/common/supplemental/windowsZones.xml"
-    xml_file = joinpath(translation_dir, "windowsZones.xml")
     try
-        download(xml_source, xml_file)
+        xml_file = download(xml_source)
     catch err
         warn(err)
         info("Falling back to cached XML")
+        xml_file = joinpath(translation_dir, "windowsZones.xml")
     end
 
     info("Pre-processing Windows translation")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -58,12 +58,12 @@ if is_windows()
     # Details on the contents of this file can be found at:
     # http://cldr.unicode.org/development/development-process/design-proposals/extended-windows-olson-zid-mapping
     xml_source = "http://unicode.org/repos/cldr/trunk/common/supplemental/windowsZones.xml"
-    try
-        xml_file = download(xml_source)
+    xml_file = try
+        download(xml_source)
     catch err
         warn(err)
         info("Falling back to cached XML")
-        xml_file = joinpath(translation_dir, "windowsZones.xml")
+        joinpath(translation_dir, "windowsZones.xml")
     end
 
     info("Pre-processing Windows translation")


### PR DESCRIPTION
On Windows downloading a new windowsZone.xml file would override the committed the committed file causing the package to be dirty. Code has been updated to download a new windowsZone.xml file to a temporary location and we can fall back to the committed file.

Originally pointed out by @tkelman https://github.com/JuliaLang/METADATA.jl/pull/8378#issuecomment-287478785