### PR TITLE
Default to using 2018g tzdata

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,4 +3,4 @@ import TimeZones: build
 # ENV variable allows users to modify the default to be "latest". Do NOT use "latest"
 # as the default here as can make it difficult to debug to past versions of working code.
 # Note: Also allows us to only download a single tzdata version during CI jobs.
-build(get(ENV, "JULIA_TZ_VERSION", "2018f"))
+build(get(ENV, "JULIA_TZ_VERSION", "2018g"))

--- a/deps/local/windowsZones.xml
+++ b/deps/local/windowsZones.xml
@@ -9,7 +9,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 <supplementalData>
 	<version number="$Revision$"/>
 	<windowsZones>
-		<mapTimezones otherVersion="7e10900" typeVersion="2018e">
+		<mapTimezones otherVersion="7e10c00" typeVersion="2018g">
 
 			<!-- (UTC-12:00) International Date Line West -->
 			<mapZone other="Dateline Standard Time" territory="001" type="Etc/GMT+12"/>
@@ -268,11 +268,6 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<mapZone other="UTC" territory="GL" type="America/Danmarkshavn"/>
 			<mapZone other="UTC" territory="ZZ" type="Etc/GMT Etc/UTC"/>
 
-			<!-- (UTC+00:00) Casablanca -->
-			<mapZone other="Morocco Standard Time" territory="001" type="Africa/Casablanca"/>
-			<mapZone other="Morocco Standard Time" territory="EH" type="Africa/El_Aaiun"/>
-			<mapZone other="Morocco Standard Time" territory="MA" type="Africa/Casablanca"/>
-
 			<!-- (UTC+00:00) Dublin, Edinburgh, Lisbon, London -->
 			<mapZone other="GMT Standard Time" territory="001" type="Europe/London"/>
 			<mapZone other="GMT Standard Time" territory="ES" type="Atlantic/Canary"/>
@@ -336,6 +331,15 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<mapZone other="Romance Standard Time" territory="DK" type="Europe/Copenhagen"/>
 			<mapZone other="Romance Standard Time" territory="ES" type="Europe/Madrid Africa/Ceuta"/>
 			<mapZone other="Romance Standard Time" territory="FR" type="Europe/Paris"/>
+			
+			<!-- (UTC+01:00) Casablanca -->
+			<mapZone other="Morocco Standard Time" territory="001" type="Africa/Casablanca"/>
+			<mapZone other="Morocco Standard Time" territory="EH" type="Africa/El_Aaiun"/>
+			<mapZone other="Morocco Standard Time" territory="MA" type="Africa/Casablanca"/>
+
+			<!-- (UTC+01:00) Sao Tome -->
+			<mapZone other="Sao Tome Standard Time" territory="001" type="Africa/Sao_Tome"/>
+			<mapZone other="Sao Tome Standard Time" territory="ST" type="Africa/Sao_Tome"/>
 
 			<!-- (UTC+01:00) Sarajevo, Skopje, Warsaw, Zagreb -->
 			<mapZone other="Central European Standard Time" territory="001" type="Europe/Warsaw"/>
@@ -357,7 +361,6 @@ For terms of use, see http://www.unicode.org/copyright.html
 			<mapZone other="W. Central Africa Standard Time" territory="GQ" type="Africa/Malabo"/>
 			<mapZone other="W. Central Africa Standard Time" territory="NE" type="Africa/Niamey"/>
 			<mapZone other="W. Central Africa Standard Time" territory="NG" type="Africa/Lagos"/>
-			<mapZone other="W. Central Africa Standard Time" territory="ST" type="Africa/Sao_Tome"/>
 			<mapZone other="W. Central Africa Standard Time" territory="TD" type="Africa/Ndjamena"/>
 			<mapZone other="W. Central Africa Standard Time" territory="TN" type="Africa/Tunis"/>
 			<mapZone other="W. Central Africa Standard Time" territory="ZZ" type="Etc/GMT-1"/>
@@ -368,7 +371,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 			<!-- (UTC+02:00) Athens, Bucharest -->
 			<mapZone other="GTB Standard Time" territory="001" type="Europe/Bucharest"/>
-			<mapZone other="GTB Standard Time" territory="CY" type="Asia/Nicosia"/>
+			<mapZone other="GTB Standard Time" territory="CY" type="Asia/Famagusta Asia/Nicosia"/>
 			<mapZone other="GTB Standard Time" territory="GR" type="Europe/Athens"/>
 			<mapZone other="GTB Standard Time" territory="RO" type="Europe/Bucharest"/>
 
@@ -443,7 +446,6 @@ For terms of use, see http://www.unicode.org/copyright.html
 
 			<!-- (UTC+03:00) Istanbul -->
 			<mapZone other="Turkey Standard Time" territory="001" type="Europe/Istanbul"/>
-			<mapZone other="Turkey Standard Time" territory="CY" type="Asia/Famagusta"/>
 			<mapZone other="Turkey Standard Time" territory="TR" type="Europe/Istanbul"/>
 
 			<!-- (UTC+03:00) Kuwait, Riyadh -->


### PR DESCRIPTION
Release notes: http://mm.icann.org/pipermail/tz-announce/2018-October/000052.html

Updated windowsZones.xml file (Last-Modified: Tue, 30 Oct 2018 12:43:48 GMT):

```bash
cd deps/local
curl -vR http://unicode.org/repos/cldr/trunk/common/supplemental/windowsZones.xml -o windowsZonesLatest.xml
cp -p windowsZonesLatest.xml windowsZones2018g.xml  # Once verified to contain new data
mv windowsZonesLatest.xml windowsZones.xml
```