### PR TITLE
#149 - Fix precompilation failure on Windows

### DIFF
--- a/src/tzdata/archive.jl
+++ b/src/tzdata/archive.jl
@@ -1,7 +1,9 @@
 import Compat: @static, Sys, devnull
 
-if Sys.iswindows()
-    const exe7z = joinpath(Sys.BINDIR, "7z.exe")
+function __init__()
+    if Sys.iswindows()
+        const exe7z = joinpath(Sys.BINDIR, "7z.exe")
+    end
 end
 
 """


### PR DESCRIPTION
Not sure about the correct Julia placement of the __init__ function. Probably OK to keep at the top of the file.