### PR TITLE
Make ZonedDateTime subtype AbstractDateTime

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -2,6 +2,7 @@
 # import Compat.Dates: UTInstant, DateTime, TimeZone, Millisecond
 using Compat
 using Compat.Dates
+using Compat: AbstractDateTime
 import Compat.Dates: value, argerror, validargs
 import Base: promote_rule, ==, hash, isequal, isless, typemin, typemax
 import Compat: xor
@@ -135,7 +136,7 @@ end
 # A `DateTime` that includes `TimeZone` information.
 # """
 
-struct ZonedDateTime <: Compat.AbstractDateTime
+struct ZonedDateTime <: AbstractDateTime
     utc_datetime::DateTime
     timezone::TimeZone
     zone::FixedTimeZone  # The current zone for the utc_datetime.

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,5 +1,6 @@
 
 # import Compat.Dates: UTInstant, DateTime, TimeZone, Millisecond
+using Compat
 using Compat.Dates
 import Compat.Dates: value, argerror, validargs
 import Base: promote_rule, ==, hash, isequal, isless, typemin, typemax
@@ -134,7 +135,7 @@ end
 # A `DateTime` that includes `TimeZone` information.
 # """
 
-struct ZonedDateTime <: TimeType
+struct ZonedDateTime <: Compat.AbstractDateTime
     utc_datetime::DateTime
     timezone::TimeZone
     zone::FixedTimeZone  # The current zone for the utc_datetime.


### PR DESCRIPTION
On Julia 0.6, `Compat.AbstractDateTime` is an alias for `TimeType`, so the behavior on 0.6 will not change. On 0.7, this is a better choice for the supertype and should fix issues noted in https://github.com/invenia/Intervals.jl/pull/30. As suggested by @rofinn.