### PR TITLE
Associative ZonedDateTime period math

### DIFF
--- a/docs/arithmetic.md
+++ b/docs/arithmetic.md
@@ -33,12 +33,17 @@ julia> (spring + Day(1)) + Hour(24)
 
 julia> (spring + Hour(24)) + Day(1)
 2014-04-01T01:00:00+02:00
-
-julia> spring + Hour(24) + Day(1)
-2014-04-01T00:00:00+02:00
 ```
 
-Take particular note of the last example which ends up merging the two periods into a single unit of 2 days.
+The first example adds 1 day to 2014-03-30T00:00:00+01:00, which results in 2014-03-31T00:00:00+02:00; then we add 24 hours to get 2014-04-01T00:00:00+02:00. The second example add 24 hours *first* to get 2014-03-31T01:00:00+02:00, and *then* add 1 day which results in 2014-04-01T01:00:00+02:00. When working with operations using multiple periods the operations will be ordered by the Period's *types* and not their positional order; this means `Day` will be added before `Hour`. Hence the following does result in associativity (in Julia 0.6 and above):
+
+```julia
+julia> spring + Hour(24) + Day(1)
+2014-04-01T00:00:00+02:00
+
+julia> spring + Day(1) + Hour(24)
+2014-04-01T00:00:00+02:00
+```
 
 ## Ranges
 

--- a/docs/arithmetic.md
+++ b/docs/arithmetic.md
@@ -25,7 +25,7 @@ julia> spring + Hour(23)
 2014-03-31T00:00:00+02:00
 ```
 
-A potential cause of confusion regarding this behaviour is the loss in associativity. For example:
+A potential cause of confusion regarding this behaviour is the loss in associativity when ordering is forced. For example:
 
 ```julia
 julia> (spring + Day(1)) + Hour(24)
@@ -35,7 +35,7 @@ julia> (spring + Hour(24)) + Day(1)
 2014-04-01T01:00:00+02:00
 ```
 
-The first example adds 1 day to 2014-03-30T00:00:00+01:00, which results in 2014-03-31T00:00:00+02:00; then we add 24 hours to get 2014-04-01T00:00:00+02:00. The second example add 24 hours *first* to get 2014-03-31T01:00:00+02:00, and *then* add 1 day which results in 2014-04-01T01:00:00+02:00. When working with operations using multiple periods the operations will be ordered by the Period's *types* and not their positional order; this means `Day` will be added before `Hour`. Hence the following does result in associativity (in Julia 0.6 and above):
+The first example adds 1 day to 2014-03-30T00:00:00+01:00, which results in 2014-03-31T00:00:00+02:00; then we add 24 hours to get 2014-04-01T00:00:00+02:00. The second example add 24 hours *first* to get 2014-03-31T01:00:00+02:00, and *then* add 1 day which results in 2014-04-01T01:00:00+02:00. When working with operations using multiple periods the operations will be ordered by the Period's *types* and not their positional order; this means `Day` will be added before `Hour`. Hence the following *does* result in associativity:
 
 ```julia
 julia> spring + Hour(24) + Day(1)
@@ -43,6 +43,23 @@ julia> spring + Hour(24) + Day(1)
 
 julia> spring + Day(1) + Hour(24)
 2014-04-01T00:00:00+02:00
+```
+
+If using a version of Julia 0.5 or below you may want to force precedence when mixing `DatePeriod`s and `TimePeriod`s since the expression `Day(1) + Hour(24)` would be automatically canonicalized to `Day(2)`:
+
+```julia
+julia> ZonedDateTime(2014, 10, 25, warsaw) + Day(1) + Hour(24)  # On Julia 0.5 or below
+2014-10-27T00:00:00+01:00
+
+julia> ZonedDateTime(2014, 10, 25, warsaw) + Day(2)
+2014-10-27T00:00:00+01:00
+```
+
+In Julia 0.6 period canonicalization no longer happens automatically:
+
+```
+julia> ZonedDateTime(2014, 10, 25, warsaw) + Day(1) + Hour(24)  # Julia 0.6 and above
+2014-10-26T23:00:00+01:00
 ```
 
 ## Ranges

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -34,10 +34,15 @@ fall = DateTime(2015, 10, 25, 0)   # a 25 hour day in warsaw
 @test ZonedDateTime(fall, warsaw) + Hour(3) == ZonedDateTime(fall + Hour(2), warsaw, 2)
 
 # Non-Associativity
-hour_day = (ZonedDateTime(spring, warsaw) + Hour(24)) + Day(1)
-day_hour = (ZonedDateTime(spring, warsaw) + Day(1)) + Hour(24)
+explicit_hour_day = (ZonedDateTime(spring, warsaw) + Hour(24)) + Day(1)
+explicit_day_hour = (ZonedDateTime(spring, warsaw) + Day(1)) + Hour(24)
+implicit_hour_day = ZonedDateTime(spring, warsaw) + Hour(24) + Day(1)
+implicit_day_hour = ZonedDateTime(spring, warsaw) + Day(1) + Hour(24)
 
-@test hour_day - day_hour == Hour(1)
+# @test explicit_hour_day == implicit_hour_day
+# @test explicit_day_hour == implicit_day_hour
+# @test implicit_hour_day != implicit_day_hour
+@test explicit_day_hour < explicit_hour_day
 
 # CompoundPeriod canonicalization interacting with period arithmetic. Since `spring_zdt` is
 # a 23 hour day this means adding `Day(1)` and `Hour(23)` are equivalent.

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -39,10 +39,10 @@ explicit_day_hour = (ZonedDateTime(spring, warsaw) + Day(1)) + Hour(24)
 implicit_hour_day = ZonedDateTime(spring, warsaw) + Hour(24) + Day(1)
 implicit_day_hour = ZonedDateTime(spring, warsaw) + Day(1) + Hour(24)
 
-# @test explicit_hour_day == implicit_hour_day
-# @test explicit_day_hour == implicit_day_hour
-# @test implicit_hour_day != implicit_day_hour
-@test explicit_day_hour < explicit_hour_day
+@test explicit_hour_day == ZonedDateTime(2015, 3, 31, 1, warsaw)
+@test explicit_day_hour == ZonedDateTime(2015, 3, 31, 0, warsaw)
+@test implicit_hour_day == ZonedDateTime(2015, 3, 31, 0, warsaw)
+@test implicit_day_hour == ZonedDateTime(2015, 3, 31, 0, warsaw)
 
 # CompoundPeriod canonicalization interacting with period arithmetic. Since `spring_zdt` is
 # a 23 hour day this means adding `Day(1)` and `Hour(23)` are equivalent.
@@ -51,10 +51,10 @@ spring_zdt = ZonedDateTime(spring, warsaw)
 
 # When canonicalization happens automatically `Hour(24) + Minute(1)` is converted into
 # `Day(1) + Minute(1)`. Fixed in `JuliaLang/julia#19268`
-if VERSION < v"0.6.0-dev.1874"
-    @test spring_zdt + Hour(23) + Minute(1) == spring_zdt + Hour(24) + Minute(1)
-else
+if VERSION >= v"0.6.0-dev.1874"
     @test spring_zdt + Hour(23) + Minute(1) < spring_zdt + Hour(24) + Minute(1)
+else
+    @test spring_zdt + Hour(23) + Minute(1) == spring_zdt + Hour(24) + Minute(1)
 end
 
 # Arithmetic with a StepRange should always work even when the start/stop lands on

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -2,9 +2,9 @@ import Base.Dates: Day, Hour
 
 warsaw = resolve("Europe/Warsaw", tzdata["europe"]...)
 
-normal = DateTime(2015, 1, 1, 0)   # 24 hour day in warsaw
-spring = DateTime(2015, 3, 29, 0)  # 23 hour day in warsaw
-fall = DateTime(2015, 10, 25, 0)   # 25 hour day in warsaw
+normal = DateTime(2015, 1, 1, 0)   # a 24 hour day in warsaw
+spring = DateTime(2015, 3, 29, 0)  # a 23 hour day in warsaw
+fall = DateTime(2015, 10, 25, 0)   # a 25 hour day in warsaw
 
 # Unary plus
 @test +ZonedDateTime(normal, warsaw) == ZonedDateTime(normal, warsaw)
@@ -39,10 +39,22 @@ day_hour = (ZonedDateTime(spring, warsaw) + Day(1)) + Hour(24)
 
 @test hour_day - day_hour == Hour(1)
 
+# CompoundPeriod canonicalization interacting with period arithmetic. Since `spring_zdt` is
+# a 23 hour day this means adding `Day(1)` and `Hour(23)` are equivalent.
+spring_zdt = ZonedDateTime(spring, warsaw)
+@test spring_zdt + Day(1) + Minute(1) == spring_zdt + Hour(23) + Minute(1)
+
+# When canonicalization happens automatically `Hour(24) + Minute(1)` is converted into
+# `Day(1) + Minute(1)`. Fixed in `JuliaLang/julia#19268`
+if VERSION < v"0.6.0-dev.1874"
+    @test spring_zdt + Hour(23) + Minute(1) == spring_zdt + Hour(24) + Minute(1)
+else
+    @test spring_zdt + Hour(23) + Minute(1) < spring_zdt + Hour(24) + Minute(1)
+end
 
 # Arithmetic with a StepRange should always work even when the start/stop lands on
 # ambiguous or non-existent DateTimes.
-ambiguous = DateTime(2015, 10, 25, 2)  # Ambiguous hour in Warsaw
+ambiguous = DateTime(2015, 10, 25, 2)   # Ambiguous hour in Warsaw
 nonexistent = DateTime(2014, 3, 30, 2)  # Non-existent hour in Warsaw
 
 range = ZonedDateTime(ambiguous - Day(1), warsaw):Hour(1):ZonedDateTime(ambiguous - Day(1) + Hour(1), warsaw)


### PR DESCRIPTION
Changes in https://github.com/JuliaLang/julia/pull/19268 change fixed of the associative arithmetic with periods. Updated documentation and added more tests.