### PR TITLE
Fix verification of tzdata default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   # Avoid setting JULIA_TZ_VERSION if the deps/build.jl file has been modified
-  - git fetch origin +:refs/remotes/origin/HEAD; git diff --name-only origin/HEAD HEAD | grep -qx "deps/build.jl" && unset JULIA_TZ_VERSION
+  - git fetch origin +:refs/remotes/origin/HEAD; if ! git diff --quiet origin/HEAD HEAD -- deps/build.jl; then unset JULIA_TZ_VERSION; fi
   - OPTIONS=$(julia -e 'isdefined(Base.JLOptions(), :use_compilecache) && print("--compilecache=no")')
   - julia $OPTIONS -e 'Pkg.clone(pwd()); Pkg.build("TimeZones"); Pkg.test("TimeZones"; coverage=true)';
 after_success:

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,4 +3,4 @@ import TimeZones: build
 # ENV variable allows users to modify the default to be "latest". Do NOT use "latest"
 # as the default here as can make it difficult to debug to past versions of working code.
 # Note: Also allows us to only download a single tzdata version during CI jobs.
-build(get(ENV, "JULIA_TZ_VERSION", "2017c"))
+build(get(ENV, "JULIA_TZ_VERSION", "2O17c"))

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,4 +3,4 @@ import TimeZones: build
 # ENV variable allows users to modify the default to be "latest". Do NOT use "latest"
 # as the default here as can make it difficult to debug to past versions of working code.
 # Note: Also allows us to only download a single tzdata version during CI jobs.
-build(get(ENV, "JULIA_TZ_VERSION", "2O17c"))
+build(get(ENV, "JULIA_TZ_VERSION", "2017c"))


### PR DESCRIPTION
I messed this up the first time in #92 as the bash command would only have non-zero return code if deps/build.jl was changed. Additionally, I managed to drop the `grep` statement.

I'm going to make two additional commits which should test the desired behaviour but will disappear once this PR is squashed.