### PR TITLE
Add assistance to no active version error

### DIFF
--- a/src/tzdata/version.jl
+++ b/src/tzdata/version.jl
@@ -93,7 +93,9 @@ function tzdata_version_archive(archive::AbstractString)
 end
 
 function active_version()
-    !isfile(ACTIVE_VERSION_FILE) && error("No active tzdata version")
+    if !isfile(ACTIVE_VERSION_FILE)
+        error("No active tzdata version. Try re-building TimeZones")
+    end
     read(ACTIVE_VERSION_FILE, String)
 end
 


### PR DESCRIPTION
Improves on the error message when no active tzdata version is available. Error can occur on a manual installation of the package.