### PR TITLE
Fix 24-hour parsing with month roll over

### DIFF
--- a/src/tzdata/compile.jl
+++ b/src/tzdata/compile.jl
@@ -102,13 +102,15 @@ function parsedate(s::AbstractString)
         format = join(split("yyyy uuu dd HH:MM:SS", " ")[1:num_periods], ' ')
         periods = parse_components(s, DateFormat(format))
 
-        # Roll over 24:00 to the next day which occurs in "Pacific/Apia".
-        # Not a general purpose solution. For example won't work at the end of the month.
+        # Roll over 24:00 to the next day which occurs in "Pacific/Apia" and "Asia/Macau".
+        # Note: shift is applied after we create the DateTime to ensure that roll over works
+        # correctly at the end of the month or year.
+        shift = Day(0)
         if length(periods) > 3 && periods[4] == Hour(24)
             periods[4] = Hour(0)
-            periods[3] += Day(1)
+            shift += Day(1)
         end
-        dt = DateTime(periods...)
+        dt = DateTime(periods...) + shift
     end
 
     # TODO: I feel like there are issues here.

--- a/test/tzdata/compile.jl
+++ b/test/tzdata/compile.jl
@@ -46,8 +46,9 @@ import Compat.Dates: Hour, Minute, Second, DateTime, Date
 # Invalid zone
 @test_throws ArgumentError parsedate("1945 Aug 2 12:34i")
 
-# Actual until date found in Zone "Pacific/Apia"
-@test parsedate("2011 Dec 29 24:00") == (DateTime(2011,12,30), 'w')
+# Actual dates found tzdata files
+@test parsedate("2011 Dec 29 24:00") == (DateTime(2011,12,30), 'w')  # Pacific/Apia (2014f)
+@test parsedate("1945 Sep 30 24:00") == (DateTime(1945,10,1), 'w')  # Asia/Macau (2018f)
 
 
 ### order_rules ###


### PR DESCRIPTION
Noticed with new 2018f tzdata release. I was aware that this could be an issue but since there were no examples in the wild until now it was hard to justify supporting this.