### PR TITLE
Remove newline when reading tzdata version

### DIFF
--- a/src/tzdata/download.jl
+++ b/src/tzdata/download.jl
@@ -6,8 +6,9 @@ const LATEST_FORMAT = Base.Dates.DateFormat("yyyy-mm-ddTHH:MM:SS")
 const LATEST_DELAY = Hour(1)  # In 1996 a correction to a release was made an hour later
 
 function read_latest(io::IO)
-    version = readline(io)
-    retrieved_utc = DateTime(readline(io), LATEST_FORMAT)
+    # Note: Prior to Julia 0.6 readline did not automatically chomp
+    version = chomp(readline(io))
+    retrieved_utc = DateTime(chomp(readline(io)), LATEST_FORMAT)
     return version, retrieved_utc
 end
 

--- a/test/tzdata/download.jl
+++ b/test/tzdata/download.jl
@@ -1,7 +1,12 @@
-import TimeZones.TZData: tzdata_url, tzdata_download, isarchive
+import TimeZones.TZData: tzdata_url, tzdata_download, isarchive, LATEST_FILE, read_latest
 
 @test tzdata_url("2016j") == "https://www.iana.org/time-zones/repository/releases/tzdata2016j.tar.gz"
 @test tzdata_url("latest") == "https://www.iana.org/time-zones/repository/tzdata-latest.tar.gz"
+
+@test isfile(LATEST_FILE)
+version, retrieved = read_latest(LATEST_FILE)
+@test ismatch(r"\A(?:\d{2}){1,2}[a-z]?\z", version)
+@test isa(retrieved, DateTime)
 
 # Note: Try to keep the number of `tzdata_download` calls low to avoid unnecessary network traffic
 mktempdir() do temp_dir

--- a/test/tzdata/download.jl
+++ b/test/tzdata/download.jl
@@ -3,11 +3,6 @@ import TimeZones.TZData: tzdata_url, tzdata_download, isarchive, LATEST_FILE, re
 @test tzdata_url("2016j") == "https://www.iana.org/time-zones/repository/releases/tzdata2016j.tar.gz"
 @test tzdata_url("latest") == "https://www.iana.org/time-zones/repository/tzdata-latest.tar.gz"
 
-@test isfile(LATEST_FILE)
-version, retrieved = read_latest(LATEST_FILE)
-@test ismatch(r"\A(?:\d{2}){1,2}[a-z]?\z", version)
-@test isa(retrieved, DateTime)
-
 # Note: Try to keep the number of `tzdata_download` calls low to avoid unnecessary network traffic
 mktempdir() do temp_dir
     file_path = ignore_output() do
@@ -26,4 +21,11 @@ mktempdir() do temp_dir
 
     @test file_path == last_file_path
     @test mtime(file_path) == last_modified
+
+    # Validate the contents of the LATEST_FILE which will be automatically created when
+    # downloading the latest data.
+    @test isfile(LATEST_FILE)
+    version, retrieved = read_latest(LATEST_FILE)
+    @test ismatch(r"\A(?:\d{2}){1,2}[a-z]?\z", version)
+    @test isa(retrieved, DateTime)
 end


### PR DESCRIPTION
When running on versions of Julia before 0.6 the `readline` function would not automatically chomp. This could become an issue if attempting to download tzdata twice in a row.

```
julia> Pkg.build("TimeZones")
INFO: Building TimeZones
INFO: Latest tzdata is 2017b
INFO: Downloading 2017b
 tzdata
curl: (3) Illegal characters found in URL
========================================[ ERROR: TimeZones ]=========================================

LoadError: failed process: Process(`curl -o '/Users/omus/.julia/v0.5/TimeZones/deps/tzarchive/tzdata2017b
.tar.gz' -L 'https://www.iana.org/time-zones/repository/releases/tzdata2017b
.tar.gz'`, ProcessExited(3)) [3]
while loading /Users/omus/.julia/v0.5/TimeZones/deps/build.jl, in expression starting on line 6

=====================================================================================================
```