### PR TITLE
Allow Reals for unix2zdt

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -118,6 +118,6 @@ function zdt2unix(::Type{T}, zdt::ZonedDateTime) where T<:Real
     convert(T, datetime2unix(utc(zdt)))
 end
 
-function unix2zdt(seconds::Integer)
+function unix2zdt(seconds::Real)
     ZonedDateTime(unix2datetime(seconds), utc_tz, from_utc=true)
 end

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -98,7 +98,7 @@ function zdt2julian(::Type{T}, zdt::ZonedDateTime) where T<:Integer
     floor(T, datetime2julian(utc(zdt)))
 end
 
-function zdt2julian(::Type{T}, zdt::ZonedDateTime) where T<:Number
+function zdt2julian(::Type{T}, zdt::ZonedDateTime) where T<:Real
     convert(T, datetime2julian(utc(zdt)))
 end
 
@@ -114,7 +114,7 @@ function zdt2unix(::Type{T}, zdt::ZonedDateTime) where T<:Integer
     floor(T, datetime2unix(utc(zdt)))
 end
 
-function zdt2unix(::Type{T}, zdt::ZonedDateTime) where T<:Number
+function zdt2unix(::Type{T}, zdt::ZonedDateTime) where T<:Real
     convert(T, datetime2unix(utc(zdt)))
 end
 

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -79,8 +79,8 @@ end
 @test TimeZones.zdt2unix(Int32, ZonedDateTime(1970, 1, 1, 0, 0, 0, 750, utc)) == 0
 
 # round-trip
-zdt = ZonedDateTime(2010, 1, 2, 3, 4, 5, utc)
-round_trip = TimeZones.unix2zdt(TimeZones.zdt2unix(Int64, zdt))
+zdt = ZonedDateTime(2010, 1, 2, 3, 4, 5, 999, utc)
+round_trip = TimeZones.unix2zdt(TimeZones.zdt2unix(zdt))
 @test round_trip == zdt
 
 # millisecond loss


### PR DESCRIPTION
`unix2datetime` supports them and `zdt2unix` supports them so it seems we should do this as well. 

I also restricted some other conversions to `Real` as non-reals would not make sense. 