### PR TITLE
Update for Dates standard library

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
-Compat 0.33
+Compat 0.37
 Mocking 0.4
 @windows LightXML 0.2

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,6 +1,6 @@
 using PkgBenchmark
 using TimeZones
-import Base.Dates: DateFormat
+import Compat.Dates: DateFormat
 import TimeZones.TZData: parse_components
 
 @benchgroup "parse" begin

--- a/docs/conversions.md
+++ b/docs/conversions.md
@@ -12,7 +12,7 @@ julia> astimezone(zdt, tz"Asia/Tokyo")
 
 ## Parsing strings
 
-`ZonedDateTime` parsing extends the functionality provided by `Base.Dates`. If you haven't already it is recommended that you first read the official Julia manual on [Date and DateTime](https://docs.julialang.org/en/stable/manual/dates/#Constructors-1). The `TimeZones` package adds `z` and `Z` to the list of available [parsing character codes](https://docs.julialang.org/en/stable/stdlib/dates/#Base.Dates.DateFormat):
+`ZonedDateTime` parsing extends the functionality provided by `Dates`. If you haven't already it is recommended that you first read the official Julia manual on [Date and DateTime](https://docs.julialang.org/en/stable/manual/dates/#Constructors-1). The `TimeZones` package adds `z` and `Z` to the list of available [parsing character codes](https://docs.julialang.org/en/stable/stdlib/dates/#Base.Dates.DateFormat):
 
 | Code | Matches              | Comment                                          |
 |:-----|:---------------------|:-------------------------------------------------|

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -2,8 +2,8 @@ __precompile__()
 
 module TimeZones
 
-using Base.Dates
-import Base.Dates: TimeZone, AbstractTime
+using Compat.Dates
+import Compat.Dates: TimeZone, AbstractTime
 import Base: @deprecate_binding
 import Compat: Sys
 
@@ -18,7 +18,7 @@ export TimeZone, @tz_str, FixedTimeZone, VariableTimeZone, ZonedDateTime, DateTi
     firstdayofmonth, lastdayofmonth,
     firstdayofyear, lastdayofyear,
     firstdayofquarter, lastdayofquarter,
-    # Re-export from Base.Dates
+    # Re-export from Dates
     yearmonthday, yearmonth, monthday, year, month, week, day, dayofmonth,
     # conversion.jl
     now, astimezone,
@@ -38,14 +38,14 @@ const TIME_ZONES = Dict{AbstractString,TimeZone}()
 
 function __init__()
     # Base extension needs to happen everytime the module is loaded (issue #24)
-    if isdefined(Base.Dates, :SLOT_RULE)
-        Base.Dates.SLOT_RULE['z'] = TimeZone
-        Base.Dates.SLOT_RULE['Z'] = TimeZone
+    if isdefined(Dates, :SLOT_RULE)
+        Dates.SLOT_RULE['z'] = TimeZone
+        Dates.SLOT_RULE['Z'] = TimeZone
     else
-        Base.Dates.CONVERSION_SPECIFIERS['z'] = TimeZone
-        Base.Dates.CONVERSION_SPECIFIERS['Z'] = TimeZone
-        Base.Dates.CONVERSION_DEFAULTS[TimeZone] = ""
-        Base.Dates.CONVERSION_TRANSLATIONS[ZonedDateTime] = (
+        Dates.CONVERSION_SPECIFIERS['z'] = TimeZone
+        Dates.CONVERSION_SPECIFIERS['Z'] = TimeZone
+        Dates.CONVERSION_DEFAULTS[TimeZone] = ""
+        Dates.CONVERSION_TRANSLATIONS[ZonedDateTime] = (
             Year, Month, Day, Hour, Minute, Second, Millisecond, TimeZone,
         )
     end

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -1,4 +1,4 @@
-import Base.Dates: Hour, Minute, Second, Millisecond,
+import Compat.Dates: Hour, Minute, Second, Millisecond,
     days, hour, minute, second, millisecond
 
 """

--- a/src/adjusters.jl
+++ b/src/adjusters.jl
@@ -1,5 +1,5 @@
-import Base.Dates: trunc, DatePeriod, TimePeriod
-import Base.Dates: firstdayofweek, lastdayofweek, firstdayofmonth, lastdayofmonth,
+import Compat.Dates: trunc, DatePeriod, TimePeriod
+import Compat.Dates: firstdayofweek, lastdayofweek, firstdayofmonth, lastdayofmonth,
     firstdayofyear, lastdayofyear, firstdayofquarter, lastdayofquarter
 
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1,6 +1,6 @@
-import Base.Dates: now, julian2datetime, unix2datetime
+import Compat.Dates: now, julian2datetime, unix2datetime
 
-# UTC is an abstract type defined in Base.Dates, for some reason
+# UTC is an abstract type defined in Dates, for some reason
 const utc_tz = FixedTimeZone("UTC")
 
 """

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -1,7 +1,7 @@
 import TimeZones.TZData: MIN_OFFSET, MAX_OFFSET
 
 # TimeZone concepts used to disambiguate context of DateTimes
-# abstract type UTC <: TimeZone end # Defined in Base.Dates
+# abstract type UTC <: TimeZone end # Defined in Dates
 abstract type Local <: TimeZone end
 
 function transition_range(local_dt::DateTime, tz::VariableTimeZone, ::Type{Local})

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,5 +1,5 @@
 import Base: print, show, showcompact
-import Base.Dates: value, DateFormat
+import Compat.Dates: value, DateFormat
 
 print(io::IO, tz::TimeZone) = print(io, tz.name)
 function print(io::IO, tz::FixedTimeZone)

--- a/src/parse-old.jl
+++ b/src/parse-old.jl
@@ -1,5 +1,5 @@
 import Base: parse
-import Base.Dates: Slot, slotparse, slotformat
+import Compat.Dates: Slot, slotparse, slotformat
 
 function slotparse(slot::Slot{TimeZone},x,locale)
     if slot.letter == 'z'
@@ -34,7 +34,7 @@ function slotformat(slot::Slot{TimeZone},zdt::ZonedDateTime,locale)
 end
 
 function parse(::Type{ZonedDateTime}, str::AbstractString, df::DateFormat)
-    ZonedDateTime(Base.Dates.parse(str, df)...)
+    ZonedDateTime(Compat.Dates.parse(str, df)...)
 end
 
 # Note: ISOZonedDateTimeFormat is defined in the module __init__ which means that this

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -1,4 +1,4 @@
-import Base.Dates: DateFormat, DatePart, tryparsenext, format, min_width, max_width
+import Compat.Dates: DateFormat, DatePart, tryparsenext, format, min_width, max_width
 
 function tryparsenext_fixedtz(str, i, len, min_width::Int=1, max_width::Int=0)
     tz_start, tz_end = i, 0

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -1,4 +1,4 @@
-import Base.Dates: guess
+import Compat.Dates: guess
 
 """
     guess(start::ZonedDateTime, finish::ZonedDateTime, step) -> Integer

--- a/src/rounding.jl
+++ b/src/rounding.jl
@@ -1,4 +1,4 @@
-import Base.Dates: Period, DatePeriod, TimePeriod
+import Compat.Dates: Period, DatePeriod, TimePeriod
 
 function Base.floor(zdt::ZonedDateTime, p::DatePeriod)
     return ZonedDateTime(floor(localtime(zdt), p), timezone(zdt))
@@ -15,7 +15,7 @@ function Base.ceil(zdt::ZonedDateTime, p::DatePeriod)
     return ZonedDateTime(ceil(localtime(zdt), p), timezone(zdt))
 end
 
-#function Base.Dates.floorceil(zdt::ZonedDateTime, p::Dates.DatePeriod)
+#function Dates.floorceil(zdt::ZonedDateTime, p::Dates.DatePeriod)
     #return floor(zdt, p), ceil(zdt, p)
 #end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,7 +1,7 @@
 
-# import Base.Dates: UTInstant, DateTime, TimeZone, Millisecond
-using Base.Dates
-import Base.Dates: value
+# import Compat.Dates: UTInstant, DateTime, TimeZone, Millisecond
+using Compat.Dates
+import Compat.Dates: value
 import Base: promote_rule, ==, hash, isequal, isless
 import Compat: xor
 

--- a/src/tzdata/compile.jl
+++ b/src/tzdata/compile.jl
@@ -1,12 +1,12 @@
-using Base.Dates
+using Compat.Dates
 
 import ...TimeZones: TZ_SOURCE_DIR, COMPILED_DIR, TIME_ZONES
 import ...TimeZones: TimeZone, FixedTimeZone, VariableTimeZone, Transition
 import ..TZData: TimeOffset, ZERO, MIN_GMT_OFFSET, MAX_GMT_OFFSET,
     MIN_SAVE, MAX_SAVE, ABS_DIFF_OFFSET
 
-if isdefined(Base.Dates, :parse_components)
-    parse_components = Base.Dates.parse_components
+if isdefined(Dates, :parse_components)
+    parse_components = Dates.parse_components
 else
     # Note: On older versions of Julia this will sort the Periods. Since our DateFormat
     # is already in reverse sorted order there shouldn't be a difference.

--- a/src/tzdata/download.jl
+++ b/src/tzdata/download.jl
@@ -1,8 +1,9 @@
 import TimeZones: DEPS_DIR
 import Compat: unsafe_get, isassigned
+using Compat.Dates
 
 const LATEST_FILE = joinpath(DEPS_DIR, "latest")
-const LATEST_FORMAT = Base.Dates.DateFormat("yyyy-mm-ddTHH:MM:SS")
+const LATEST_FORMAT = Dates.DateFormat("yyyy-mm-ddTHH:MM:SS")
 const LATEST_DELAY = Hour(1)  # In 1996 a correction to a release was made an hour later
 
 function read_latest(io::IO)

--- a/src/tzdata/timeoffset.jl
+++ b/src/tzdata/timeoffset.jl
@@ -1,5 +1,5 @@
 import Base: convert, promote_rule, string, print, show
-import Base.Dates: Period, TimePeriod, Week, Day, Hour, Minute, Second, Millisecond,
+import Compat.Dates: Period, TimePeriod, Week, Day, Hour, Minute, Second, Millisecond,
     value, toms, hour, minute, second
 
 # Convenience type for working with HH:MM:SS.

--- a/src/utcoffset.jl
+++ b/src/utcoffset.jl
@@ -1,5 +1,5 @@
 import Base: +, -, isequal, isless, print, show
-import Base.Dates: AbstractTime, Second, value
+import Compat.Dates: AbstractTime, Second, value
 
 # Note: The IANA time zone database rounds offset precision to the nearest second
 # See "America/New_York" notes in tzdata file "northamerica" for an example.

--- a/test/accessors.jl
+++ b/test/accessors.jl
@@ -1,4 +1,5 @@
-import Base.Dates: Second
+import Compat.Dates
+import Compat.Dates: Second
 
 warsaw = resolve("Europe/Warsaw", tzdata["europe"]...)
 fixed = FixedTimeZone("Fixed", -7200, 3600)
@@ -14,7 +15,7 @@ zdt = ZonedDateTime(DateTime(2014,6,12,23,59,58,57), fixed)
 @test TimeZones.second(zdt) == 58
 @test TimeZones.millisecond(zdt) == 57
 
-# Make sure that Base.Dates accessors work with ZonedDateTime.
+# Make sure that Dates accessors work with ZonedDateTime.
 @test Dates.year(zdt) == 2014
 @test Dates.month(zdt) == 6
 @test Dates.week(zdt) == 24

--- a/test/adjusters.jl
+++ b/test/adjusters.jl
@@ -1,4 +1,4 @@
-using Base.Dates
+using Compat.Dates
 
 # Basic truncation
 warsaw = resolve("Europe/Warsaw", tzdata["europe"]...)
@@ -36,5 +36,5 @@ zdt = ZonedDateTime(DateTime(2013,9,9), warsaw) # Monday
 @test TimeZones.lastdayofquarter(zdt) == ZonedDateTime(DateTime(2013,9,30), warsaw)
 
 
-# TODO: Should be in Base.Dates.
+# TODO: Should be in Dates.
 @test Dates.lastdayofyear(DateTime(2013,9,9)) == DateTime(2013,12,31)

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -1,4 +1,4 @@
-import Base.Dates: Day, Hour
+import Compat.Dates: Day, Hour
 
 warsaw = resolve("Europe/Warsaw", tzdata["europe"]...)
 

--- a/test/io.jl
+++ b/test/io.jl
@@ -49,7 +49,7 @@ zdt = ZonedDateTime(dt, warsaw)
 # TimeZone parsing
 
 # Make sure that TimeZone conversion specifiers are set (issue #24)
-CONVERSION_SPECIFIERS = isdefined(Base.Dates, :SLOT_RULE) ? Dates.keys(Dates.SLOT_RULE) : keys(Dates.CONVERSION_SPECIFIERS)
+CONVERSION_SPECIFIERS = isdefined(Dates, :SLOT_RULE) ? Dates.keys(Dates.SLOT_RULE) : keys(Dates.CONVERSION_SPECIFIERS)
 @test 'z' in CONVERSION_SPECIFIERS
 @test 'Z' in CONVERSION_SPECIFIERS
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1,4 +1,4 @@
-import Base.Dates: Day, Hour, Minute
+import Compat.Dates: Day, Hour, Minute
 
 
 utc = FixedTimeZone("UTC", 0)

--- a/test/types.jl
+++ b/test/types.jl
@@ -1,5 +1,5 @@
 import TimeZones: Transition
-import Base.Dates: Hour, Second, UTM
+import Compat.Dates: Hour, Second, UTM
 
 
 # Constructor FixedTimeZone from a string.

--- a/test/tzdata/compile.jl
+++ b/test/tzdata/compile.jl
@@ -1,6 +1,6 @@
 import TimeZones: Transition
 import TimeZones.TZData: ZoneDict, RuleDict, zoneparse, ruleparse, resolve, parsedate, order_rules
-import Base.Dates: Hour, Minute, Second
+import Compat.Dates: Hour, Minute, Second, DateTime, Date
 
 ### parsedate ###
 


### PR DESCRIPTION
Updated to work on 0.7 by replacing Base.Dates with either Dates or Compat.Dates, as appropriate.