### PR TITLE
Update docs to use tz string macro

### DIFF
--- a/docs/arithmetic.md
+++ b/docs/arithmetic.md
@@ -5,7 +5,7 @@
 ```julia
 julia> using Base.Dates
 
-julia> warsaw = TimeZone("Europe/Warsaw")
+julia> warsaw = tz"Europe/Warsaw"
 Europe/Warsaw (UTC+1/UTC+2)
 
 julia> spring = ZonedDateTime(2014, 3, 30, warsaw)
@@ -67,7 +67,7 @@ julia> ZonedDateTime(2014, 10, 25, warsaw) + Day(1) + Hour(24)  # Julia 0.6 and 
 Julia allows for the use of powerful [adjuster functions](http://julia.readthedocs.io/en/latest/manual/dates/#adjuster-functions) to perform certain cendrical and temporal calculations. The `recur()` function, for example, can take a `StepRange` of `TimeType`s and apply a function to produce a vector of dates that fit certain inclusion criteria (for example, "every fifth Wednesday of the month in 2014 at 09:00"):
 
 ```julia
-julia> warsaw = TimeZone("Europe/Warsaw")
+julia> warsaw = tz"Europe/Warsaw"
 Europe/Warsaw (UTC+1/UTC+2)
 
 julia> start = ZonedDateTime(2014, warsaw)
@@ -94,10 +94,10 @@ Note the transition from standard time to daylight saving time (and back again).
 It is possible to define a range `start:step:stop` such that `start` and `stop` have different time zones. In this case the resulting `ZonedDateTime`s will all share a time zone with `start` but the range will stop at the instant that corresponds to `stop` in `start`'s time zone. For example:
 
 ```julia
-julia> start = ZonedDateTime(2016, 1, 1, 12, TimeZone("UTC"))
+julia> start = ZonedDateTime(2016, 1, 1, 12, tz"UTC")
 2016-01-01T12:00:00+00:00
 
-julia> stop = ZonedDateTime(2016, 1, 1, 18, TimeZone("Europe/Warsaw"))
+julia> stop = ZonedDateTime(2016, 1, 1, 18, tz"Europe/Warsaw")
 2016-01-01T18:00:00+01:00
 
 julia> collect(start:Dates.Hour(1):stop)

--- a/docs/conversions.md
+++ b/docs/conversions.md
@@ -3,10 +3,10 @@
 Switching an existing `ZonedDateTime` from one `TimeZone` to another can be done with the function `astimezone`:
 
 ```julia
-julia> zdt = ZonedDateTime(2014, 1, 1, TimeZone("UTC"))
+julia> zdt = ZonedDateTime(2014, 1, 1, tz"UTC")
 2014-01-01T00:00:00+00:00
 
-julia> astimezone(zdt, TimeZone("Asia/Tokyo"))
+julia> astimezone(zdt, tz"Asia/Tokyo")
 2014-01-01T09:00:00+09:00
 ```
 
@@ -57,7 +57,7 @@ It is recommended that you prefer the use of the `z` character code over `Z` tim
 Formatting uses the `Dates.format` function with a `ZonedDateTime` and a format string:
 
 ```julia
-julia> zdt = ZonedDateTime(2015,8,6,22,25,TimeZone("Europe/Warsaw"))
+julia> zdt = ZonedDateTime(2015,8,6,22,25,tz"Europe/Warsaw")
 2015-08-06T22:25:00+02:00
 
 julia> Dates.format(zdt, "yyyymmddzzzz")

--- a/docs/current.md
+++ b/docs/current.md
@@ -3,7 +3,7 @@
 Julia provides the `now()` method to retrieve your current system's time as a `DateTime`. The TimeZones.jl package provides an additional method to the `now` function providing the current time as a `ZonedDateTime`:
 
 ```julia
-now(TimeZone("Europe/Warsaw"))
+now(tz"Europe/Warsaw")
 ```
 
 To get the `TimeZone` currently specified on you system you can use `localzone()`. Combining this method with the new `now` method produces the current system time in the current system's time zone:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,11 +1,11 @@
 Frequently Asked Questions
 ==========================
 
-## Why are the "Etc/*" time zones unsupported?
+## Why are the "Etc/&ast;" time zones unsupported?
 
-According to [IANA](ftp://ftp.iana.org/tz/data/etcetera) the "Etc/*" time zones are only included in the tz database for "historical reasons". Furthermore the time zones offsets provided the Etc/GMT±HH can be misleading. For example the Etc/GMT+4 time zone is 4 hours **behind** UTC rather than 4 hours **ahead** as most people expect. Since TimeZones.jl already provides an easy way of constructing fixed offset time zones using `FixedTimeZone` it was decided to leave these time zones out.
+According to [IANA](ftp://ftp.iana.org/tz/data/etcetera) the "Etc/&ast;" time zones are only included in the tz database for "historical reasons". Furthermore the time zones offsets provided the Etc/GMT±HH can be misleading. For example the Etc/GMT+4 time zone is 4 hours **behind** UTC rather than 4 hours **ahead** as most people expect. Since TimeZones.jl already provides an easy way of constructing fixed offset time zones using `FixedTimeZone` it was decided to leave these time zones out.
 
-If you truly do want to include the "Etc/*" time zones you just need to download the tz source file and re-compile:
+If you truly do want to include the "Etc/&ast;" time zones you just need to download the tz source file and re-compile:
 
 ```julia
 import TimeZones.TZData: extract, active_archive, compile

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,7 +18,7 @@ compile()
 Due to the internal representation of a `VariableTimeZone` it is infeasible to determine a time zones transitions to infinity. Since [2038-01-19T03:14:07](https://en.wikipedia.org/wiki/Year_2038_problem) is the last `DateTime` that can be represented by an `Int32` (`Dates.unix2datetime(typemax(Int32))`) it was decided that 2037 would be the last year in which all transition dates are computed. If additional transitions are known to exist after the last transition then a cutoff date is specified.
 
 ```julia
-julia> warsaw = TimeZone("Europe/Warsaw")
+julia> warsaw = tz"Europe/Warsaw"
 Europe/Warsaw (UTC+1/UTC+2)
 
 julia> last(warsaw.transitions)
@@ -38,6 +38,22 @@ julia> using TimeZones
 
 julia> TimeZones.TZData.compile(max_year=2200)
 
-julia> ZonedDateTime(DateTime(2100), TimeZone("Europe/Warsaw"))
+julia> ZonedDateTime(DateTime(2100), tz"Europe/Warsaw")
 2100-01-01T00:00:00+01:00
+```
+
+Warning: since the `tz` string macro loads the `TimeZone` at compile time the time zone will be loaded before the tz data is recompiled. You can avoid this problem by using the `TimeZone` constructor.
+
+```julia
+julia> begin
+           TimeZones.TZData.compile(max_year=2210)
+           ZonedDateTime(DateTime(2205), tz"Europe/Warsaw")
+       end
+ERROR: UnhandledTimeError: TimeZone Europe/Warsaw does not handle dates on or after 2038-03-28T01:00:00 UTC
+
+julia> begin
+           TimeZones.TZData.compile(max_year=2220)
+           ZonedDateTime(DateTime(2215), TimeZone("Europe/Warsaw"))
+       end
+2215-01-01T00:00:00+01:00
 ```

--- a/docs/rounding.md
+++ b/docs/rounding.md
@@ -42,7 +42,7 @@ The `America/Winnipeg` time zone transitioned from Central Standard Time (UTC-6:
 Central Daylight Time (UTC-5:00) on 2016-03-13, moving directly from 01:59:59 to 03:00:00.
 
 ```julia
-julia> zdt = ZonedDateTime(2016, 3, 13, 1, 45, TimeZone("America/Winnipeg"))
+julia> zdt = ZonedDateTime(2016, 3, 13, 1, 45, tz"America/Winnipeg")
 2016-03-13T01:45:00-06:00
 
 julia> floor(zdt, Dates.Day)
@@ -68,7 +68,7 @@ The `Asia/Colombo` time zone revised the definition of Lanka Time from UTC+6:30 
 on 1996-10-26, moving from 00:29:59 back to 00:00:00.
 
 ```julia
-julia> zdt = ZonedDateTime(1996, 10, 25, 23, 45, TimeZone("Asia/Colombo"))
+julia> zdt = ZonedDateTime(1996, 10, 25, 23, 45, tz"Asia/Colombo")
 1996-10-25T23:45:00+06:30
 
 julia> round(zdt, Dates.Hour)

--- a/docs/types.md
+++ b/docs/types.md
@@ -27,10 +27,10 @@ A `ZonedDateTime` is a *time zone aware* version of a `DateTime` (in Python parl
 To construct a `ZonedDateTime` instance you just need a `DateTime` and a `TimeZone`:
 
 ```julia
-julia> ZonedDateTime(DateTime(2014,1,1), TimeZone("Europe/Warsaw"))
+julia> ZonedDateTime(DateTime(2014,1,1), tz"Europe/Warsaw")
 2014-01-01T00:00:00+01:00
 
-julia> ZonedDateTime(2014, 1, 1, TimeZone("Europe/Warsaw"))
+julia> ZonedDateTime(2014, 1, 1, tz"Europe/Warsaw")
 2014-01-01T00:00:00+01:00
 ```
 
@@ -39,7 +39,7 @@ julia> ZonedDateTime(2014, 1, 1, TimeZone("Europe/Warsaw"))
 A `VariableTimeZone` is a concrete type that is a subtype of `TimeZone` that has offsets that change depending on the specified time. We've already seen an example of a `VariableTimeZone`: "Europe/Warsaw"
 
 ```julia
-julia> warsaw = TimeZone("Europe/Warsaw")
+julia> warsaw = tz"Europe/Warsaw"
 Europe/Warsaw (UTC+1/UTC+2)
 
 julia> typeof(warsaw)
@@ -126,6 +126,6 @@ FixedTimeZone("FOO", -6 * 3600)  # 6 hours in seconds
 Constructing a `ZonedDateTime` works similarly to `VariableTimeZone`:
 
 ```julia
-julia> ZonedDateTime(1960, 1, 1, TimeZone("UTC"))
+julia> ZonedDateTime(1960, 1, 1, tz"UTC")
 1960-01-01T00:00:00+00:00
 ```


### PR DESCRIPTION
Most people will probably want to use the `tz` string macro because it's shorter. I've updated the documentation to reflect typical usage.