### PR TITLE
Update to Julia 0.7 syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ os:
   - osx
   - linux
 julia:
-  - "0.4"
-  - "0.5"
   - "0.6"
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.6
 Compat 0.25
 Mocking 0.2
 @windows LightXML 0.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
-Compat 0.25
+Compat 0.27
 Mocking 0.2
 @windows LightXML 0.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,13 +3,9 @@ environment:
 
   matrix:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-    COVERAGE: "true"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-    COVERAGE: "true"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-    COVERAGE: "true"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
-    COVERAGE: "true"
 
 # branches:
 #   only:
@@ -43,15 +39,7 @@ build_script:
       Pkg.clone(pwd(), \"TimeZones\"); Pkg.build(\"TimeZones\")"
 
 test_script:
-# Using coverage keyword with Julia 0.5+ is broken (https://github.com/JuliaLang/julia/issues/21289)
-  - IF DEFINED COVERAGE (
-      C:\projects\julia\bin\julia -e "Pkg.test(\"TimeZones\", coverage=true)"
-    ) ELSE (
-      C:\projects\julia\bin\julia -e "Pkg.test(\"TimeZones\")"
-    )
+  - C:\projects\julia\bin\julia -e "Pkg.test(\"TimeZones\", coverage=true)"
 
 after_test:
-# Only processing coverage if we ran with the coverage keyword. Note we need Coverage.jl > v0.3.3
-  - IF DEFINED COVERAGE (
-      C:\projects\julia\bin\julia -e "cd(Pkg.dir(\"TimeZones\")); Pkg.add(\"Coverage\"); using Coverage; Codecov.submit(process_folder())"
-    )
+  - C:\projects\julia\bin\julia -e "cd(Pkg.dir(\"TimeZones\")); Pkg.add(\"Coverage\"); using Coverage; Codecov.submit(process_folder())"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,6 @@ environment:
   JULIA_TZ_VERSION: "2016j"
 
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
     COVERAGE: "true"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"

--- a/src/adjusters.jl
+++ b/src/adjusters.jl
@@ -5,10 +5,10 @@ import Base.Dates: firstdayofweek, lastdayofweek, firstdayofmonth, lastdayofmont
 
 # Truncation
 # TODO: Just utilize floor code for truncation?
-function trunc{P<:DatePeriod}(zdt::ZonedDateTime, ::Type{P})
+function trunc(zdt::ZonedDateTime, ::Type{P}) where P<:DatePeriod
     ZonedDateTime(trunc(localtime(zdt), P), timezone(zdt))
 end
-function trunc{P<:TimePeriod}(zdt::ZonedDateTime, ::Type{P})
+function trunc(zdt::ZonedDateTime, ::Type{P}) where P<:TimePeriod
     local_dt = trunc(localtime(zdt), P)
     utc_dt = local_dt - zdt.zone.offset
     ZonedDateTime(utc_dt, timezone(zdt); from_utc=true)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -49,11 +49,11 @@ function zdt2unix(zdt::ZonedDateTime)
     Dates.datetime2unix(utc(zdt))
 end
 
-function zdt2unix{T<:Integer}(::Type{T}, zdt::ZonedDateTime)
+function zdt2unix(::Type{T}, zdt::ZonedDateTime) where T<:Integer
     floor(T, Dates.datetime2unix(utc(zdt)))
 end
 
-function zdt2unix{T<:Number}(::Type{T}, zdt::ZonedDateTime)
+function zdt2unix(::Type{T}, zdt::ZonedDateTime) where T<:Number
     convert(T, Dates.datetime2unix(utc(zdt)))
 end
 

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -8,7 +8,7 @@ abstract type TimeError <: Exception end
 The provided local datetime is ambiguous within the specified timezone. Typically occurs on
 daylight saving time transitions which "fall back" causing duplicate hour long period.
 """
-mutable struct AmbiguousTimeError <: TimeError
+struct AmbiguousTimeError <: TimeError
     local_dt::DateTime
     timezone::TimeZone
 end
@@ -25,7 +25,7 @@ The provided local datetime is does not exist within the specified timezone. Typ
 occurs on daylight saving time transitions which "spring forward" causing an hour long
 period to be skipped.
 """
-mutable struct NonExistentTimeError <: TimeError
+struct NonExistentTimeError <: TimeError
     local_dt::DateTime
     timezone::TimeZone
 end
@@ -40,7 +40,7 @@ end
 
 The timezone calculation occurs beyond the last calculated transition.
 """
-mutable struct UnhandledTimeError <: TimeError
+struct UnhandledTimeError <: TimeError
     tz::VariableTimeZone
 end
 

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -9,7 +9,7 @@ import Compat: @compat
 The provided local datetime is ambiguous within the specified timezone. Typically occurs on
 daylight saving time transitions which "fall back" causing duplicate hour long period.
 """
-type AmbiguousTimeError <: TimeError
+mutable struct AmbiguousTimeError <: TimeError
     local_dt::DateTime
     timezone::TimeZone
 end
@@ -26,7 +26,7 @@ The provided local datetime is does not exist within the specified timezone. Typ
 occurs on daylight saving time transitions which "spring forward" causing an hour long
 period to be skipped.
 """
-type NonExistentTimeError <: TimeError
+mutable struct NonExistentTimeError <: TimeError
     local_dt::DateTime
     timezone::TimeZone
 end
@@ -41,7 +41,7 @@ end
 
 The timezone calculation occurs beyond the last calculated transition.
 """
-type UnhandledTimeError <: TimeError
+mutable struct UnhandledTimeError <: TimeError
     tz::VariableTimeZone
 end
 

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -1,7 +1,6 @@
 import Base: showerror
-import Compat: @compat
 
-@compat abstract type TimeError <: Exception end
+abstract type TimeError <: Exception end
 
 """
     AmbiguousTimeError(local_datetime, timezone)

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -1,9 +1,8 @@
 import TimeZones.TZData: MIN_OFFSET, MAX_OFFSET
-import Compat: @compat
 
 # TimeZone concepts used to disambiguate context of DateTimes
-# abstract UTC <: TimeZone  # Defined in Base.Dates
-@compat abstract type Local <: TimeZone end
+# abstract type UTC <: TimeZone end # Defined in Base.Dates
+abstract type Local <: TimeZone end
 
 function transition_range(local_dt::DateTime, tz::VariableTimeZone, ::Type{Local})
     transitions = tz.transitions

--- a/src/local.jl
+++ b/src/local.jl
@@ -1,9 +1,9 @@
 # Determine the local system's time zone
 # Based upon Python's tzlocal https://pypi.python.org/pypi/tzlocal
-import Compat: @static, is_apple, is_unix, is_windows, readstring
+import Compat: @static, Sys, readstring
 using Mocking
 
-if is_windows()
+if Sys.iswindows()
     import TimeZones.WindowsTimeZoneIDs: WINDOWS_TRANSLATION
 end
 
@@ -13,7 +13,7 @@ end
 Returns a `TimeZone` object that is equivalent to the system's current time zone.
 """
 function localzone()
-    @static if is_apple()
+    @static if Sys.isapple()
         name = @mock readstring(`systemsetup -gettimezone`)  # Appears to only work as root
         if contains(name, "Time Zone: ")
             name = strip(replace(name, "Time Zone: ", ""))
@@ -23,7 +23,7 @@ function localzone()
             name = match(r"(?<=zoneinfo/).*$", name).match
         end
         return TimeZone(name)
-    elseif is_unix()
+    elseif Sys.isunix()
         name = ""
         validnames = timezone_names()
 
@@ -121,7 +121,7 @@ function localzone()
                 read_tzfile(f, "local")
             end
         end
-    elseif is_windows()
+    elseif Sys.iswindows()
         # Windows powershell should be available on Windows 7 and above
         win_name = strip(@mock readstring(`powershell -Command "[TimeZoneInfo]::Local.Id"`))
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -28,7 +28,7 @@ const FIXED_TIME_ZONE_REGEX = r"""
 
 A `TimeZone` with a constant offset for all of time.
 """
-immutable FixedTimeZone <: TimeZone
+struct FixedTimeZone <: TimeZone
     name::Symbol
     offset::UTCOffset
 end
@@ -89,7 +89,7 @@ function FixedTimeZone(s::AbstractString)
     return FixedTimeZone(name, offset)
 end
 
-immutable Transition
+struct Transition
     utc_datetime::DateTime  # Instant where new zone applies
     zone::FixedTimeZone
 end
@@ -101,7 +101,7 @@ Base.isless(x::Transition,y::Transition) = isless(x.utc_datetime,y.utc_datetime)
 
 A `TimeZone` with an offset that changes over time.
 """
-immutable VariableTimeZone <: TimeZone
+struct VariableTimeZone <: TimeZone
     name::Symbol
     transitions::Vector{Transition}
     cutoff::Nullable{DateTime}
@@ -126,7 +126,7 @@ end
 # A `DateTime` that includes `TimeZone` information.
 # """
 
-immutable ZonedDateTime <: TimeType
+struct ZonedDateTime <: TimeType
     utc_datetime::DateTime
     timezone::TimeZone
     zone::FixedTimeZone  # The current zone for the utc_datetime.

--- a/src/tzdata/archive.jl
+++ b/src/tzdata/archive.jl
@@ -1,6 +1,6 @@
-import Compat: @static, is_windows
+import Compat: @static, Sys
 
-if is_windows()
+if Sys.iswindows()
     const exe7z = joinpath(JULIA_HOME, "7z.exe")
 end
 
@@ -12,7 +12,7 @@ specified only the files given will be extracted. The `verbose` flag can be used
 additional information to STDOUT.
 """
 function extract(archive, directory, files=AbstractString[]; verbose::Bool=false)
-    @static if is_windows()
+    @static if Sys.iswindows()
         cmd = pipeline(`$exe7z x $archive -y -so`, `$exe7z x -si -y -ttar -o$directory $files`)
     else
         cmd = `tar xvf $archive --directory=$directory $files`
@@ -31,7 +31,7 @@ end
 Determines if the given `path` is an archive.
 """
 function isarchive(path)
-    @static if is_windows()
+    @static if Sys.iswindows()
         success(`$exe7z t $path -y`)
     else
         success(`tar tf $path`)
@@ -44,7 +44,7 @@ end
 Returns the file names contained in the `archive`.
 """
 function readarchive(archive)
-    @static if is_windows()
+    @static if Sys.iswindows()
         files = AbstractString[]
         header = "-" ^ 24
         content = false

--- a/src/tzdata/compile.jl
+++ b/src/tzdata/compile.jl
@@ -16,7 +16,7 @@ else
 end
 
 # Zone type maps to an Olson Timezone database entity
-type Zone
+mutable struct Zone
     gmtoffset::TimeOffset
     save::TimeOffset
     rules::AbstractString
@@ -39,7 +39,7 @@ function Base.isless(x::Zone,y::Zone)
 end
 
 # Rules govern how Daylight Savings transitions happen for a given time zone
-type Rule
+mutable struct Rule
     from::Nullable{Int}  # First year rule applies
     to::Nullable{Int}    # Rule applies up until, but not including this year
     month::Int           # Month in which DST transition happens

--- a/src/tzdata/compile.jl
+++ b/src/tzdata/compile.jl
@@ -16,7 +16,7 @@ else
 end
 
 # Zone type maps to an Olson Timezone database entity
-mutable struct Zone
+struct Zone
     gmtoffset::TimeOffset
     save::TimeOffset
     rules::AbstractString
@@ -39,7 +39,7 @@ function Base.isless(x::Zone,y::Zone)
 end
 
 # Rules govern how Daylight Savings transitions happen for a given time zone
-mutable struct Rule
+struct Rule
     from::Nullable{Int}  # First year rule applies
     to::Nullable{Int}    # Rule applies up until, but not including this year
     month::Int           # Month in which DST transition happens

--- a/src/tzdata/timeoffset.jl
+++ b/src/tzdata/timeoffset.jl
@@ -50,7 +50,7 @@ end
 
 convert(::Type{Second}, t::TimeOffset) = Second(value(t))
 convert(::Type{Millisecond}, t::TimeOffset) = Millisecond(value(t) * 1000)
-promote_rule{P<:Union{Week,Day,Hour,Minute,Second}}(::Type{P}, ::Type{TimeOffset}) = Second
+promote_rule(::Type{<:Union{Week,Day,Hour,Minute,Second}}, ::Type{TimeOffset}) = Second
 promote_rule(::Type{Millisecond}, ::Type{TimeOffset}) = Millisecond
 
 # https://en.wikipedia.org/wiki/ISO_8601#Times

--- a/src/tzdata/timeoffset.jl
+++ b/src/tzdata/timeoffset.jl
@@ -3,7 +3,7 @@ import Base.Dates: Period, TimePeriod, Week, Day, Hour, Minute, Second, Millisec
     value, toms, hour, minute, second
 
 # Convenience type for working with HH:MM:SS.
-immutable TimeOffset <: TimePeriod
+struct TimeOffset <: TimePeriod
     seconds::Int
 end
 const ZERO = TimeOffset(0)

--- a/src/tzfile.jl
+++ b/src/tzfile.jl
@@ -6,7 +6,7 @@ import Compat: read, unsafe_string
 
 const TZFILE_MAX = unix2datetime(typemax(Int32))
 
-immutable TransitionTimeInfo
+struct TransitionTimeInfo
     gmtoff::Int32     # tt_gmtoff
     isdst::Int8       # tt_isdst
     abbrindex::UInt8  # tt_abbrind

--- a/src/utcoffset.jl
+++ b/src/utcoffset.jl
@@ -9,7 +9,7 @@ import Base.Dates: AbstractTime, Second, value
 A `UTCOffset` is an amount of time subtracted from or added to UTC to get the current
 local time – whether it's standard time or daylight saving time.
 """
-immutable UTCOffset <: AbstractTime
+struct UTCOffset <: AbstractTime
     std::Second  # Standard time offset from UTC in seconds
     dst::Second  # Daylight saving time offset in seconds
 

--- a/test/local.jl
+++ b/test/local.jl
@@ -1,5 +1,5 @@
 import TimeZones: TimeZone, localzone, parse_tz_format
-import Compat: is_linux
+import Compat: Sys
 
 # Parse the TZ environment variable format
 # Should mirror the behaviour of running:
@@ -39,7 +39,7 @@ import Compat: is_linux
 @test isa(localzone(), TimeZone)
 
 
-if is_linux()
+if Sys.islinux()
     # Bad TZ environment variable formats
     withenv("TZ" => "+12:00") do
         @test_throws ArgumentError localzone()

--- a/test/local_mocking.jl
+++ b/test/local_mocking.jl
@@ -1,7 +1,7 @@
 import TimeZones: TimeZone, localzone
 import Mocking: @patch, apply
 import Base: AbstractCmd
-import Compat: is_apple, is_windows, is_linux, readstring
+import Compat: Sys, readstring
 
 # For mocking make sure we are actually changing the time zone
 name = string(localzone()) == "Europe/Warsaw" ? "Pacific/Apia" : "Europe/Warsaw"
@@ -11,7 +11,7 @@ tzfile_path = joinpath(TZFILE_DIR, split(name, '/')...)
 win_name = name == "Europe/Warsaw" ? "Central European Standard Time" : "Samoa Standard Time"
 timezone = TimeZone(name)
 
-if is_apple()
+if Sys.isapple()
     # Determine time zone via systemsetup.
     patch = @patch readstring(cmd::AbstractCmd) = "Time Zone:  " * name * "\n"
     apply(patch) do
@@ -27,7 +27,7 @@ if is_apple()
         @test localzone() == timezone
     end
 
-elseif is_windows()
+elseif Sys.iswindows()
     patch = @patch readstring(cmd::AbstractCmd) = "$win_name\r\n"
     apply(patch) do
         @test localzone() == timezone
@@ -35,7 +35,7 @@ elseif is_windows()
 
     # Dateline Standard Time -> Etc/GMT+12 -> UTC-12:00
 
-elseif is_linux()
+elseif Sys.islinux()
     # Test TZ environmental variable
     withenv("TZ" => ":$name") do
         @test localzone() == timezone


### PR DESCRIPTION
Drops support for Julia 0.4 and 0.5. Replaces #85