### PR TITLE
Fix errors for parsing tests on julia 0.7

### DIFF
--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -66,12 +66,7 @@ string is assumed to be a static time zone.
 A list of recognized time zones names is available from `timezone_names()`. Supported static
 time zone string formats can be found in `FixedTimeZone(::AbstractString)`.
 """
-function TimeZone(str::Union{AbstractString, Nullable{String}})
-    if str isa Nullable
-        str = isnull(str) ? throw(ArgumentError("Unknown time zone \"$str\"")) : get(str)
-        str = convert(AbstractString, str)
-    end
-
+function TimeZone(str::AbstractString)
     return get!(TIME_ZONES, str) do
         if ismatch(FIXED_TIME_ZONE_REGEX, str)
             return FixedTimeZone(str)
@@ -84,6 +79,17 @@ function TimeZone(str::Union{AbstractString, Nullable{String}})
             return deserialize(fp)
         end
     end
+end
+
+"""
+    TimeZone(str::Nullable{String}) -> TimeZone
+
+Constructs a `TimeZone` subtype based upon the string. If the string is null throws an
+ArgumentError.
+"""
+function TimeZone(str::Nullable{String})
+    isnull(str) && throw(ArgumentError("Unknown time zone \"$str\""))
+    TimeZone(get(str))
 end
 
 """

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -66,7 +66,12 @@ string is assumed to be a static time zone.
 A list of recognized time zones names is available from `timezone_names()`. Supported static
 time zone string formats can be found in `FixedTimeZone(::AbstractString)`.
 """
-function TimeZone(str::AbstractString)
+function TimeZone(str::Union{AbstractString, Nullable{String}})
+    if str isa Nullable
+        str = isnull(str) ? throw(ArgumentError("Unknown time zone \"$str\"")) : get(str)
+        str = convert(AbstractString, str)
+    end
+
     return get!(TIME_ZONES, str) do
         if ismatch(FIXED_TIME_ZONE_REGEX, str)
             return FixedTimeZone(str)

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -29,7 +29,7 @@ function tryparsenext_fixedtz(str, i, len, min_width::Int=1, max_width::Int=0)
         return Nullable{String}(), i
     else
         tz = SubString(str, tz_start, tz_end)
-        return Nullable{String}(tz), i
+        return Nullable{String}(convert(String, tz)), i
     end
 end
 
@@ -56,7 +56,7 @@ function tryparsenext_tz(str, i, len, min_width::Int=1, max_width::Int=0)
         # purposes we'll treat all abbreviations except for UTC and GMT as ambiguous.
         # e.g. "MST": "Mountain Standard Time" (UTC-7) or "Moscow Summer Time" (UTC+3:31).
         if contains(name, "/") || name in ("UTC", "GMT")
-            return Nullable{String}(name), i
+            return Nullable{String}(convert(String, name)), i
         else
             return Nullable{String}(), i
         end

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -29,7 +29,7 @@ function tryparsenext_fixedtz(str, i, len, min_width::Int=1, max_width::Int=0)
         return Nullable{String}(), i
     else
         tz = SubString(str, tz_start, tz_end)
-        return Nullable{String}(convert(String, tz)), i
+        return Nullable{String}(String(tz)), i
     end
 end
 
@@ -56,7 +56,7 @@ function tryparsenext_tz(str, i, len, min_width::Int=1, max_width::Int=0)
         # purposes we'll treat all abbreviations except for UTC and GMT as ambiguous.
         # e.g. "MST": "Mountain Standard Time" (UTC-7) or "Moscow Summer Time" (UTC+3:31).
         if contains(name, "/") || name in ("UTC", "GMT")
-            return Nullable{String}(convert(String, name)), i
+            return Nullable{String}(String(name)), i
         else
             return Nullable{String}(), i
         end

--- a/src/types.jl
+++ b/src/types.jl
@@ -242,7 +242,7 @@ end
 
 # Parsing constructor. Note we typically don't support passing in time zone information as a
 # string since we cannot do not know if we need to support resolving ambiguity.
-function ZonedDateTime(y::Int64, m::Int64, d::Int64, h::Int64, mi::Int64, s::Int64, ms::Int64, tz::AbstractString)
+function ZonedDateTime(y::Int64, m::Int64, d::Int64, h::Int64, mi::Int64, s::Int64, ms::Int64, tz::Union{AbstractString, Nullable{String}})
     ZonedDateTime(DateTime(y,m,d,h,mi,s,ms), TimeZone(tz))
 end
 
@@ -305,7 +305,7 @@ end
 typemin(::Type{ZonedDateTime}) = ZonedDateTime(typemin(DateTime), utc_tz; from_utc=true)
 typemax(::Type{ZonedDateTime}) = ZonedDateTime(typemax(DateTime), utc_tz; from_utc=true)
 
-function validargs(::Type{ZonedDateTime}, y::Int64, m::Int64, d::Int64, h::Int64, mi::Int64, s::Int64, ms::Int64, tz::AbstractString)
+function validargs(::Type{ZonedDateTime}, y::Int64, m::Int64, d::Int64, h::Int64, mi::Int64, s::Int64, ms::Int64, tz::Union{AbstractString, Nullable{String}})
     err = validargs(DateTime, y, m, d, h, mi, s, ms)
     isnull(err) || return err
     istimezone(tz) || return argerror("TimeZone: \"$str\" is not a recognized time zone")

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -18,25 +18,15 @@ import Compat.Dates: parse_components, default_format
 end
 
 @testset "tryparse" begin
-    if VERSION < v"0.7.0-DEV.3017"
-        @test isequal(
-            tryparse(ZonedDateTime, "2013-03-20 11:00:00+04:00", dateformat"y-m-d H:M:SSz"),
-            Nullable(ZonedDateTime(2013, 3, 20, 11, tz"UTC+04")),
-        )
-        @test isequal(
-            tryparse(ZonedDateTime, "2016-04-11 08:00 EST", dateformat"yyyy-mm-dd HH:MM zzz"),
-            Nullable{ZonedDateTime}(),
-        )
-    else
-        @test isequal(
-            tryparse(ZonedDateTime, "2013-03-20 11:00:00+04:00", dateformat"y-m-d H:M:SSz"),
-            ZonedDateTime(2013, 3, 20, 11, tz"UTC+04"),
-        )
-        @test isequal(
-            tryparse(ZonedDateTime, "2016-04-11 08:00 EST", dateformat"yyyy-mm-dd HH:MM zzz"),
-            nothing,
-        )
-    end
+    zdt = ZonedDateTime(2013, 3, 20, 11, tz"UTC+04")
+    @test isequal(
+        tryparse(ZonedDateTime, "2013-03-20 11:00:00+04:00", dateformat"y-m-d H:M:SSz"),
+        VERSION < v"0.7.0-DEV.3017" ? Nullable(zdt) : zdt,
+    )
+    @test isequal(
+        tryparse(ZonedDateTime, "2016-04-11 08:00 EST", dateformat"yyyy-mm-dd HH:MM zzz"),
+        VERSION < v"0.7.0-DEV.3017" ? Nullable{ZonedDateTime}() : nothing,
+    )
 end
 
 @testset "parse components" begin

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -18,14 +18,25 @@ import Compat.Dates: parse_components, default_format
 end
 
 @testset "tryparse" begin
-    @test isequal(
-        tryparse(ZonedDateTime, "2013-03-20 11:00:00+04:00", dateformat"y-m-d H:M:SSz"),
-        Nullable(ZonedDateTime(2013, 3, 20, 11, tz"UTC+04")),
-    )
-    @test isequal(
-        tryparse(ZonedDateTime, "2016-04-11 08:00 EST", dateformat"yyyy-mm-dd HH:MM zzz"),
-        Nullable{ZonedDateTime}(),
-    )
+    if VERSION < v"0.7.0-DEV.3017"
+        @test isequal(
+            tryparse(ZonedDateTime, "2013-03-20 11:00:00+04:00", dateformat"y-m-d H:M:SSz"),
+            Nullable(ZonedDateTime(2013, 3, 20, 11, tz"UTC+04")),
+        )
+        @test isequal(
+            tryparse(ZonedDateTime, "2016-04-11 08:00 EST", dateformat"yyyy-mm-dd HH:MM zzz"),
+            Nullable{ZonedDateTime}(),
+        )
+    else
+        @test isequal(
+            tryparse(ZonedDateTime, "2013-03-20 11:00:00+04:00", dateformat"y-m-d H:M:SSz"),
+            ZonedDateTime(2013, 3, 20, 11, tz"UTC+04"),
+        )
+        @test isequal(
+            tryparse(ZonedDateTime, "2016-04-11 08:00 EST", dateformat"yyyy-mm-dd HH:MM zzz"),
+            nothing,
+        )
+    end
 end
 
 @testset "parse components" begin


### PR DESCRIPTION
Most of the errors were caused by the expulsion of Nullables from Base (and hence how Base parses TimeZone strings).
  