### PR TITLE
Default to using 2018d tzdata

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,4 +3,4 @@ import TimeZones: build
 # ENV variable allows users to modify the default to be "latest". Do NOT use "latest"
 # as the default here as can make it difficult to debug to past versions of working code.
 # Note: Also allows us to only download a single tzdata version during CI jobs.
-build(get(ENV, "JULIA_TZ_VERSION", "2018c"))
+build(get(ENV, "JULIA_TZ_VERSION", "2018d"))

--- a/deps/local/windowsZones.xml
+++ b/deps/local/windowsZones.xml
@@ -9,7 +9,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 <supplementalData>
 	<version number="$Revision$"/>
 	<windowsZones>
-		<mapTimezones otherVersion="7e00600" typeVersion="2017a">
+		<mapTimezones otherVersion="7e10900" typeVersion="2018d">
 
 			<!-- (UTC-12:00) International Date Line West -->
 			<mapZone other="Dateline Standard Time" territory="001" type="Etc/GMT+12"/>
@@ -428,7 +428,11 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<!-- (UTC+02:00) Kaliningrad -->
 			<mapZone other="Kaliningrad Standard Time" territory="001" type="Europe/Kaliningrad"/>
 			<mapZone other="Kaliningrad Standard Time" territory="RU" type="Europe/Kaliningrad"/>
-
+			
+			<!-- (UTC+02:00) Khartoum -->
+			<mapZone other="Sudan Standard Time" territory="001" type="Africa/Khartoum"/>
+			<mapZone other="Sudan Standard Time" territory="SD" type="Africa/Khartoum"/>
+			
 			<!-- (UTC+02:00) Tripoli -->
 			<mapZone other="Libya Standard Time" territory="001" type="Africa/Tripoli"/>
 			<mapZone other="Libya Standard Time" territory="LY" type="Africa/Tripoli"/>
@@ -468,7 +472,6 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<mapZone other="E. Africa Standard Time" territory="KE" type="Africa/Nairobi"/>
 			<mapZone other="E. Africa Standard Time" territory="KM" type="Indian/Comoro"/>
 			<mapZone other="E. Africa Standard Time" territory="MG" type="Indian/Antananarivo"/>
-			<mapZone other="E. Africa Standard Time" territory="SD" type="Africa/Khartoum"/>
 			<mapZone other="E. Africa Standard Time" territory="SO" type="Africa/Mogadishu"/>
 			<mapZone other="E. Africa Standard Time" territory="SS" type="Africa/Juba"/>
 			<mapZone other="E. Africa Standard Time" territory="TZ" type="Africa/Dar_es_Salaam"/>
@@ -626,6 +629,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 			<!-- (UTC+08:00) Perth -->
 			<mapZone other="W. Australia Standard Time" territory="001" type="Australia/Perth"/>
+			<mapZone other="W. Australia Standard Time" territory="AQ" type="Antarctica/Casey"/>
 			<mapZone other="W. Australia Standard Time" territory="AU" type="Australia/Perth"/>
 
 			<!-- (UTC+08:00) Taipei -->
@@ -723,7 +727,6 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 			<!-- (UTC+11:00) Solomon Is., New Caledonia -->
 			<mapZone other="Central Pacific Standard Time" territory="001" type="Pacific/Guadalcanal"/>
-			<mapZone other="Central Pacific Standard Time" territory="AQ" type="Antarctica/Casey"/>
 			<mapZone other="Central Pacific Standard Time" territory="AU" type="Antarctica/Macquarie"/>
 			<mapZone other="Central Pacific Standard Time" territory="FM" type="Pacific/Ponape Pacific/Kosrae"/>
 			<mapZone other="Central Pacific Standard Time" territory="NC" type="Pacific/Noumea"/>


### PR DESCRIPTION
Release notes: http://mm.icann.org/pipermail/tz-announce/2018-March/000049.html

Updated windowsZones.xml file (Last-Modified: Wed, 28 Mar 2018 16:36:47 GMT):
```bash
cd deps/local
curl -R http://unicode.org/repos/cldr/trunk/common/supplemental/windowsZones.xml -o windowsZones2018d.xml
cp -p windowsZones2018d.xml windowsZones.xml
```