### PR TITLE
Compatibility with Julia 0.7.0-DEV.3861

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   # Avoid setting JULIA_TZ_VERSION if the deps/build.jl file has been modified
   - git fetch origin +:refs/remotes/origin/HEAD; if ! git diff --quiet origin/HEAD HEAD -- deps/build.jl; then unset JULIA_TZ_VERSION; fi
   - julia -e 'Pkg.clone(pwd()); Pkg.build("TimeZones")'
-  - OPTIONS=$(julia -e 'using Mocking; print(DISABLE_PRECOMPILE_STR)')
+  - OPTIONS=$(julia -e 'using Mocking; print(DISABLE_COMPILED_MODULES_STR)')
   - julia $OPTIONS -e 'Pkg.test("TimeZones"; coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("TimeZones")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
-Compat 0.49
+Compat 0.50
 Mocking 0.4.1
 Nullables 0.0.3
 @windows LightXML 0.2

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -4,16 +4,9 @@ module TimeZones
 
 import Compat: Sys, uninitialized, @info, @warn
 
-using Compat.Dates, Compat.Printf, Compat.Unicode
+using Compat.Dates, Compat.Printf, Compat.Serialization, Compat.Unicode
 import Compat.Dates: TimeZone, AbstractTime
 using Nullables
-
-# https://github.com/JuliaLang/Compat.jl/pull/473
-if VERSION < v"0.7.0-DEV.3476"
-    using Base.Serializer
-else
-    using Serialization
-end
 
 export TimeZone, @tz_str, istimezone, FixedTimeZone, VariableTimeZone, ZonedDateTime,
     DateTime, TimeError, AmbiguousTimeError, NonExistentTimeError, UnhandledTimeError,

--- a/src/tzdata/TZData.jl
+++ b/src/tzdata/TZData.jl
@@ -5,13 +5,6 @@ using Compat: @info, @warn
 using Compat.Printf
 using Nullables
 
-# https://github.com/JuliaLang/Compat.jl/pull/473
-if VERSION < v"0.7.0-DEV.3476"
-    using Base.Serializer
-else
-    using Serialization
-end
-
 # Note: The tz database is made up of two parts: code and data. TimeZones.jl only requires
 # the "tzdata" archive or more specifically the "tz source" files within the archive
 # (africa, australasia, ...)

--- a/src/tzdata/compile.jl
+++ b/src/tzdata/compile.jl
@@ -1,4 +1,4 @@
-using Compat.Dates
+using Compat.Dates, Compat.Serialization
 import Compat.Dates: parse_components
 
 import ...TimeZones: TZ_SOURCE_DIR, COMPILED_DIR, TIME_ZONES


### PR DESCRIPTION
The previous version was also compatible but these changes:
- Fix a Mocking deprecation
- Use Compat.Serialization