### PR TITLE
Default to using 2018c tzdata

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,4 +3,4 @@ import TimeZones: build
 # ENV variable allows users to modify the default to be "latest". Do NOT use "latest"
 # as the default here as can make it difficult to debug to past versions of working code.
 # Note: Also allows us to only download a single tzdata version during CI jobs.
-build(get(ENV, "JULIA_TZ_VERSION", "2018b"))
+build(get(ENV, "JULIA_TZ_VERSION", "2018c"))


### PR DESCRIPTION
Release notes: http://mm.icann.org/pipermail/tz-announce/2018-January/000048.html