### PR TITLE
Add support for TZ format `std offset`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,7 @@ environment:
 
   matrix:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-    COVERAGE: "true"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-    COVERAGE: "true"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
@@ -59,5 +57,5 @@ test_script:
 after_test:
 # Only processing coverage if we ran with the coverage keyword. Note we need Coverage.jl > v0.3.3
   - IF DEFINED COVERAGE (
-      C:\projects\julia\bin\julia -e "cd(Pkg.dir(\"TimeZones\")); Pkg.add(\"Coverage\"); Pkg.checkout(\"Coverage\"); using Coverage; Codecov.submit(process_folder())"
+      C:\projects\julia\bin\julia -e "cd(Pkg.dir(\"TimeZones\")); Pkg.add(\"Coverage\"); using Coverage; Codecov.submit(process_folder())"
     )

--- a/src/local.jl
+++ b/src/local.jl
@@ -31,7 +31,14 @@ function localzone()
         # http://linux.die.net/man/3/tzset
         if haskey(ENV, "TZ")
             name = ENV["TZ"]
-            startswith(name, ':') || error("Currently only support filespec for TZ variable")
+
+            # Currently the only supported TZ format is reading time zone information from
+            # a file.
+            if !startswith(name, ':')
+                error("Encountered an unhandled TZ environment variable format: \"$name\"")
+            end
+
+            # Strip the leading colon
             name = name[2:end]
 
             if startswith(name, '/')

--- a/test/local.jl
+++ b/test/local.jl
@@ -1,5 +1,38 @@
-import TimeZones: TimeZone, localzone
+import TimeZones: TimeZone, localzone, parse_tz_format
 import Compat: is_linux
+
+# Parse the TZ environment variable format
+# Should mirror the behaviour of running:
+# `date -u; env TZ="..." date`
+
+@test_throws ArgumentError parse_tz_format("AB")
+@test_throws ArgumentError parse_tz_format("+")
+@test_throws ArgumentError parse_tz_format("12")
+
+@test parse_tz_format("") == FixedTimeZone("UTC", 0, 0)
+@test parse_tz_format("ABC") == FixedTimeZone("ABC", 0, 0)
+@test parse_tz_format("ABC+") == FixedTimeZone("ABC", 0, 0)
+@test parse_tz_format("ABC-") == FixedTimeZone("ABC", 0, 0)
+
+@test parse_tz_format("ABC1") == FixedTimeZone("ABC", -1 * 3600, 0)
+@test parse_tz_format("ABC+1") == FixedTimeZone("ABC", -1 * 3600, 0)
+@test parse_tz_format("ABC-1") == FixedTimeZone("ABC", 1 * 3600, 0)
+
+@test parse_tz_format("ABC-24")  == FixedTimeZone("ABC", 24 * 3600, 0)
+@test parse_tz_format("ABC-25")  == FixedTimeZone("ABC", 24 * 3600, 0)
+@test parse_tz_format("ABC-100") == FixedTimeZone("ABC", 24 * 3600, 0)
+
+@test parse_tz_format("ABC-00:59")  == FixedTimeZone("ABC", 59 * 60, 0)
+@test parse_tz_format("ABC-00:99")  == FixedTimeZone("ABC", 59 * 60, 0)
+@test parse_tz_format("ABC-00:100") == FixedTimeZone("ABC", 59 * 60, 0)
+
+@test parse_tz_format("ABC-00:00:59")  == FixedTimeZone("ABC", 59, 0)
+@test parse_tz_format("ABC-00:00:99")  == FixedTimeZone("ABC", 59, 0)
+@test parse_tz_format("ABC-00:00:100") == FixedTimeZone("ABC", 59, 0)
+
+@test_throws ArgumentError parse_tz_format("ABC+00:")  # Terminal test is valid and equal to "ABC"
+@test_throws ArgumentError parse_tz_format("ABC+12:")
+
 
 # Ensure that the current system's local time zone is supported. If this test fails make
 # sure to report it as an issue.
@@ -7,12 +40,25 @@ import Compat: is_linux
 
 
 if is_linux()
-    # Bad TZ environmental variables
-    withenv("TZ" => "") do
-        @test_throws ErrorException localzone()
+    # Bad TZ environment variable formats
+    withenv("TZ" => "+12:00") do
+        @test_throws ArgumentError localzone()
     end
     withenv("TZ" => "Europe/Warsaw") do
-        @test_throws ErrorException localzone()
+        @test_throws ArgumentError localzone()
+    end
+
+    # Currently unsupported TZ environment variable formats
+    withenv("TZ" => "NZST-12:00:00NZDT-13:00:00,M10.1.0,M3.3.0") do
+        @test_throws ArgumentError localzone()
+    end
+
+    # Valid TZ formats
+    withenv("TZ" => "") do
+        @test localzone() == utc
+    end
+    withenv("TZ" => "UTC") do
+        @test localzone() == utc
     end
 
     # Absolute filespec


### PR DESCRIPTION
Adding support for parsing the TZ environmental variable format which includes the standard offset name and value.

The reason for this change is to support `TZ="UTC"` which is the new way that Travis CI indicates the time zone in a Linux environment. Additionally, when a TZ env var cannot be processed it is now included in the error message which should help with debugging unsupported TZ formats.