### PR TITLE
Avoid invalid use of SystemError

### DIFF
--- a/src/local.jl
+++ b/src/local.jl
@@ -60,7 +60,7 @@ function localzone()
                     end
                 end
 
-                throw(SystemError("unable to locate tzfile: $name"))
+                error("unable to locate tzfile: $name")
             end
         end
 


### PR DESCRIPTION
Creating a partial `SystemError` struct will result in an `UndefRefError` when attempting to display the exception:

```julia
julia> throw(SystemError("demo"))
ERROR: SYSTEM: show(lasterr) caused an error
UndefRefError()
```