### PR TITLE
Fix FixedTimeZone negative parsing corner case

### DIFF
--- a/src/utcoffset.jl
+++ b/src/utcoffset.jl
@@ -39,16 +39,18 @@ end
 isless(x::UTCOffset, y::UTCOffset) = isless(value(x), value(y))
 
 function offset_string(seconds::Second, iso8601::Bool=false)
-    v = value(seconds)
-    h, v = divrem(v, 3600)
-    m, s  = divrem(abs(v), 60)
+    val = value(seconds)
+    sig = val < 0 ? '-' : '+'
+    hour, val = divrem(abs(val), 3600)
+    minute, second  = divrem(val, 60)
 
-    if !iso8601 && m == 0 && s == 0
-        return @sprintf("%+02d", h)
-    elseif s == 0
-        return @sprintf("%+03d:%02d", h, m)
+    if !iso8601 && minute == 0 && second == 0
+        return @sprintf("%c%01d", sig, hour)
+    elseif second == 0
+        return @sprintf("%c%02d:%02d", sig, hour, minute)
     else
-        return @sprintf("%+03d:%02d:%02d", h, m, s)  # Not in the ISO 8601 standard
+        # Not in the ISO 8601 standard
+        return @sprintf("%c%02d:%02d:%02d", sig, hour, minute, second)
     end
 end
 function offset_string(offset::UTCOffset, iso8601::Bool=false)

--- a/test/types.jl
+++ b/test/types.jl
@@ -24,6 +24,8 @@ import Compat.Dates: Hour, Second, UTM
 
 @test FixedTimeZone("+01") == FixedTimeZone("UTC+01:00", 3600)
 @test FixedTimeZone("-02") == FixedTimeZone("UTC-02:00", -7200)
+@test FixedTimeZone("+00:30") == FixedTimeZone("UTC+00:30", 1800)
+@test FixedTimeZone("-00:30") == FixedTimeZone("UTC-00:30", -1800)
 
 @test_throws ArgumentError FixedTimeZone("1")
 @test_throws ArgumentError FixedTimeZone("01")

--- a/test/utcoffset.jl
+++ b/test/utcoffset.jl
@@ -10,6 +10,8 @@ import TimeZones: UTCOffset, value, isdst
 @test string(UTCOffset(0, 3600)) == "+01:00"
 @test string(UTCOffset(-7200, 3600)) == "-01:00"
 @test string(UTCOffset(-3661)) == "-01:01:01"
+@test string(UTCOffset( 1800)) == "+00:30"
+@test string(UTCOffset(-1800)) == "-00:30"
 
 @test !isdst(UTCOffset(0))
 @test !isdst(UTCOffset(0, 0))


### PR DESCRIPTION
When parsing a FixedTimeZone where the offset is negative but the hour is zero the resulting FixedTimeZone would have the offset be positive.

Fixes https://github.com/JuliaTime/TimeZones.jl/issues/132