### PR TITLE
Extend functions using module in declaration instead of import

### DIFF
--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -2,10 +2,11 @@ __precompile__()
 
 module TimeZones
 
-import Compat: Sys, uninitialized, @info, @warn
+import Compat: Dates, Sys
+using Compat: @info, @warn, @static, read, uninitialized, unsafe_string, xor
 
 using Compat.Dates, Compat.Printf, Compat.Serialization, Compat.Unicode
-import Compat.Dates: TimeZone, AbstractTime
+import Dates: TimeZone, AbstractTime
 using Nullables
 
 export TimeZone, @tz_str, istimezone, FixedTimeZone, VariableTimeZone, ZonedDateTime,

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -1,4 +1,4 @@
-import Dates: Hour, Minute, Second, Millisecond, days, hour, minute, second, millisecond
+using Dates: Hour, Minute, Second, Millisecond, days, hour, minute, second, millisecond
 
 """
     localtime(::ZonedDateTime) -> DateTime
@@ -23,12 +23,12 @@ Returns the `TimeZone` used by the `ZonedDateTime`.
 """
 timezone(zdt::ZonedDateTime) = zdt.timezone
 
-days(zdt::ZonedDateTime) = days(localtime(zdt))
+Dates.days(zdt::ZonedDateTime) = days(localtime(zdt))
 
 for period in (:Hour, :Minute, :Second, :Millisecond)
     accessor = Symbol(lowercase(string(period)))
     @eval begin
-        $accessor(zdt::ZonedDateTime) = $accessor(localtime(zdt))
-        $period(zdt::ZonedDateTime) = $period($accessor(zdt))
+        Dates.$accessor(zdt::ZonedDateTime) = $accessor(localtime(zdt))
+        Dates.$period(zdt::ZonedDateTime) = $period($accessor(zdt))
     end
 end

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -1,5 +1,4 @@
-import Compat.Dates: Hour, Minute, Second, Millisecond,
-    days, hour, minute, second, millisecond
+import Dates: Hour, Minute, Second, Millisecond, days, hour, minute, second, millisecond
 
 """
     localtime(::ZonedDateTime) -> DateTime

--- a/src/adjusters.jl
+++ b/src/adjusters.jl
@@ -1,24 +1,23 @@
-using Dates: DatePeriod, TimePeriod
-import Dates: trunc, firstdayofweek, lastdayofweek, firstdayofmonth, lastdayofmonth,
+using Dates: DatePeriod, TimePeriod, trunc,
+    firstdayofweek, lastdayofweek, firstdayofmonth, lastdayofmonth,
     firstdayofyear, lastdayofyear, firstdayofquarter, lastdayofquarter
-
 
 # Truncation
 # TODO: Just utilize floor code for truncation?
-function trunc(zdt::ZonedDateTime, ::Type{P}) where P<:DatePeriod
+function Dates.trunc(zdt::ZonedDateTime, ::Type{P}) where P<:DatePeriod
     ZonedDateTime(trunc(localtime(zdt), P), timezone(zdt))
 end
-function trunc(zdt::ZonedDateTime, ::Type{P}) where P<:TimePeriod
+function Dates.trunc(zdt::ZonedDateTime, ::Type{P}) where P<:TimePeriod
     local_dt = trunc(localtime(zdt), P)
     utc_dt = local_dt - zdt.zone.offset
     ZonedDateTime(utc_dt, timezone(zdt); from_utc=true)
 end
-trunc(zdt::ZonedDateTime, ::Type{Millisecond}) = zdt
+Dates.trunc(zdt::ZonedDateTime, ::Type{Millisecond}) = zdt
 
 # Adjusters
 for prefix in ("firstdayof", "lastdayof"), suffix in ("week", "month", "year", "quarter")
     func = Symbol(prefix * suffix)
     @eval begin
-        $func(dt::ZonedDateTime) = ZonedDateTime($func(localtime(dt)), dt.timezone)
+        Dates.$func(dt::ZonedDateTime) = ZonedDateTime($func(localtime(dt)), dt.timezone)
     end
 end

--- a/src/adjusters.jl
+++ b/src/adjusters.jl
@@ -1,5 +1,5 @@
-import Compat.Dates: trunc, DatePeriod, TimePeriod
-import Compat.Dates: firstdayofweek, lastdayofweek, firstdayofmonth, lastdayofmonth,
+using Dates: DatePeriod, TimePeriod
+import Dates: trunc, firstdayofweek, lastdayofweek, firstdayofmonth, lastdayofmonth,
     firstdayofyear, lastdayofyear, firstdayofquarter, lastdayofquarter
 
 

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,4 +1,4 @@
-import Base: +, -, .+, .-, broadcast
+import Base: +, -
 
 # ZonedDateTime arithmetic
 (+)(x::ZonedDateTime) = x
@@ -17,7 +17,7 @@ function (-)(zdt::ZonedDateTime, p::TimePeriod)
     return ZonedDateTime(zdt.utc_datetime - p, timezone(zdt); from_utc=true)
 end
 
-function broadcast(::typeof(+), r::StepRange{ZonedDateTime}, p::DatePeriod)
+function Base.broadcast(::typeof(+), r::StepRange{ZonedDateTime}, p::DatePeriod)
     start, step, stop = first(r), Base.step(r), last(r)
 
     # Since the localtime + period can result in an invalid local datetime when working with
@@ -41,4 +41,6 @@ function broadcast(::typeof(+), r::StepRange{ZonedDateTime}, p::DatePeriod)
     return StepRange(start, step, stop)
 end
 
-broadcast(::typeof(-), r::StepRange{ZonedDateTime}, p::DatePeriod) = broadcast(+, r, -p)
+function Base.broadcast(::typeof(-), r::StepRange{ZonedDateTime}, p::DatePeriod)
+    broadcast(+, r, -p)
+end

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,5 +1,4 @@
 import Base: +, -, .+, .-, broadcast
-import Compat: @static
 
 # ZonedDateTime arithmetic
 (+)(x::ZonedDateTime) = x

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1,4 +1,4 @@
-import Dates: unix2datetime, datetime2unix, julian2datetime, datetime2julian, now, today
+using Dates: unix2datetime, datetime2unix, julian2datetime, datetime2julian
 using Mocking
 
 # UTC is an abstract type defined in Dates, for some reason
@@ -16,7 +16,7 @@ DateTime(zdt::ZonedDateTime) = localtime(zdt)
 
 Returns a `ZonedDateTime` corresponding to the user's system time in the specified `TimeZone`.
 """
-function now(tz::TimeZone)
+function Dates.now(tz::TimeZone)
     utc = unix2datetime(time())
     ZonedDateTime(utc, tz, from_utc=true)
 end
@@ -39,7 +39,7 @@ julia> today(tz"Pacific/Midway"), today(tz"Pacific/Apia")
 (2017-11-09, 2017-11-10)
 ```
 """
-today(tz::TimeZone) = Date(localtime(now(tz)))
+Dates.today(tz::TimeZone) = Date(localtime(now(tz)))
 
 """
     todayat(tod::Time, tz::TimeZone, [amb]) -> ZonedDateTime

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1,5 +1,4 @@
-import Compat.Dates: unix2datetime, datetime2unix, julian2datetime, datetime2julian,
-    now, today
+import Dates: unix2datetime, datetime2unix, julian2datetime, datetime2julian, now, today
 using Mocking
 
 # UTC is an abstract type defined in Dates, for some reason

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,4 +1,5 @@
-import Base: @deprecate, @deprecate_binding, colon
+using Base: @deprecate, @deprecate_binding
+import Base: colon
 
 # BEGIN TimeZones 0.6 deprecations
 

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -1,5 +1,3 @@
-import Base: showerror
-
 abstract type TimeError <: Exception end
 
 """
@@ -13,7 +11,7 @@ struct AmbiguousTimeError <: TimeError
     timezone::TimeZone
 end
 
-function showerror(io::IO, e::AmbiguousTimeError)
+function Base.showerror(io::IO, e::AmbiguousTimeError)
     print(io, "AmbiguousTimeError: ")
     print(io, "Local DateTime $(e.local_dt) is ambiguous within $(string(e.timezone))")
 end
@@ -30,7 +28,7 @@ struct NonExistentTimeError <: TimeError
     timezone::TimeZone
 end
 
-function showerror(io::IO, e::NonExistentTimeError)
+function Base.showerror(io::IO, e::NonExistentTimeError)
     print(io, "NonExistentTimeError: ")
     print(io, "Local DateTime $(e.local_dt) does not exist within $(string(e.timezone))")
 end
@@ -44,7 +42,7 @@ struct UnhandledTimeError <: TimeError
     tz::VariableTimeZone
 end
 
-function showerror(io::IO, e::UnhandledTimeError)
+function Base.showerror(io::IO, e::UnhandledTimeError)
     print(io, "UnhandledTimeError: ")
     print(io, "TimeZone $(string(e.tz)) does not handle dates on or after $(get(e.tz.cutoff)) UTC")
 end

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -1,4 +1,4 @@
-import TimeZones.TZData: MIN_OFFSET, MAX_OFFSET
+using TimeZones.TZData: MIN_OFFSET, MAX_OFFSET
 
 # TimeZone concepts used to disambiguate context of DateTimes
 # abstract type UTC <: TimeZone end # Defined in Dates

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,5 +1,5 @@
 import Base: print, show, showcompact
-import Compat.Dates: value, DateFormat
+using Dates: value, DateFormat
 
 print(io::IO, tz::TimeZone) = print(io, tz.name)
 function print(io::IO, tz::FixedTimeZone)

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,23 +1,22 @@
-import Base: print, show, showcompact
 using Dates: value, DateFormat
 
-print(io::IO, tz::TimeZone) = print(io, tz.name)
-function print(io::IO, tz::FixedTimeZone)
+Base.print(io::IO, tz::TimeZone) = print(io, tz.name)
+function Base.print(io::IO, tz::FixedTimeZone)
     name = string(tz.name)
     isempty(name) ? print(io, "UTC", tz.offset) : print(io, name)
 end
-print(io::IO, zdt::ZonedDateTime) = print(io, localtime(zdt), zdt.zone.offset)
+Base.print(io::IO, zdt::ZonedDateTime) = print(io, localtime(zdt), zdt.zone.offset)
 
-showcompact(io::IO, tz::TimeZone) = print(io, string(tz))
+Base.showcompact(io::IO, tz::TimeZone) = print(io, string(tz))
 
-function show(io::IO, t::Transition)
+function Base.show(io::IO, t::Transition)
     name_str = string(t.zone.name)
     print(io, t.utc_datetime, " ")
     show(io, t.zone.offset)
     !isempty(name_str) && print(io, " (", name_str, ")")
 end
 
-function show(io::IO, tz::FixedTimeZone)
+function Base.show(io::IO, tz::FixedTimeZone)
     offset_str = "UTC" * offset_string(tz.offset, true)  # Use ISO 8601 for comparision
     name_str = string(tz.name)
     if isempty(name_str)
@@ -29,7 +28,7 @@ function show(io::IO, tz::FixedTimeZone)
     end
 end
 
-function show(io::IO,tz::VariableTimeZone)
+function Base.show(io::IO,tz::VariableTimeZone)
     trans = tz.transitions
 
     # Retrieve the "modern" time zone transitions. We'll treat the latest transitions as
@@ -54,4 +53,4 @@ function show(io::IO,tz::VariableTimeZone)
     )
 end
 
-show(io::IO,dt::ZonedDateTime) = print(io, string(dt))
+Base.show(io::IO,dt::ZonedDateTime) = print(io, string(dt))

--- a/src/local.jl
+++ b/src/local.jl
@@ -1,6 +1,5 @@
 # Determine the local system's time zone
 # Based upon Python's tzlocal https://pypi.python.org/pypi/tzlocal
-import Compat: @static, Sys, read
 using Mocking
 
 if Sys.iswindows()

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -1,5 +1,4 @@
 using Dates: DateFormat, DatePart, min_width, max_width
-import Dates: tryparsenext, format, default_format
 
 # Handle Nullable deprecation on Julia 0.7
 if VERSION < v"0.7.0-DEV.3017"
@@ -70,19 +69,19 @@ function tryparsenext_tz(str, i, len, min_width::Int=1, max_width::Int=0)
     end
 end
 
-function tryparsenext(d::DatePart{'z'}, str, i, len)
+function Dates.tryparsenext(d::DatePart{'z'}, str, i, len)
     tryparsenext_fixedtz(str, i, len, min_width(d), max_width(d))
 end
 
-function tryparsenext(d::DatePart{'Z'}, str, i, len)
+function Dates.tryparsenext(d::DatePart{'Z'}, str, i, len)
     tryparsenext_tz(str, i, len, min_width(d), max_width(d))
 end
 
-function format(io::IO, d::DatePart{'z'}, zdt, locale)
+function Dates.format(io::IO, d::DatePart{'z'}, zdt, locale)
     write(io, string(zdt.zone.offset))
 end
 
-function format(io::IO, d::DatePart{'Z'}, zdt, locale)
+function Dates.format(io::IO, d::DatePart{'Z'}, zdt, locale)
     write(io, string(zdt.zone))  # In most cases will be an abbreviation.
 end
 
@@ -92,7 +91,7 @@ function ZonedDateTime(str::AbstractString, df::DateFormat=ISOZonedDateTimeForma
     parse(ZonedDateTime, str, df)
 end
 function ZonedDateTime(str::AbstractString, format::AbstractString; locale::AbstractString="english")
-    ZonedDateTime(str, DateFormat(format,locale))
+    ZonedDateTime(str, DateFormat(format, locale))
 end
 
-default_format(::Type{ZonedDateTime}) = ISOZonedDateTimeFormat
+Dates.default_format(::Type{ZonedDateTime}) = ISOZonedDateTimeFormat

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -1,5 +1,5 @@
-import Compat.Dates: DateFormat, DatePart, tryparsenext, format, min_width, max_width,
-    default_format
+using Dates: DateFormat, DatePart, min_width, max_width
+import Dates: tryparsenext, format, default_format
 
 # Handle Nullable deprecation on Julia 0.7
 if VERSION < v"0.7.0-DEV.3017"

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -1,4 +1,4 @@
-import Dates: guess
+using Dates: guess
 
 """
     guess(start::ZonedDateTime, finish::ZonedDateTime, step) -> Integer
@@ -6,6 +6,6 @@ import Dates: guess
 Given a start and end date, indicates how many steps/periods are between them. Defining this
 function allows `StepRange`s to be defined for `ZonedDateTime`s.
 """
-function guess(start::ZonedDateTime, finish::ZonedDateTime, step)
+function Dates.guess(start::ZonedDateTime, finish::ZonedDateTime, step)
     guess(start.utc_datetime, finish.utc_datetime, step)
 end

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -1,4 +1,4 @@
-import Compat.Dates: guess
+import Dates: guess
 
 """
     guess(start::ZonedDateTime, finish::ZonedDateTime, step) -> Integer

--- a/src/rounding.jl
+++ b/src/rounding.jl
@@ -1,17 +1,17 @@
 using Dates: Period, DatePeriod, TimePeriod
 
-function Base.floor(zdt::ZonedDateTime, p::DatePeriod)
+function Dates.floor(zdt::ZonedDateTime, p::DatePeriod)
     return ZonedDateTime(floor(localtime(zdt), p), timezone(zdt))
 end
 
-function Base.floor(zdt::ZonedDateTime, p::TimePeriod)
+function Dates.floor(zdt::ZonedDateTime, p::TimePeriod)
     # Rounding is done using the current fixed offset to avoid transitional ambiguities.
     dt = floor(localtime(zdt), p)
     utc_dt = dt - zdt.zone.offset
     return ZonedDateTime(utc_dt, timezone(zdt); from_utc=true)
 end
 
-function Base.ceil(zdt::ZonedDateTime, p::DatePeriod)
+function Dates.ceil(zdt::ZonedDateTime, p::DatePeriod)
     return ZonedDateTime(ceil(localtime(zdt), p), timezone(zdt))
 end
 
@@ -47,7 +47,7 @@ julia> floor(zdt, Dates.Hour)
 2016-03-13T01:00:00-06:00
 ```
 """
-Base.floor(::TimeZones.ZonedDateTime, ::Union{Period, Type{Period}})
+Dates.floor(::TimeZones.ZonedDateTime, ::Union{Period, Type{Period}})
 
 """
     ceil(zdt::ZonedDateTime, p::Period) -> ZonedDateTime
@@ -77,7 +77,7 @@ julia> ceil(zdt, Dates.Hour)
 2016-03-13T03:00:00-05:00
 ```
 """
-Base.ceil(::TimeZones.ZonedDateTime, ::Union{Period, Type{Period}})
+Dates.ceil(::TimeZones.ZonedDateTime, ::Union{Period, Type{Period}})
 
 """
     round(zdt::ZonedDateTime, p::Period, [r::RoundingMode]) -> ZonedDateTime
@@ -148,4 +148,4 @@ julia> round(zdt, Dates.Day)
 ERROR: Local DateTime 1996-10-26T00:00:00 is ambiguous
 ```
 """     # Defined in base/dates/rounding.jl
-Base.round(::TimeZones.ZonedDateTime, ::Union{Period, Type{Period}})
+Dates.round(::TimeZones.ZonedDateTime, ::Union{Period, Type{Period}})

--- a/src/rounding.jl
+++ b/src/rounding.jl
@@ -1,4 +1,4 @@
-import Compat.Dates: Period, DatePeriod, TimePeriod
+using Dates: Period, DatePeriod, TimePeriod
 
 function Base.floor(zdt::ZonedDateTime, p::DatePeriod)
     return ZonedDateTime(floor(localtime(zdt), p), timezone(zdt))

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,6 +1,6 @@
 using Dates
-import Dates: value, argerror, validargs
-import Base: promote_rule, ==, hash, isequal, isless, typemin, typemax
+using Dates: argerror, validargs
+import Base: ==
 
 const FIXED_TIME_ZONE_REGEX = r"""
 ^(?|
@@ -267,24 +267,24 @@ end
 # undefined promote_rule on TimeType types.
 # Otherwise, typejoin(T,S) is called (returning TimeType) so no conversion happens, and
 # isless(promote(x,y)...) is called again, causing a stack overflow.
-function promote_rule(::Type{T}, ::Type{S}) where {T<:TimeType, S<:ZonedDateTime}
+function Base.promote_rule(::Type{T}, ::Type{S}) where {T<:TimeType, S<:ZonedDateTime}
     error("no promotion exists for ", T, " and ", S)
 end
 
 # Equality
 ==(a::ZonedDateTime, b::ZonedDateTime) = a.utc_datetime == b.utc_datetime
-isless(a::ZonedDateTime, b::ZonedDateTime) = isless(a.utc_datetime, b.utc_datetime)
+Base.isless(a::ZonedDateTime, b::ZonedDateTime) = isless(a.utc_datetime, b.utc_datetime)
 
 # Note: `hash` and `isequal` assume that the "zone" of a ZonedDateTime is not being set
 # incorrectly.
 
-function hash(zdt::ZonedDateTime, h::UInt)
+function Base.hash(zdt::ZonedDateTime, h::UInt)
     h = hash(zdt.utc_datetime, h)
     h = hash(zdt.timezone, h)
     return h
 end
 
-function isequal(a::ZonedDateTime, b::ZonedDateTime)
+function Base.isequal(a::ZonedDateTime, b::ZonedDateTime)
     isequal(a.utc_datetime, b.utc_datetime) && isequal(a.timezone, b.timezone)
 end
 
@@ -292,17 +292,21 @@ function ==(a::VariableTimeZone, b::VariableTimeZone)
     a.name == b.name && a.transitions == b.transitions
 end
 
-function hash(tz::VariableTimeZone, h::UInt)
+function Base.hash(tz::VariableTimeZone, h::UInt)
     h = hash(tz.name, h)
     h = hash(tz.transitions, h)
     h = hash(tz.cutoff, h)
     return h
 end
 
-typemin(::Type{ZonedDateTime}) = ZonedDateTime(typemin(DateTime), utc_tz; from_utc=true)
-typemax(::Type{ZonedDateTime}) = ZonedDateTime(typemax(DateTime), utc_tz; from_utc=true)
+function Base.typemin(::Type{ZonedDateTime})
+    ZonedDateTime(typemin(DateTime), utc_tz; from_utc=true)
+end
+function Base.typemax(::Type{ZonedDateTime})
+    ZonedDateTime(typemax(DateTime), utc_tz; from_utc=true)
+end
 
-function validargs(::Type{ZonedDateTime}, y::Int64, m::Int64, d::Int64, h::Int64, mi::Int64, s::Int64, ms::Int64, tz::AbstractString)
+function Dates.validargs(::Type{ZonedDateTime}, y::Int64, m::Int64, d::Int64, h::Int64, mi::Int64, s::Int64, ms::Int64, tz::AbstractString)
     err = validargs(DateTime, y, m, d, h, mi, s, ms)
     isnull(err) || return err
     istimezone(tz) || return argerror("TimeZone: \"$str\" is not a recognized time zone")

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,9 +1,6 @@
-
-# import Compat.Dates: UTInstant, DateTime, TimeZone, Millisecond
-using Compat.Dates
-import Compat.Dates: value, argerror, validargs
+using Dates
+import Dates: value, argerror, validargs
 import Base: promote_rule, ==, hash, isequal, isless, typemin, typemax
-import Compat: xor
 
 const FIXED_TIME_ZONE_REGEX = r"""
 ^(?|

--- a/src/tzdata/TZData.jl
+++ b/src/tzdata/TZData.jl
@@ -1,7 +1,7 @@
 module TZData
 
-using Compat
-using Compat: @info, @warn
+import Compat: Dates, Serialization, Sys
+using Compat: @info, @warn, isassigned, read
 using Compat.Printf
 using Nullables
 

--- a/src/tzdata/archive.jl
+++ b/src/tzdata/archive.jl
@@ -1,5 +1,3 @@
-import Compat: @static, Sys
-
 if Sys.iswindows()
     const exe7z = joinpath(JULIA_HOME, "7z.exe")
 end

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -1,4 +1,4 @@
-import ...TimeZones: ARCHIVE_DIR, TZ_SOURCE_DIR, COMPILED_DIR
+using ...TimeZones: ARCHIVE_DIR, TZ_SOURCE_DIR, COMPILED_DIR
 
 # The default tz source files we care about. See "ftp://ftp.iana.org/tz/data/Makefile"
 # "PRIMARY_YDATA" for listing of tz source files to include.

--- a/src/tzdata/compile.jl
+++ b/src/tzdata/compile.jl
@@ -1,9 +1,9 @@
-using Compat.Dates, Compat.Serialization
-import Compat.Dates: parse_components
+using Dates: parse_components
+using Serialization: serialize
 
-import ...TimeZones: TZ_SOURCE_DIR, COMPILED_DIR, TIME_ZONES
-import ...TimeZones: TimeZone, FixedTimeZone, VariableTimeZone, Transition
-import ..TZData: TimeOffset, ZERO, MIN_GMT_OFFSET, MAX_GMT_OFFSET,
+using ...TimeZones: TZ_SOURCE_DIR, COMPILED_DIR, TIME_ZONES
+using ...TimeZones: TimeZone, FixedTimeZone, VariableTimeZone, Transition
+using ..TZData: TimeOffset, ZERO, MIN_GMT_OFFSET, MAX_GMT_OFFSET,
     MIN_SAVE, MAX_SAVE, ABS_DIFF_OFFSET
 
 # Zone type maps to an Olson Timezone database entity

--- a/src/tzdata/download.jl
+++ b/src/tzdata/download.jl
@@ -1,6 +1,5 @@
-import TimeZones: DEPS_DIR
-import Compat: isassigned
-using Compat.Dates
+using Dates
+using TimeZones: DEPS_DIR
 
 const LATEST_FILE = joinpath(DEPS_DIR, "latest")
 const LATEST_FORMAT = Dates.DateFormat("yyyy-mm-ddTHH:MM:SS")

--- a/src/tzdata/timeoffset.jl
+++ b/src/tzdata/timeoffset.jl
@@ -1,6 +1,4 @@
-import Base: convert, promote_rule, string, print, show
-import Dates: Period, TimePeriod, Week, Day, Hour, Minute, Second, Millisecond, value, toms,
-    hour, minute, second
+using Dates: TimePeriod, Week, Day, Hour, Minute, Second, Millisecond, value
 
 # Convenience type for working with HH:MM:SS.
 struct TimeOffset <: TimePeriod
@@ -35,12 +33,12 @@ function TimeOffset(s::AbstractString)
 end
 
 # TimePeriod methods
-value(t::TimeOffset) = t.seconds
-toms(t::TimeOffset) = value(t) * 1000
+Dates.value(t::TimeOffset) = t.seconds
+Dates.toms(t::TimeOffset) = value(t) * 1000
 
-hour(t::TimeOffset) = div(value(t), 3600)
-minute(t::TimeOffset) = rem(div(value(t), 60), 60)
-second(t::TimeOffset) = rem(value(t), 60)
+Dates.hour(t::TimeOffset) = div(value(t), 3600)
+Dates.minute(t::TimeOffset) = rem(div(value(t), 60), 60)
+Dates.second(t::TimeOffset) = rem(value(t), 60)
 
 function hourminutesecond(t::TimeOffset)
     h, r = divrem(value(t), 3600)
@@ -48,19 +46,19 @@ function hourminutesecond(t::TimeOffset)
     return h, m, s
 end
 
-convert(::Type{Second}, t::TimeOffset) = Second(value(t))
-convert(::Type{Millisecond}, t::TimeOffset) = Millisecond(value(t) * 1000)
-promote_rule(::Type{<:Union{Week,Day,Hour,Minute,Second}}, ::Type{TimeOffset}) = Second
-promote_rule(::Type{Millisecond}, ::Type{TimeOffset}) = Millisecond
+Base.convert(::Type{Second}, t::TimeOffset) = Second(value(t))
+Base.convert(::Type{Millisecond}, t::TimeOffset) = Millisecond(value(t) * 1000)
+Base.promote_rule(::Type{<:Union{Week,Day,Hour,Minute,Second}}, ::Type{TimeOffset}) = Second
+Base.promote_rule(::Type{Millisecond}, ::Type{TimeOffset}) = Millisecond
 
 # https://en.wikipedia.org/wiki/ISO_8601#Times
-function string(t::TimeOffset)
+function Base.string(t::TimeOffset)
     neg = value(t) < 0 ? "-" : ""
     h, m, s = map(abs, hourminutesecond(t))
     @sprintf("%s%02d:%02d:%02d", neg, h, m, s)
 end
-print(io::IO, t::TimeOffset) = print(io, string(t))
-show(io::IO, t::TimeOffset) = print(io, t)
+Base.print(io::IO, t::TimeOffset) = print(io, string(t))
+Base.show(io::IO, t::TimeOffset) = print(io, t)
 
 
 # min/max offsets across all zones and all time.

--- a/src/tzdata/timeoffset.jl
+++ b/src/tzdata/timeoffset.jl
@@ -1,6 +1,6 @@
 import Base: convert, promote_rule, string, print, show
-import Compat.Dates: Period, TimePeriod, Week, Day, Hour, Minute, Second, Millisecond,
-    value, toms, hour, minute, second
+import Dates: Period, TimePeriod, Week, Day, Hour, Minute, Second, Millisecond, value, toms,
+    hour, minute, second
 
 # Convenience type for working with HH:MM:SS.
 struct TimeOffset <: TimePeriod

--- a/src/tzdata/version.jl
+++ b/src/tzdata/version.jl
@@ -1,5 +1,4 @@
-import ...TimeZones: DEPS_DIR, ARCHIVE_DIR
-import Compat: read
+using ...TimeZones: DEPS_DIR, ARCHIVE_DIR
 
 # Note: A tz code or data version consists of a year and letter while a release consists of
 # a pair of tz code and data versions. In recent releases the tz code and data use the same

--- a/src/tzfile.jl
+++ b/src/tzfile.jl
@@ -2,8 +2,6 @@
 # - http://man7.org/linux/man-pages/man5/tzfile.5.html
 # - ftp://ftp.iana.org/tz/code/tzfile.5.txt
 
-import Compat: read, unsafe_string
-
 const TZFILE_MAX = unix2datetime(typemax(Int32))
 
 struct TransitionTimeInfo

--- a/src/utcoffset.jl
+++ b/src/utcoffset.jl
@@ -1,5 +1,6 @@
 import Base: +, -, isequal, isless, print, show
-import Compat.Dates: AbstractTime, Second, value
+using Dates: AbstractTime, Second
+import Dates: value
 
 # Note: The IANA time zone database rounds offset precision to the nearest second
 # See "America/New_York" notes in tzdata file "northamerica" for an example.

--- a/src/utcoffset.jl
+++ b/src/utcoffset.jl
@@ -1,6 +1,5 @@
-import Base: +, -, isequal, isless, print, show
+import Base: +, -
 using Dates: AbstractTime, Second
-import Dates: value
 
 # Note: The IANA time zone database rounds offset precision to the nearest second
 # See "America/New_York" notes in tzdata file "northamerica" for an example.
@@ -23,7 +22,7 @@ function UTCOffset(std_offset::Integer, dst_offset::Integer=0)
     UTCOffset(Second(std_offset), Second(dst_offset))
 end
 
-value(offset::UTCOffset) = value(offset.std + offset.dst)
+Dates.value(offset::UTCOffset) = value(offset.std + offset.dst)
 
 (+)(dt::DateTime, offset::UTCOffset) = dt + (offset.std + offset.dst)
 (-)(dt::DateTime, offset::UTCOffset) = dt - (offset.std + offset.dst)
@@ -33,10 +32,10 @@ isdst(offset::UTCOffset) = offset.dst != Second(0)
 
 # Two `UTCOffset`s can be considered equal if the total offset is the same and they are
 # both either offsets for standard time or daylight saving time.
-function isequal(x::UTCOffset, y::UTCOffset)
+function Base.isequal(x::UTCOffset, y::UTCOffset)
     x == y || value(x) == value(y) && isdst(x) == isdst(y)
 end
-isless(x::UTCOffset, y::UTCOffset) = isless(value(x), value(y))
+Base.isless(x::UTCOffset, y::UTCOffset) = isless(value(x), value(y))
 
 function offset_string(seconds::Second, iso8601::Bool=false)
     v = value(seconds)
@@ -55,8 +54,8 @@ function offset_string(offset::UTCOffset, iso8601::Bool=false)
     offset_string(offset.std + offset.dst, iso8601)
 end
 
-print(io::IO, o::UTCOffset) = print(io, offset_string(o, true))
-function show(io::IO, o::UTCOffset)
+Base.print(io::IO, o::UTCOffset) = print(io, offset_string(o, true))
+function Base.show(io::IO, o::UTCOffset)
     # Show DST as a separate offset since we want to distinguish between normal hourly
     # daylight saving time offsets and exotic DST offsets (e.g. midsummer time).
     print(io, "UTC", offset_string(o.std), "/", offset_string(o.dst))

--- a/test/accessors.jl
+++ b/test/accessors.jl
@@ -1,5 +1,4 @@
-import Compat.Dates
-import Compat.Dates: Second
+using Dates: Second
 
 warsaw = resolve("Europe/Warsaw", tzdata["europe"]...)
 fixed = FixedTimeZone("Fixed", -7200, 3600)

--- a/test/adjusters.jl
+++ b/test/adjusters.jl
@@ -1,4 +1,4 @@
-using Compat.Dates
+using Dates: Year, Month, Day, Hour, Minute, Second, Millisecond
 
 # Basic truncation
 warsaw = resolve("Europe/Warsaw", tzdata["europe"]...)

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -1,4 +1,4 @@
-import Compat.Dates: Day, Hour
+using Dates: Day, Hour
 
 warsaw = resolve("Europe/Warsaw", tzdata["europe"]...)
 

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -1,4 +1,4 @@
-import Compat.Dates
+using Compat.Dates
 using Mocking
 
 utc = FixedTimeZone("UTC")

--- a/test/discovery.jl
+++ b/test/discovery.jl
@@ -1,4 +1,4 @@
-import TimeZones: timezone_names
+using TimeZones: timezone_names
 
 names = timezone_names()
 @test length(names) >= 436

--- a/test/io.jl
+++ b/test/io.jl
@@ -1,4 +1,4 @@
-import TimeZones.TZData: parse_components
+using TimeZones.TZData: parse_components
 
 null = FixedTimeZone("", 10800)
 fixed = FixedTimeZone("UTC+01:00")

--- a/test/local.jl
+++ b/test/local.jl
@@ -1,5 +1,4 @@
-import TimeZones: TimeZone, localzone, parse_tz_format
-import Compat: Sys
+using TimeZones: TimeZone, localzone, parse_tz_format
 
 # Parse the TZ environment variable format
 # Should mirror the behaviour of running:

--- a/test/local_mocking.jl
+++ b/test/local_mocking.jl
@@ -1,7 +1,6 @@
-import TimeZones: TimeZone, localzone
-import Mocking: @patch, apply
-import Base: AbstractCmd
-import Compat: Sys, read
+using TimeZones: TimeZone, localzone
+using Mocking: @patch, apply
+using Base: AbstractCmd
 
 # For mocking make sure we are actually changing the time zone
 name = string(localzone()) == "Europe/Warsaw" ? "Pacific/Apia" : "Europe/Warsaw"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,8 +14,9 @@ using Test
 using TimeZones
 import TimeZones: PKG_DIR, ARCHIVE_DIR
 import TimeZones.TZData: ZoneDict, RuleDict, tzparse, resolve, build
-import Compat: Sys
+import Compat: Dates, Sys
 using Compat.Unicode
+using Compat: findall, read
 using Nullables
 
 const TZDATA_VERSION = "2016j"

--- a/test/types.jl
+++ b/test/types.jl
@@ -1,6 +1,5 @@
-import TimeZones: Transition
-import Compat.Dates: Hour, Second, UTM
-
+using TimeZones: Transition
+using Dates: Hour, Second, UTM
 
 # Constructor FixedTimeZone from a string.
 @test FixedTimeZone("0123") == FixedTimeZone("UTC+01:23", 4980)

--- a/test/tzdata/archive.jl
+++ b/test/tzdata/archive.jl
@@ -1,5 +1,5 @@
-import TimeZones: ARCHIVE_DIR
-import TimeZones.TZData: isarchive, readarchive, extract
+using TimeZones: ARCHIVE_DIR
+using TimeZones.TZData: isarchive, readarchive, extract
 
 const ARCHIVE_PATH = let
     archives = filter(file -> endswith(file, "tar.gz"), readdir(ARCHIVE_DIR))

--- a/test/tzdata/compile.jl
+++ b/test/tzdata/compile.jl
@@ -1,6 +1,6 @@
-import TimeZones: Transition
-import TimeZones.TZData: ZoneDict, RuleDict, zoneparse, ruleparse, resolve, parsedate, order_rules
-import Compat.Dates: Hour, Minute, Second, DateTime, Date
+using TimeZones: Transition
+using TimeZones.TZData: ZoneDict, RuleDict, zoneparse, ruleparse, resolve, parsedate, order_rules
+using Dates: Hour, Minute, Second, DateTime, Date
 
 ### parsedate ###
 

--- a/test/tzdata/download.jl
+++ b/test/tzdata/download.jl
@@ -1,4 +1,4 @@
-import TimeZones.TZData: tzdata_url, tzdata_download, isarchive, LATEST_FILE, read_latest
+using TimeZones.TZData: tzdata_url, tzdata_download, isarchive, LATEST_FILE, read_latest
 
 @test tzdata_url("2016j") == "https://www.iana.org/time-zones/repository/releases/tzdata2016j.tar.gz"
 @test tzdata_url("latest") == "https://www.iana.org/time-zones/repository/tzdata-latest.tar.gz"

--- a/test/tzdata/timeoffset.jl
+++ b/test/tzdata/timeoffset.jl
@@ -1,4 +1,4 @@
-import TimeZones.TZData: TimeOffset, value, hour, minute, second, hourminutesecond
+using TimeZones.TZData: TimeOffset, value, hour, minute, second, hourminutesecond
 
 # Time seconds constructor
 t = TimeOffset(5025)

--- a/test/tzdata/version.jl
+++ b/test/tzdata/version.jl
@@ -1,7 +1,7 @@
-import TimeZones: ARCHIVE_DIR
-import TimeZones.TZData: TZDATA_VERSION_REGEX, TZDATA_NEWS_REGEX
-import TimeZones.TZData: read_news, extract, tzdata_version_dir, tzdata_version_archive
-import TimeZones.TZData: active_version, active_archive
+using TimeZones: ARCHIVE_DIR
+using TimeZones.TZData: TZDATA_VERSION_REGEX, TZDATA_NEWS_REGEX
+using TimeZones.TZData: read_news, extract, tzdata_version_dir, tzdata_version_archive
+using TimeZones.TZData: active_version, active_archive
 
 for year = ("12", "1234"), letter = ("", "z")
     version = year * letter

--- a/test/tzfile.jl
+++ b/test/tzfile.jl
@@ -1,5 +1,4 @@
-import Compat: findall
-import TimeZones: Transition, TZFILE_MAX
+using TimeZones: Transition, TZFILE_MAX
 
 
 abbrs = b"LMT\0WSST\0SDT\0WSDT\0"  # Pacific/Apia

--- a/test/utcoffset.jl
+++ b/test/utcoffset.jl
@@ -1,4 +1,4 @@
-import TimeZones: UTCOffset, value, isdst
+using TimeZones: UTCOffset, value, isdst
 
 @test value(UTCOffset(0, 0)) == 0
 @test value(UTCOffset(3600, 0)) == 3600

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,4 +1,4 @@
-import TimeZones: optional
+using TimeZones: optional
 
 function strip(ex::Expr)
     args = []


### PR DESCRIPTION
I decided to stick with `import` for `+` and `-` as I find this reads nicer.