### PR TITLE
Use runtime paths for TimeZones data

### DIFF
--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -31,11 +31,11 @@ export TimeZone, @tz_str, istimezone, FixedTimeZone, VariableTimeZone, ZonedDate
     # TZData
     build
 
-const PKG_DIR = normpath(joinpath(dirname(@__FILE__), ".."))
-const DEPS_DIR = joinpath(PKG_DIR, "deps")
-const ARCHIVE_DIR = joinpath(DEPS_DIR, "tzarchive")
-const TZ_SOURCE_DIR = joinpath(DEPS_DIR, "tzsource")
-const COMPILED_DIR = joinpath(DEPS_DIR, "compiled")
+PKG_DIR() = Pkg.dir("TimeZones")
+DEPS_DIR() = joinpath(PKG_DIR(), "deps")
+ARCHIVE_DIR() = joinpath(DEPS_DIR(), "tzarchive")
+TZ_SOURCE_DIR() = joinpath(DEPS_DIR(), "tzsource")
+COMPILED_DIR() = joinpath(DEPS_DIR(), "compiled")
 const TIME_ZONES = Dict{AbstractString,TimeZone}()
 
 function __init__()
@@ -66,7 +66,7 @@ function TimeZone(str::AbstractString)
             return FixedTimeZone(str)
         end
 
-        tz_path = joinpath(COMPILED_DIR, split(str, "/")...)
+        tz_path = joinpath(COMPILED_DIR(), split(str, "/")...)
         isfile(tz_path) || throw(ArgumentError("Unknown time zone \"$str\""))
 
         open(tz_path, "r") do fp
@@ -99,7 +99,7 @@ function istimezone(str::AbstractString)
     return (
         haskey(TIME_ZONES, str) ||
         occursin(FIXED_TIME_ZONE_REGEX, str) ||
-        isfile(joinpath(COMPILED_DIR, split(str, "/")...))
+        isfile(joinpath(COMPILED_DIR(), split(str, "/")...))
     )
 end
 

--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -9,7 +9,7 @@ Returns a sorted list of all of the valid names for constructing a `TimeZone`.
 function timezone_names()
     # Note: IANA time zone names are typically encoded only in ASCII.
     names = AbstractString[]
-    check = Tuple{AbstractString,AbstractString}[(COMPILED_DIR, "")]
+    check = Tuple{AbstractString,AbstractString}[(COMPILED_DIR(), "")]
 
     for (dir, partial) in check
         for filename in readdir(dir)

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -59,17 +59,17 @@ function build(
 end
 
 function build(version::AbstractString="latest", regions=REGIONS)
-    isdir(ARCHIVE_DIR) || mkdir(ARCHIVE_DIR)
-    isdir(TZ_SOURCE_DIR) || mkdir(TZ_SOURCE_DIR)
-    isdir(COMPILED_DIR) || mkdir(COMPILED_DIR)
+    isdir(ARCHIVE_DIR()) || mkdir(ARCHIVE_DIR())
+    isdir(TZ_SOURCE_DIR()) || mkdir(TZ_SOURCE_DIR())
+    isdir(COMPILED_DIR()) || mkdir(COMPILED_DIR())
 
     # Empty the compile directory in case to handle different versions not overriding all
     # files.
-    for file in readdir(COMPILED_DIR)
-        rm(joinpath(COMPILED_DIR, file), recursive=true)
+    for file in readdir(COMPILED_DIR())
+        rm(joinpath(COMPILED_DIR(), file), recursive=true)
     end
 
-    version = build(version, regions, ARCHIVE_DIR, TZ_SOURCE_DIR, COMPILED_DIR, verbose=true)
+    version = build(version, regions, ARCHIVE_DIR(), TZ_SOURCE_DIR(), COMPILED_DIR(), verbose=true)
     write(ACTIVE_VERSION_FILE, version)
 
     return version

--- a/src/tzdata/compile.jl
+++ b/src/tzdata/compile.jl
@@ -540,7 +540,7 @@ function tzparse(tz_source_file::AbstractString)
     return zones, rules
 end
 
-function load(tz_source_dir::AbstractString=TZ_SOURCE_DIR; max_year::Integer=MAX_YEAR)
+function load(tz_source_dir::AbstractString=TZ_SOURCE_DIR(); max_year::Integer=MAX_YEAR)
     timezones = Dict{AbstractString,TimeZone}()
     for filename in readdir(tz_source_dir)
         zones, rules = tzparse(joinpath(tz_source_dir, filename))
@@ -549,7 +549,7 @@ function load(tz_source_dir::AbstractString=TZ_SOURCE_DIR; max_year::Integer=MAX
     return timezones
 end
 
-function compile(tz_source_dir::AbstractString=TZ_SOURCE_DIR, dest_dir::AbstractString=COMPILED_DIR; max_year::Integer=MAX_YEAR)
+function compile(tz_source_dir::AbstractString=TZ_SOURCE_DIR(), dest_dir::AbstractString=COMPILED_DIR(); max_year::Integer=MAX_YEAR)
     timezones = load(tz_source_dir; max_year=max_year)
 
     isdir(dest_dir) || error("Destination directory doesn't exist")

--- a/src/tzdata/download.jl
+++ b/src/tzdata/download.jl
@@ -2,7 +2,7 @@ import TimeZones: DEPS_DIR
 using Compat: isassigned, mv
 using Compat.Dates
 
-const LATEST_FILE = joinpath(DEPS_DIR, "latest")
+LATEST_FILE() = joinpath(DEPS_DIR(), "latest")
 const LATEST_FORMAT = Dates.DateFormat("yyyy-mm-ddTHH:MM:SS")
 const LATEST_DELAY = Hour(1)  # In 1996 a correction to a release was made an hour later
 
@@ -26,11 +26,11 @@ function write_latest(io::IO, version::AbstractString, retrieved_utc::DateTime)
 end
 
 T = Tuple{AbstractString, DateTime}
-const LATEST = isfile(LATEST_FILE) ? Ref{T}(read_latest(LATEST_FILE)) : Ref{T}()
+const LATEST = isfile(LATEST_FILE()) ? Ref{T}(read_latest(LATEST_FILE())) : Ref{T}()
 
 function set_latest(version::AbstractString, retrieved_utc::DateTime)
     LATEST[] = version, retrieved_utc
-    open(LATEST_FILE, "w") do io
+    open(LATEST_FILE(), "w") do io
         write_latest(io, version, retrieved_utc)
     end
 end

--- a/src/tzdata/version.jl
+++ b/src/tzdata/version.jl
@@ -25,7 +25,7 @@ const TZDATA_NEWS_REGEX = r"""
     \b
 """x
 
-const ACTIVE_VERSION_FILE = joinpath(DEPS_DIR, "active_version")
+ACTIVE_VERSION_FILE() = joinpath(DEPS_DIR(), "active_version")
 
 """
     read_news(news, [limit]) -> Vector{AbstractString}
@@ -93,15 +93,15 @@ function tzdata_version_archive(archive::AbstractString)
 end
 
 function active_version()
-    if !isfile(ACTIVE_VERSION_FILE)
+    if !isfile(ACTIVE_VERSION_FILE())
         error("No active tzdata version. Try re-building TimeZones")
     end
-    read(ACTIVE_VERSION_FILE, String)
+    read(ACTIVE_VERSION_FILE(), String)
 end
 
 function active_archive()
     version = active_version()
-    archive = joinpath(ARCHIVE_DIR, "tzdata$version.tar.gz")
+    archive = joinpath(ARCHIVE_DIR(), "tzdata$version.tar.gz")
     !isfile(archive) && error("Missing $version tzdata archive")
     return archive
 end

--- a/src/winzone/WindowsTimeZoneIDs.jl
+++ b/src/winzone/WindowsTimeZoneIDs.jl
@@ -10,10 +10,10 @@ using EzXML
 # http://cldr.unicode.org/development/development-process/design-proposals/extended-windows-olson-zid-mapping
 const WINDOWS_ZONE_URL = "http://unicode.org/repos/cldr/trunk/common/supplemental/windowsZones.xml"
 
-const WINDOWS_XML_DIR = joinpath(DEPS_DIR, "local")
-const WINDOWS_XML_FILE = joinpath(WINDOWS_XML_DIR, "windowsZones.xml")
+WINDOWS_XML_DIR() = joinpath(DEPS_DIR(), "local")
+WINDOWS_XML_FILE() = joinpath(WINDOWS_XML_DIR(), "windowsZones.xml")
 
-isdir(WINDOWS_XML_DIR) || mkdir(WINDOWS_XML_DIR)
+isdir(WINDOWS_XML_DIR()) || mkdir(WINDOWS_XML_DIR())
 
 function compile(xml_file::AbstractString)
     # Get the timezone conversions from the file
@@ -40,14 +40,14 @@ function compile(xml_file::AbstractString)
     return translation
 end
 
-const WINDOWS_TRANSLATION = if isfile(WINDOWS_XML_FILE)
-    compile(WINDOWS_XML_FILE)
+const WINDOWS_TRANSLATION = if isfile(WINDOWS_XML_FILE())
+    compile(WINDOWS_XML_FILE())
 else
     Dict{AbstractString, AbstractString}()
 end
 
-function build(xml_file::AbstractString=WINDOWS_XML_FILE; force::Bool=false)
-    fallback_xml_file = joinpath(WINDOWS_XML_DIR, "windowsZones2017a.xml")
+function build(xml_file::AbstractString=WINDOWS_XML_FILE(); force::Bool=false)
+    fallback_xml_file = joinpath(WINDOWS_XML_DIR(), "windowsZones2017a.xml")
 
     if !isfile(xml_file)
         if isfile(fallback_xml_file) && !force

--- a/test/TimeZones.jl
+++ b/test/TimeZones.jl
@@ -10,30 +10,30 @@ if lowercase(get(ENV, "CI", "false")) == "true"
     @info "Testing build process"
 
     # Clean out deps directories for a clean re-build
-    rm(TimeZones.COMPILED_DIR, recursive=true)
-    for file in readdir(TimeZones.TZ_SOURCE_DIR)
+    rm(TimeZones.COMPILED_DIR(), recursive=true)
+    for file in readdir(TimeZones.TZ_SOURCE_DIR())
         file == "utc" && continue
-        rm(joinpath(TimeZones.TZ_SOURCE_DIR, file))
+        rm(joinpath(TimeZones.TZ_SOURCE_DIR(), file))
     end
 
-    @test !isdir(TimeZones.COMPILED_DIR)
-    @test length(readdir(TimeZones.TZ_SOURCE_DIR)) == 1
+    @test !isdir(TimeZones.COMPILED_DIR())
+    @test length(readdir(TimeZones.TZ_SOURCE_DIR())) == 1
 
     # Using a version we already have avoids triggering a download
     TimeZones.build(TZDATA_VERSION, TimeZones.REGIONS)
 
-    @test isdir(TimeZones.COMPILED_DIR)
-    @test length(readdir(TimeZones.COMPILED_DIR)) > 0
-    @test readdir(TimeZones.TZ_SOURCE_DIR) == sort!([TimeZones.REGIONS; "utc"])
+    @test isdir(TimeZones.COMPILED_DIR())
+    @test length(readdir(TimeZones.COMPILED_DIR())) > 0
+    @test readdir(TimeZones.TZ_SOURCE_DIR()) == sort!([TimeZones.REGIONS; "utc"])
 
 
     # Compile the "etcetera" tz source file. An example from the FAQ.
-    @test !isfile(joinpath(TimeZones.TZ_SOURCE_DIR, "etcetera"))
+    @test !isfile(joinpath(TimeZones.TZ_SOURCE_DIR(), "etcetera"))
 
     archive = TimeZones.TZData.active_archive()
-    TimeZones.TZData.extract(archive, TimeZones.TZ_SOURCE_DIR, "etcetera")
+    TimeZones.TZData.extract(archive, TimeZones.TZ_SOURCE_DIR(), "etcetera")
 
-    @test isfile(joinpath(TimeZones.TZ_SOURCE_DIR, "etcetera"))
+    @test isfile(joinpath(TimeZones.TZ_SOURCE_DIR(), "etcetera"))
     TimeZones.TZData.compile()
 
     @test TimeZone("Etc/GMT") == FixedTimeZone("Etc/GMT", 0)

--- a/test/local.jl
+++ b/test/local.jl
@@ -62,7 +62,7 @@ if Sys.islinux()
     end
 
     # Absolute filespec
-    warsaw_path = joinpath(TZFILE_DIR, "Europe", "Warsaw")
+    warsaw_path = joinpath(TZFILE_DIR(), "Europe", "Warsaw")
     warsaw_from_file = open(warsaw_path) do f
         TimeZones.read_tzfile(f, "local")
     end
@@ -78,10 +78,10 @@ if Sys.islinux()
 
     # Set TZDIR and use time zone unrecognized by TimeZone
     @test_throws ArgumentError TimeZone("Etc/UTC")
-    utc = open(joinpath(TZFILE_DIR, "Etc", "UTC")) do f
+    utc = open(joinpath(TZFILE_DIR(), "Etc", "UTC")) do f
         TimeZones.read_tzfile(f, "Etc/UTC")
     end
-    withenv("TZ" => ":Etc/UTC", "TZDIR" => TZFILE_DIR) do
+    withenv("TZ" => ":Etc/UTC", "TZDIR" => TZFILE_DIR()) do
         @test localzone() == utc
     end
 

--- a/test/local_mocking.jl
+++ b/test/local_mocking.jl
@@ -6,7 +6,7 @@ import Compat: Sys, read
 # For mocking make sure we are actually changing the time zone
 name = string(localzone()) == "Europe/Warsaw" ? "Pacific/Apia" : "Europe/Warsaw"
 
-tzfile_path = joinpath(TZFILE_DIR, split(name, '/')...)
+tzfile_path = joinpath(TZFILE_DIR(), split(name, '/')...)
 @assert isfile(tzfile_path) "Tests require a local tzfile present"
 win_name = name == "Europe/Warsaw" ? "Central European Standard Time" : "Samoa Standard Time"
 timezone = TimeZone(name)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,16 +11,16 @@ import TimeZones.TZData: ZoneDict, RuleDict, tzparse, resolve, build
 using Nullables
 
 const TZDATA_VERSION = "2016j"
-const TZ_SOURCE_DIR = get(ENV, "TZ_SOURCE_DIR", joinpath(PKG_DIR, "test", "tzsource"))
-const TZFILE_DIR = joinpath(PKG_DIR, "test", "tzfile")
+TZ_SOURCE_DIR() = get(ENV, "TZ_SOURCE_DIR", joinpath(PKG_DIR(), "test", "tzsource"))
+TZFILE_DIR() = joinpath(PKG_DIR(), "test", "tzfile")
 const TEST_REGIONS = ("asia", "australasia", "europe", "northamerica")
 
-isdir(ARCHIVE_DIR) || mkdir(ARCHIVE_DIR)
-isdir(TZ_SOURCE_DIR) || mkdir(TZ_SOURCE_DIR)
+isdir(ARCHIVE_DIR()) || mkdir(ARCHIVE_DIR())
+isdir(TZ_SOURCE_DIR()) || mkdir(TZ_SOURCE_DIR())
 
 # By default use a specific version of the tz database so we just testing for TimeZones.jl
 # changes and not changes to the tzdata.
-build(TZDATA_VERSION, TEST_REGIONS, ARCHIVE_DIR, TZ_SOURCE_DIR)
+build(TZDATA_VERSION, TEST_REGIONS, ARCHIVE_DIR(), TZ_SOURCE_DIR())
 
 # For testing we'll reparse the tzdata every time to instead of using the serialized data.
 # This should make the development/testing cycle simplier since you won't be forced to
@@ -30,7 +30,7 @@ build(TZDATA_VERSION, TEST_REGIONS, ARCHIVE_DIR, TZ_SOURCE_DIR)
 # recompiles all the time zones.
 tzdata = Dict{AbstractString,Tuple{ZoneDict,RuleDict}}()
 for name in TEST_REGIONS
-    tzdata[name] = tzparse(joinpath(TZ_SOURCE_DIR, name))
+    tzdata[name] = tzparse(joinpath(TZ_SOURCE_DIR(), name))
 end
 
 include("helpers.jl")

--- a/test/tzfile.jl
+++ b/test/tzfile.jl
@@ -29,20 +29,20 @@ end
 
 # Ensure that read_tzfile returns a FixedTimeZone with the right data
 utc = FixedTimeZone("UTC", 0)
-open(joinpath(TZFILE_DIR, "Etc", "UTC")) do f
+open(joinpath(TZFILE_DIR(), "Etc", "UTC")) do f
     tz = TimeZones.read_tzfile(f, "UTC")
     @test tz == utc
 end
 
 # Fixed time zone using version 2 data.
 utc_plus_6 = FixedTimeZone("UTC+6", 6 * 3600)
-open(joinpath(TZFILE_DIR, "Etc", "GMT-6")) do f
+open(joinpath(TZFILE_DIR(), "Etc", "GMT-6")) do f
     tz = TimeZones.read_tzfile(f, "UTC+6")
     @test tz == utc_plus_6
 end
 
 warsaw = resolve("Europe/Warsaw", tzdata["europe"]...)
-open(joinpath(TZFILE_DIR, "Europe", "Warsaw")) do f
+open(joinpath(TZFILE_DIR(), "Europe", "Warsaw")) do f
     tz = TimeZones.read_tzfile(f, "Europe/Warsaw")
     @test string(tz) == "Europe/Warsaw"
     @test first(tz.transitions).utc_datetime == DateTime(1915,8,4,22,36)
@@ -52,7 +52,7 @@ open(joinpath(TZFILE_DIR, "Europe", "Warsaw")) do f
 end
 
 # Read version 1 compatible data
-open(joinpath(TZFILE_DIR, "Europe", "Warsaw (Version 2)")) do f
+open(joinpath(TZFILE_DIR(), "Europe", "Warsaw (Version 2)")) do f
     version, tz = TimeZones.read_tzfile_internal(f, "Europe/Warsaw")
     @test version == '2'
     @test string(tz) == "Europe/Warsaw"
@@ -65,7 +65,7 @@ open(joinpath(TZFILE_DIR, "Europe", "Warsaw (Version 2)")) do f
 end
 
 # Read version 2 data
-open(joinpath(TZFILE_DIR, "Europe", "Warsaw (Version 2)")) do f
+open(joinpath(TZFILE_DIR(), "Europe", "Warsaw (Version 2)")) do f
     tz = TimeZones.read_tzfile(f, "Europe/Warsaw")
     @test string(tz) == "Europe/Warsaw"
     @test first(tz.transitions).utc_datetime == typemin(DateTime)
@@ -76,7 +76,7 @@ end
 
 
 godthab = resolve("America/Godthab", tzdata["europe"]...)
-open(joinpath(TZFILE_DIR, "America", "Godthab")) do f
+open(joinpath(TZFILE_DIR(), "America", "Godthab")) do f
     tz = TimeZones.read_tzfile(f, "America/Godthab")
     @test string(tz) == "America/Godthab"
     @test first(tz.transitions).utc_datetime == DateTime(1916,7,28,3,26,56)
@@ -86,7 +86,7 @@ open(joinpath(TZFILE_DIR, "America", "Godthab")) do f
 end
 
 # Read version 1 compatible data
-open(joinpath(TZFILE_DIR, "America", "Godthab (Version 3)")) do f
+open(joinpath(TZFILE_DIR(), "America", "Godthab (Version 3)")) do f
     version, tz = TimeZones.read_tzfile_internal(f, "America/Godthab")
     @test version == '3'
     @test string(tz) == "America/Godthab"
@@ -97,7 +97,7 @@ open(joinpath(TZFILE_DIR, "America", "Godthab (Version 3)")) do f
 end
 
 # Read version 3 data
-open(joinpath(TZFILE_DIR, "America", "Godthab (Version 3)")) do f
+open(joinpath(TZFILE_DIR(), "America", "Godthab (Version 3)")) do f
     tz = TimeZones.read_tzfile(f, "America/Godthab")
     @test string(tz) == "America/Godthab"
     @test first(tz.transitions).utc_datetime == typemin(DateTime)
@@ -111,7 +111,7 @@ end
 # DST calculation. The entire day of 2011/12/30 was skipped when they changed from a
 # -11:00 GMT offset to 13:00 GMT offset
 apia = resolve("Pacific/Apia", tzdata["australasia"]...)
-open(joinpath(TZFILE_DIR, "Pacific", "Apia")) do f
+open(joinpath(TZFILE_DIR(), "Pacific", "Apia")) do f
     tz = TimeZones.read_tzfile(f, "Pacific/Apia")
     @test string(tz) == "Pacific/Apia"
     @test first(tz.transitions).utc_datetime == DateTime(1911,1,1,11,26,56)
@@ -125,7 +125,7 @@ end
 # midsomer back in 1940's there were 2 different dst one after another, we get a
 # different utc and dst than Olson.
 paris = resolve("Europe/Paris", tzdata["europe"]...)
-open(joinpath(TZFILE_DIR, "Europe", "Paris")) do f
+open(joinpath(TZFILE_DIR(), "Europe", "Paris")) do f
     tz = TimeZones.read_tzfile(f, "Europe/Paris")
     @test string(tz) == "Europe/Paris"
     @test first(tz.transitions).utc_datetime == DateTime(1911,3,10,23,51,39)
@@ -143,7 +143,7 @@ open(joinpath(TZFILE_DIR, "Europe", "Paris")) do f
 end
 
 madrid = resolve("Europe/Madrid", tzdata["europe"]...)
-open(joinpath(TZFILE_DIR, "Europe", "Madrid")) do f
+open(joinpath(TZFILE_DIR(), "Europe", "Madrid")) do f
     tz = TimeZones.read_tzfile(f, "Europe/Madrid")
     @test string(tz) == "Europe/Madrid"
     @test first(tz.transitions).utc_datetime == DateTime(1917,5,5,23)
@@ -163,7 +163,7 @@ end
 
 # "Australia/Perth" test processing a tzfile that should not contain a cutoff
 perth = resolve("Australia/Perth", tzdata["australasia"]...)
-open(joinpath(TZFILE_DIR, "Australia", "Perth")) do f
+open(joinpath(TZFILE_DIR(), "Australia", "Perth")) do f
     tz = TimeZones.read_tzfile(f, "Australia/Perth")
     @test string(tz) == "Australia/Perth"
     @test first(tz.transitions).utc_datetime == DateTime(1916,12,31,16,1)

--- a/test/winzone/WindowsTimeZoneIDs.jl
+++ b/test/winzone/WindowsTimeZoneIDs.jl
@@ -1,6 +1,6 @@
 import TimeZones.WindowsTimeZoneIDs
 
-xml_file = TimeZones.WindowsTimeZoneIDs.WINDOWS_XML_FILE
+xml_file = TimeZones.WindowsTimeZoneIDs.WINDOWS_XML_FILE()
 !isfile(xml_file) && error("Missing required XML file. Run Pkg.build(\"TimeZones\").")
 
 trans = TimeZones.WindowsTimeZoneIDs.compile(xml_file)


### PR DESCRIPTION
We build an embedded julia image that is distributed across multiple machines. Fixing paths at precompilation time doesn't really work in this scenario and I couldn't find a better or less intrusive solution.

One possible option was to override constant paths in `__init__()`, but julia spits warnings at that and I couldn't really override all constants this way (namely some bits under TzData). Another alternative was to not define constants globally, and only define them in `__init__()`, but that would require even more extensive changes.