### PR TITLE
Define iterate for AbstractString in stead of just String in the iterate compatibility code.

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -11,7 +11,7 @@ end
 
 # https://github.com/JuliaLang/julia/pull/25261
 if VERSION < v"0.7.0-DEV.5126"
-    iterate(str::String, i::Int) = next(str, i)
+    iterate(str::AbstractString, i::Int) = next(str, i)
 end
 
 function tryparsenext_fixedtz(str, i, len, min_width::Int=1, max_width::Int=0)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -15,6 +15,12 @@ import Compat.Dates: parse_components, default_format
         ZonedDateTime(2000, tz"UTC"),
     )
     @test_throws ArgumentError parse(ZonedDateTime, "2016-04-11 08:00 EST", dateformat"yyyy-mm-dd HH:MM zzz")
+    # test AbstractString
+    @test isequal(
+        parse(ZonedDateTime, Base.Test.GenericString("2018-01-01 00:00 UTC"), dateformat"yyyy-mm-dd HH:MM ZZZ"),
+        ZonedDateTime(2018, 1, 1, 0, tz"UTC"),
+    )
+
 end
 
 @testset "tryparse" begin

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -17,7 +17,7 @@ import Compat.Dates: parse_components, default_format
     @test_throws ArgumentError parse(ZonedDateTime, "2016-04-11 08:00 EST", dateformat"yyyy-mm-dd HH:MM zzz")
     # test AbstractString
     @test isequal(
-        parse(ZonedDateTime, Base.Test.GenericString("2018-01-01 00:00 UTC"), dateformat"yyyy-mm-dd HH:MM ZZZ"),
+        parse(ZonedDateTime, Test.GenericString("2018-01-01 00:00 UTC"), dateformat"yyyy-mm-dd HH:MM ZZZ"),
         ZonedDateTime(2018, 1, 1, 0, tz"UTC"),
     )
 


### PR DESCRIPTION
This allows AbstractString's to be used again, as was possible before commit d061d91a892f5f643733df9c89bf36b04c5b1118.