### PR TITLE
Implement show_next_transition

### DIFF
--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -12,6 +12,7 @@ export TimeZone, @tz_str, istimezone, FixedTimeZone, VariableTimeZone, ZonedDate
     DateTime, TimeError, AmbiguousTimeError, NonExistentTimeError, UnhandledTimeError,
     # discovery.jl
     timezone_names, all_timezones, timezones_from_abbr, timezone_abbrs,
+    next_transition_instant, show_next_transition,
     # accessors.jl
     hour, minute, second, millisecond,
     # adjusters.jl

--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -1,3 +1,5 @@
+using Mocking
+
 """
     timezone_names() -> Array{AbstractString}
 
@@ -123,3 +125,95 @@ function timezone_abbrs()
     end
     return sort!(collect(abbrs))
 end
+
+
+"""
+    next_transition_instant(zdt::ZonedDateTime) -> ZonedDateTime
+    next_transition_instant(tz::TimeZone=localzone()) -> ZonedDateTime
+
+Determine the next instant at which a time zone transition occurs (typically
+due to daylight-savings time).
+
+Note that the provided `ZonedDateTime` isn't normally constructable:
+
+```julia
+julia> instant = next_transition_instant(ZonedDateTime(2018, 3, 1, tz"Europe/London"))
+2018-03-25T01:00:00+00:00
+
+julia> instant - Millisecond(1)  # Instant prior to the change
+2018-03-25T00:59:59.999+00:00
+
+julia> instant - Millisecond(0)  # Instant after the change
+2018-03-25T02:00:00+01:00
+
+julia> ZonedDateTime(2018, 3, 25, 1, tz"Europe/London")  # Cannot normally construct the `instant`
+ERROR: NonExistentTimeError: Local DateTime 2018-03-25T01:00:00 does not exist within Europe/London
+...
+"""
+next_transition_instant
+
+function next_transition_instant(zdt::ZonedDateTime)
+    tz = zdt.timezone
+    index = searchsortedfirst(
+        tz.transitions, TimeZones.utc(zdt),
+        by=el -> isa(el, TimeZones.Transition) ? el.utc_datetime : el,
+    )
+    utc_datetime = tz.transitions[index].utc_datetime
+    prev_zone = tz.transitions[index - 1].zone
+    ZonedDateTime(utc_datetime, tz, prev_zone)
+end
+
+next_transition_instant(tz::TimeZone=localzone()) = next_transition_instant(@mock now(tz))
+
+
+"""
+    show_next_transition(io::IO=STDOUT, zdt::ZonedDateTime)
+    show_next_transition(io::IO=STDOUT, tz::TimeZone=localzone())
+
+Display useful information about the next time zone transition (typically
+due to daylight-savings time). Information displayed includes:
+
+* The local date at which the transition occurs "2018-10-28"
+* The local time change "02:00 → 01:00"
+* The direction of the transition: "Forward" or "Backward"
+* The instant before the transition occurs
+* The instant after the transition occurs
+
+```julia
+julia> show_next_transition(ZonedDateTime(2018, 8, 1, tz"Europe/London"))
+2018-10-28 02:00 → 01:00 (Backward)
+Before: 2018-10-28T01:59:59.999+01:00 (BST)
+After:  2018-10-28T01:00:00.000+00:00 (GMT)
+
+julia> show_next_transition(ZonedDateTime(2011, 12, 1, tz"Pacific/Apia"))
+2011-12-30 00:00 → 00:00 (Forward)
+Before: 2011-12-29T23:59:59.999-10:00 (UTC-10:00)
+After:  2011-12-31T00:00:00.000+14:00 (UTC+14:00)
+"""
+show_next_transition
+
+function show_next_transition(io::IO, zdt::ZonedDateTime)
+    instant = next_transition_instant(zdt)
+    a, b = instant - Millisecond(1), instant + Millisecond(0)
+    direction = value(b.zone.offset) - value(a.zone.offset) < 0 ? "Backward" : "Forward"
+
+    zdt_format(zdt) = string(
+        Dates.format(zdt, dateformat"yyyy-mm-ddTHH:MM:SS.sss"),  # Note: zzz won't work here
+        zdt.zone.offset,
+        " ($(zdt.zone))",
+    )
+    time_format(zdt) = Dates.format(
+        zdt, second(zdt) == 0 ? dateformat"HH:MM" : dateformat"HH:MM:SS"
+    )
+
+    println(io, "Transition Date:   ", Dates.format(instant, dateformat"yyyy-mm-dd"))
+    println(io, "Local Time Change: ", time_format(instant), " → ", time_format(b), " (", direction, ")")
+    println(io, "Transition From:   ", zdt_format(a))
+    println(io, "Transition To:     ", zdt_format(b))
+end
+
+function show_next_transition(io::IO, tz::TimeZone=localzone())
+    show_next_transition(io, @mock now(tz))
+end
+
+show_next_transition(x...) = show_next_transition(STDOUT, x...)

--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -201,14 +201,18 @@ function show_next_transition(io::IO, zdt::ZonedDateTime)
     a, b = instant - Millisecond(1), instant + Millisecond(0)
     direction = value(b.zone.offset) - value(a.zone.offset) < 0 ? "Backward" : "Forward"
 
-    zdt_format(zdt) = string(
-        Dates.format(zdt, dateformat"yyyy-mm-ddTHH:MM:SS.sss"),  # Note: zzz won't work here
-        zdt.zone.offset,
-        " ($(zdt.zone))",
-    )
-    time_format(zdt) = Dates.format(
-        zdt, second(zdt) == 0 ? dateformat"HH:MM" : dateformat"HH:MM:SS"
-    )
+    function zdt_format(zdt)
+        name_suffix = string(zdt.zone.name)
+        !isempty(name_suffix) && (name_suffix = string(" (", name_suffix, ")"))
+        string(
+            Dates.format(zdt, dateformat"yyyy-mm-ddTHH:MM:SS.sss"),
+            zdt.zone.offset,  # Note: "zzz" will not work in the format above as is
+            name_suffix,
+        )
+    end
+    function time_format(zdt)
+        Dates.format(zdt, second(zdt) == 0 ? dateformat"HH:MM" : dateformat"HH:MM:SS")
+    end
 
     println(io, "Transition Date:   ", Dates.format(instant, dateformat"yyyy-mm-dd"))
     println(io, "Local Time Change: ", time_format(instant), " → ", time_format(b), " (", direction, ")")

--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -149,6 +149,7 @@ julia> instant - Millisecond(0)  # Instant after the change
 julia> ZonedDateTime(2018, 3, 25, 1, tz"Europe/London")  # Cannot normally construct the `instant`
 ERROR: NonExistentTimeError: Local DateTime 2018-03-25T01:00:00 does not exist within Europe/London
 ...
+```
 """
 next_transition_instant
 
@@ -181,14 +182,17 @@ due to daylight-savings time). Information displayed includes:
 
 ```julia
 julia> show_next_transition(ZonedDateTime(2018, 8, 1, tz"Europe/London"))
-2018-10-28 02:00 → 01:00 (Backward)
-Before: 2018-10-28T01:59:59.999+01:00 (BST)
-After:  2018-10-28T01:00:00.000+00:00 (GMT)
+Transition Date:   2018-10-28
+Local Time Change: 02:00 → 01:00 (Backward)
+Transition From:   2018-10-28T01:59:59.999+01:00 (BST)
+Transition To:     2018-10-28T01:00:00.000+00:00 (GMT)
 
 julia> show_next_transition(ZonedDateTime(2011, 12, 1, tz"Pacific/Apia"))
-2011-12-30 00:00 → 00:00 (Forward)
-Before: 2011-12-29T23:59:59.999-10:00 (UTC-10:00)
-After:  2011-12-31T00:00:00.000+14:00 (UTC+14:00)
+Transition Date:   2011-12-30
+Local Time Change: 00:00 → 00:00 (Forward)
+Transition From:   2011-12-29T23:59:59.999-10:00 (UTC-10:00)
+Transition To:     2011-12-31T00:00:00.000+14:00 (UTC+14:00)
+```
 """
 show_next_transition
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -288,7 +288,11 @@ function hash(zdt::ZonedDateTime, h::UInt)
 end
 
 function isequal(a::ZonedDateTime, b::ZonedDateTime)
-    isequal(a.utc_datetime, b.utc_datetime) && isequal(a.timezone, b.timezone)
+    return (
+        isequal(a.utc_datetime, b.utc_datetime) &&
+        isequal(a.timezone, b.timezone) &&
+        isequal(a.zone, b.zone)
+    )
 end
 
 function ==(a::VariableTimeZone, b::VariableTimeZone)

--- a/src/utcoffset.jl
+++ b/src/utcoffset.jl
@@ -26,6 +26,7 @@ value(offset::UTCOffset) = value(offset.std + offset.dst)
 
 (+)(dt::DateTime, offset::UTCOffset) = dt + (offset.std + offset.dst)
 (-)(dt::DateTime, offset::UTCOffset) = dt - (offset.std + offset.dst)
+(-)(a::UTCOffset, b::UTCOffset) = UTCOffset(a.std - b.std, a.dst - b.dst)
 
 # Determines if the given `UTCOffset` is an offset for daylight saving time.
 isdst(offset::UTCOffset) = offset.dst != Second(0)

--- a/test/discovery.jl
+++ b/test/discovery.jl
@@ -1,4 +1,6 @@
 import TimeZones: timezone_names
+import Compat.Dates: Millisecond
+
 
 names = timezone_names()
 @test length(names) >= 436
@@ -25,3 +27,85 @@ timezones = timezones_from_abbr("EET")
 abbrs = timezone_abbrs()
 @test isa(abbrs, Array{AbstractString})
 @test issorted(abbrs)
+
+
+wpg = resolve("America/Winnipeg", tzdata["northamerica"]...)
+apia = resolve("Pacific/Apia", tzdata["australasia"]...)
+
+@testset "next_transition_instant" begin
+    @testset "non-existent" begin
+        zone = FixedTimeZone("CST", -6 * 3600)
+
+        instant = next_transition_instant(ZonedDateTime(2018, 1, 1, wpg))
+        expected_instant = ZonedDateTime(DateTime(2018, 3, 11, 8), wpg, zone)
+        expected_valid = ZonedDateTime(2018, 3, 11, 3, wpg)
+
+        @test isequal(instant, expected_instant)
+        @test instant == expected_valid
+        @test !isequal(instant, expected_valid)
+        @test isequal(instant + Millisecond(0), expected_valid)
+    end
+
+    @testset "ambiguous" begin
+        zone = FixedTimeZone("CDT", -6 * 3600, 3600)
+
+        instant = next_transition_instant(ZonedDateTime(2018, 6, 1, wpg))
+        expected_instant = ZonedDateTime(DateTime(2018, 11, 4, 7), wpg, zone)
+        expected_valid = ZonedDateTime(2018, 11, 4, 1, wpg, 2)
+
+        @test isequal(instant, expected_instant)
+        @test instant == expected_valid
+        @test !isequal(instant, expected_valid)
+        @test isequal(instant + Millisecond(0), expected_valid)
+    end
+
+    @testset "upcoming" begin
+        if !compiled_modules_enabled
+            patch = @patch now(tz::TimeZone) = ZonedDateTime(2000, 1, 1, tz)
+            apply(patch) do
+                @test next_transition_instant(wpg) == ZonedDateTime(2000, 4, 2, 3, wpg)
+            end
+        end
+    end
+end
+
+@testset "show_next_transition" begin
+    @testset "non-existent" begin
+        @test sprint(show_next_transition, ZonedDateTime(2018, 1, 1, wpg)) ==
+            """
+            Transition Date:   2018-03-11
+            Local Time Change: 02:00 → 03:00 (Forward)
+            Transition From:   2018-03-11T01:59:59.999-06:00 (CST)
+            Transition To:     2018-03-11T03:00:00.000-05:00 (CDT)
+            """
+    end
+
+    @testset "ambiguous" begin
+         @test sprint(show_next_transition, ZonedDateTime(2018, 6, 1, wpg)) ==
+            """
+            Transition Date:   2018-11-04
+            Local Time Change: 02:00 → 01:00 (Backward)
+            Transition From:   2018-11-04T01:59:59.999-05:00 (CDT)
+            Transition To:     2018-11-04T01:00:00.000-06:00 (CST)
+            """
+    end
+
+    @testset "standard offset change" begin
+        @test sprint(show_next_transition, ZonedDateTime(2011, 12, 1, apia)) ==
+            """
+            Transition Date:   2011-12-30
+            Local Time Change: 00:00 → 00:00 (Forward)
+            Transition From:   2011-12-29T23:59:59.999-10:00 (SDT)
+            Transition To:     2011-12-31T00:00:00.000+14:00 (WSDT)
+            """
+    end
+
+    @testset "upcoming" begin
+        if !compiled_modules_enabled
+            patch = @patch now(tz::TimeZone) = ZonedDateTime(2000, 1, 1, tz)
+            apply(patch) do
+                @test contains(sprint(show_next_transition, wpg), "2000-04-02")
+            end
+        end
+    end
+end

--- a/test/discovery.jl
+++ b/test/discovery.jl
@@ -31,6 +31,7 @@ abbrs = timezone_abbrs()
 
 wpg = resolve("America/Winnipeg", tzdata["northamerica"]...)
 apia = resolve("Pacific/Apia", tzdata["australasia"]...)
+paris = resolve("Europe/Paris", tzdata["europe"]...)
 
 @testset "next_transition_instant" begin
     @testset "non-existent" begin
@@ -75,6 +76,7 @@ end
             """
             Transition Date:   2018-03-11
             Local Time Change: 02:00 → 03:00 (Forward)
+            Offset Change:     UTC-6/+0 → UTC-6/+1
             Transition From:   2018-03-11T01:59:59.999-06:00 (CST)
             Transition To:     2018-03-11T03:00:00.000-05:00 (CDT)
             """
@@ -85,6 +87,7 @@ end
             """
             Transition Date:   2018-11-04
             Local Time Change: 02:00 → 01:00 (Backward)
+            Offset Change:     UTC-6/+1 → UTC-6/+0
             Transition From:   2018-11-04T01:59:59.999-05:00 (CDT)
             Transition To:     2018-11-04T01:00:00.000-06:00 (CST)
             """
@@ -95,8 +98,20 @@ end
             """
             Transition Date:   2011-12-30
             Local Time Change: 00:00 → 00:00 (Forward)
+            Offset Change:     UTC-11/+1 → UTC+13/+1
             Transition From:   2011-12-29T23:59:59.999-10:00 (SDT)
             Transition To:     2011-12-31T00:00:00.000+14:00 (WSDT)
+            """
+    end
+
+    @testset "dst offset change" begin
+        @test sprint(show_next_transition, ZonedDateTime(1945, 4, 1, paris)) ==
+            """
+            Transition Date:   1945-04-02
+            Local Time Change: 02:00 → 03:00 (Forward)
+            Offset Change:     UTC+0/+1 → UTC+0/+2
+            Transition From:   1945-04-02T01:59:59.999+01:00 (WEST)
+            Transition To:     1945-04-02T03:00:00.000+02:00 (WEMT)
             """
     end
 


### PR DESCRIPTION
Add a human friendly function which displays information about the next time zone transition. For example:
```julia
julia> show_next_transition(tz"America/New_York")
Transition Date:   2018-03-11
Local Time Change: 02:00 → 03:00 (Forward)
Offset Change:     UTC-5/+0 → UTC-5/+1
Transition From:   2018-03-11T01:59:59.999-05:00 (EST)
Transition To:     2018-03-11T03:00:00.000-04:00 (EDT)
```