### PR TITLE
Drop Julia 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ os:
   - osx
   - linux
 julia:
-  - 0.6
   - 0.7
   - 1.0
   - nightly
@@ -25,8 +24,8 @@ script:
   - git fetch origin +:refs/remotes/origin/HEAD; if ! git diff --quiet origin/HEAD HEAD -- deps/build.jl; then unset JULIA_TZ_VERSION; fi
   - |
     julia -e '
-      VERSION >= v"0.7.0-DEV.3656" && using Pkg
-      if VERSION >= v"0.7.0-DEV.5183" && (isfile("Project.toml") || isfile("JuliaProject.toml"))
+      using Pkg
+      if isfile("Project.toml") || isfile("JuliaProject.toml")
           Pkg.build(); Pkg.test(coverage=true)
       else
           Pkg.clone(pwd()); Pkg.build("TimeZones"); Pkg.test("TimeZones"; coverage=true)
@@ -34,8 +33,7 @@ script:
 after_success:
   - |
     julia -e '
-      VERSION >= v"0.7.0-DEV.3656" && using Pkg
-      VERSION >= v"0.7.0-DEV.5183" || cd(Pkg.dir("TimeZones"))
+      using Pkg
       Pkg.add("Coverage"); using Coverage
       Codecov.submit(process_folder())
       Coveralls.submit(Coveralls.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.7.0
 Mocking 0.5.6
-Nullables 0.0.7
 @windows EzXML 0.8.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.7.0
-Compat 0.66
 Mocking 0.5.6
 Nullables 0.0.7
-@windows EzXML 0.7.3
+@windows EzXML 0.8.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7.0
 Compat 0.66
 Mocking 0.5.6
 Nullables 0.0.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ environment:
   JULIA_TZ_VERSION: "2016j"
 
   matrix:
-  - julia_version: 0.6
   - julia_version: 0.7
   - julia_version: 1.0
   - julia_version: latest

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,6 +1,6 @@
 using PkgBenchmark
 using TimeZones
-import Compat.Dates: DateFormat
+import Dates: DateFormat
 import TimeZones.TZData: parse_components
 
 @benchgroup "parse" begin

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -4,8 +4,6 @@
 DocTestSetup = quote
     using TimeZones
 end
-# https://github.com/JuliaLang/julia/pull/30200
-DocTestFilters = r"Nullable\{DateTime\}\((\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}|DateTime\((\d+, ){0,6}\d+\))\)"
 ```
 
 ## [Why are the "Etc/\*" time zones unsupported?](@id etc_tzs)
@@ -34,7 +32,7 @@ julia> last(warsaw.transitions)
 2037-10-25T01:00:00 UTC+1/+0 (CET)
 
 julia> warsaw.cutoff  # DateTime up until the last transition is effective
-Nullable{DateTime}(DateTime(2038, 3, 28, 1))
+2038-03-28T01:00:00
 
 julia> ZonedDateTime(DateTime(2039), warsaw)
 ERROR: UnhandledTimeError: TimeZone Europe/Warsaw does not handle dates on or after 2038-03-28T01:00:00 UTC

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -1,12 +1,11 @@
-VERSION < v"0.7.0-beta2.199" && __precompile__()
-
 module TimeZones
 
-import Compat: Sys, occursin, undef, @info, @warn
-
-using Compat.Dates, Compat.Printf, Compat.Serialization, Compat.Unicode
-import Compat.Dates: TimeZone, AbstractTime
+using Dates
 using Nullables
+using Printf
+using Serialization
+using Unicode
+import Dates: TimeZone
 
 export TimeZone, @tz_str, istimezone, FixedTimeZone, VariableTimeZone, ZonedDateTime,
     DateTime, TimeError, AmbiguousTimeError, NonExistentTimeError, UnhandledTimeError,

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -1,7 +1,6 @@
 module TimeZones
 
 using Dates
-using Nullables
 using Printf
 using Serialization
 using Unicode

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -1,6 +1,4 @@
-import Base: eps
-import Compat.Dates: Hour, Minute, Second, Millisecond,
-    days, hour, minute, second, millisecond
+using Dates: Hour, Minute, Second, Millisecond, days, hour, minute, second, millisecond
 
 """
     localtime(::ZonedDateTime) -> DateTime
@@ -25,14 +23,14 @@ Returns the `TimeZone` used by the `ZonedDateTime`.
 """
 timezone(zdt::ZonedDateTime) = zdt.timezone
 
-days(zdt::ZonedDateTime) = days(localtime(zdt))
+Dates.days(zdt::ZonedDateTime) = days(localtime(zdt))
 
 for period in (:Hour, :Minute, :Second, :Millisecond)
     accessor = Symbol(lowercase(string(period)))
     @eval begin
-        $accessor(zdt::ZonedDateTime) = $accessor(localtime(zdt))
-        $period(zdt::ZonedDateTime) = $period($accessor(zdt))
+        Dates.$accessor(zdt::ZonedDateTime) = $accessor(localtime(zdt))
+        Dates.$period(zdt::ZonedDateTime) = $period($accessor(zdt))
     end
 end
 
-eps(::ZonedDateTime) = Millisecond(1)
+Base.eps(::ZonedDateTime) = Millisecond(1)

--- a/src/adjusters.jl
+++ b/src/adjusters.jl
@@ -1,24 +1,24 @@
-import Compat.Dates: trunc, DatePeriod, TimePeriod
-import Compat.Dates: firstdayofweek, lastdayofweek, firstdayofmonth, lastdayofmonth,
-    firstdayofyear, lastdayofyear, firstdayofquarter, lastdayofquarter
+using Dates: DatePeriod, TimePeriod, firstdayofweek, lastdayofweek,
+    firstdayofmonth, lastdayofmonth, firstdayofyear, lastdayofyear,
+    firstdayofquarter, lastdayofquarter
 
 
 # Truncation
 # TODO: Just utilize floor code for truncation?
-function trunc(zdt::ZonedDateTime, ::Type{P}) where P<:DatePeriod
+function Base.trunc(zdt::ZonedDateTime, ::Type{P}) where P <: DatePeriod
     ZonedDateTime(trunc(localtime(zdt), P), timezone(zdt))
 end
-function trunc(zdt::ZonedDateTime, ::Type{P}) where P<:TimePeriod
+function Base.trunc(zdt::ZonedDateTime, ::Type{P}) where P <: TimePeriod
     local_dt = trunc(localtime(zdt), P)
     utc_dt = local_dt - zdt.zone.offset
     ZonedDateTime(utc_dt, timezone(zdt); from_utc=true)
 end
-trunc(zdt::ZonedDateTime, ::Type{Millisecond}) = zdt
+Base.trunc(zdt::ZonedDateTime, ::Type{Millisecond}) = zdt
 
 # Adjusters
 for prefix in ("firstdayof", "lastdayof"), suffix in ("week", "month", "year", "quarter")
     func = Symbol(prefix * suffix)
     @eval begin
-        $func(dt::ZonedDateTime) = ZonedDateTime($func(localtime(dt)), dt.timezone)
+        Dates.$func(dt::ZonedDateTime) = ZonedDateTime($func(localtime(dt)), dt.timezone)
     end
 end

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -1,27 +1,19 @@
-import Base: +, -
-import Compat: @static
-
-if VERSION < v"0.7.0-DEV.4955"
-    import Base: broadcast
-    const broadcasted = broadcast
-else
-    import Base.Broadcast: broadcasted
-end
+import Base.Broadcast: broadcasted
 
 # ZonedDateTime arithmetic
-(+)(x::ZonedDateTime) = x
-(-)(x::ZonedDateTime, y::ZonedDateTime) = x.utc_datetime - y.utc_datetime
+Base.:(+)(x::ZonedDateTime) = x
+Base.:(-)(x::ZonedDateTime, y::ZonedDateTime) = x.utc_datetime - y.utc_datetime
 
-function (+)(zdt::ZonedDateTime, p::DatePeriod)
+function Base.:(+)(zdt::ZonedDateTime, p::DatePeriod)
     return ZonedDateTime(localtime(zdt) + p, timezone(zdt))
 end
-function (+)(zdt::ZonedDateTime, p::TimePeriod)
+function Base.:(+)(zdt::ZonedDateTime, p::TimePeriod)
     return ZonedDateTime(zdt.utc_datetime + p, timezone(zdt); from_utc=true)
 end
-function (-)(zdt::ZonedDateTime, p::DatePeriod)
+function Base.:(-)(zdt::ZonedDateTime, p::DatePeriod)
     return ZonedDateTime(localtime(zdt) - p, timezone(zdt))
 end
-function (-)(zdt::ZonedDateTime, p::TimePeriod)
+function Base.:(-)(zdt::ZonedDateTime, p::TimePeriod)
     return ZonedDateTime(zdt.utc_datetime - p, timezone(zdt); from_utc=true)
 end
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1,6 +1,5 @@
-import Compat.Dates: unix2datetime, datetime2unix, julian2datetime, datetime2julian,
-    now, today
-using Mocking
+using Dates: unix2datetime, datetime2unix, julian2datetime, datetime2julian
+using Mocking: Mocking, @mock
 
 # UTC is an abstract type defined in Dates, for some reason
 const utc_tz = FixedTimeZone("UTC")
@@ -17,7 +16,7 @@ DateTime(zdt::ZonedDateTime) = localtime(zdt)
 
 Returns a `ZonedDateTime` corresponding to the user's system time in the specified `TimeZone`.
 """
-function now(tz::TimeZone)
+function Dates.now(tz::TimeZone)
     utc = unix2datetime(time())
     ZonedDateTime(utc, tz, from_utc=true)
 end
@@ -40,7 +39,7 @@ julia> today(tz"Pacific/Midway"), today(tz"Pacific/Apia")
 (2017-11-09, 2017-11-10)
 ```
 """
-today(tz::TimeZone) = Date(localtime(now(tz)))
+Dates.today(tz::TimeZone) = Date(localtime(now(tz)))
 
 """
     todayat(tod::Time, tz::TimeZone, [amb]) -> ZonedDateTime

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,22 +1,11 @@
-import Base: @deprecate, @deprecate_binding
-
-if VERSION < v"0.7.0-DEV.4003"
-    import Base: colon
-else
-    import Base: (:)
-end
+using Base: @deprecate, @deprecate_binding
+import Base: (:)
 
 # BEGIN TimeZones 0.6 deprecations
 
-# JuliaLang/julia#24258
-if VERSION < v"0.7.0-DEV.2778"
-    # Only remove this method when support for Julia 0.6 is dropped.
-    colon(start::T, stop::T) where {T <: ZonedDateTime} = start:Day(1):stop
-elseif VERSION < v"0.7.0-DEV.4003"  # JuliaLang/julia#26074
-    @deprecate colon(start::T, stop::T) where {T <: ZonedDateTime} start:Day(1):stop  false
-else
-    # Only remove this deprecation when support for Julia 0.7 is dropped.
-    @deprecate (:)(start::T, stop::T) where {T <: ZonedDateTime}   start:Day(1):stop  false
+# Only remove this deprecation when support for Julia 0.7 is dropped (JuliaLang/julia#24258)
+if VERSION < v"1.0.0-DEV.44"
+    @deprecate ((:)(start::T, stop::T) where {T <: ZonedDateTime}) start:Day(1):stop false
 end
 
 # END TimeZones 0.6 deprecations

--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -1,5 +1,4 @@
-using Mocking
-using Compat: stdout
+using Mocking: Mocking, @mock
 
 """
     timezone_names() -> Array{AbstractString}

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -1,5 +1,3 @@
-import Base: showerror
-
 abstract type TimeError <: Exception end
 
 """
@@ -13,7 +11,7 @@ struct AmbiguousTimeError <: TimeError
     timezone::TimeZone
 end
 
-function showerror(io::IO, e::AmbiguousTimeError)
+function Base.showerror(io::IO, e::AmbiguousTimeError)
     print(io, "AmbiguousTimeError: ")
     print(io, "Local DateTime $(e.local_dt) is ambiguous within $(string(e.timezone))")
 end
@@ -30,7 +28,7 @@ struct NonExistentTimeError <: TimeError
     timezone::TimeZone
 end
 
-function showerror(io::IO, e::NonExistentTimeError)
+function Base.showerror(io::IO, e::NonExistentTimeError)
     print(io, "NonExistentTimeError: ")
     print(io, "Local DateTime $(e.local_dt) does not exist within $(string(e.timezone))")
 end
@@ -44,7 +42,7 @@ struct UnhandledTimeError <: TimeError
     tz::VariableTimeZone
 end
 
-function showerror(io::IO, e::UnhandledTimeError)
+function Base.showerror(io::IO, e::UnhandledTimeError)
     print(io, "UnhandledTimeError: ")
     print(io, "TimeZone $(string(e.tz)) does not handle dates on or after $(get(e.tz.cutoff)) UTC")
 end

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -44,5 +44,5 @@ end
 
 function Base.showerror(io::IO, e::UnhandledTimeError)
     print(io, "UnhandledTimeError: ")
-    print(io, "TimeZone $(string(e.tz)) does not handle dates on or after $(get(e.tz.cutoff)) UTC")
+    print(io, "TimeZone $(string(e.tz)) does not handle dates on or after $(e.tz.cutoff) UTC")
 end

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -1,4 +1,4 @@
-import TimeZones.TZData: MIN_OFFSET, MAX_OFFSET
+using TimeZones.TZData: MIN_OFFSET, MAX_OFFSET
 
 # TimeZone concepts used to disambiguate context of DateTimes
 # abstract type UTC <: TimeZone end # Defined in Dates

--- a/src/io.jl
+++ b/src/io.jl
@@ -39,7 +39,7 @@ function Base.show(io::IO, tz::VariableTimeZone)
         # Retrieve the "modern" time zone transitions. We'll treat the latest transitions as
         # the same as the transitions for `now()` since these future transitions should be
         # based upon the same rules.
-        if isnull(tz.cutoff) || length(trans) == 1
+        if tz.cutoff === nothing || length(trans) == 1
             trans = trans[end:end]
         else
             trans = trans[end-1:end]

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,21 +1,20 @@
-import Base: print, show
-import Compat.Dates: value, DateFormat
+using Dates: value
 
-print(io::IO, tz::TimeZone) = print(io, tz.name)
-function print(io::IO, tz::FixedTimeZone)
+Base.print(io::IO, tz::TimeZone) = print(io, tz.name)
+function Base.print(io::IO, tz::FixedTimeZone)
     name = string(tz.name)
     isempty(name) ? print(io, "UTC", tz.offset) : print(io, name)
 end
-print(io::IO, zdt::ZonedDateTime) = print(io, localtime(zdt), zdt.zone.offset)
+Base.print(io::IO, zdt::ZonedDateTime) = print(io, localtime(zdt), zdt.zone.offset)
 
-function show(io::IO, t::Transition)
+function Base.show(io::IO, t::Transition)
     name_str = string(t.zone.name)
     print(io, t.utc_datetime, " ")
     show(io, t.zone.offset)
     !isempty(name_str) && print(io, " (", name_str, ")")
 end
 
-function show(io::IO, tz::FixedTimeZone)
+function Base.show(io::IO, tz::FixedTimeZone)
     if get(io, :compact, false)
         print(io, tz)
     else
@@ -31,7 +30,7 @@ function show(io::IO, tz::FixedTimeZone)
     end
 end
 
-function show(io::IO, tz::VariableTimeZone)
+function Base.show(io::IO, tz::VariableTimeZone)
     if get(io, :compact, false)
         print(io, tz)
     else
@@ -60,4 +59,4 @@ function show(io::IO, tz::VariableTimeZone)
     end
 end
 
-show(io::IO,dt::ZonedDateTime) = print(io, string(dt))
+Base.show(io::IO,dt::ZonedDateTime) = print(io, string(dt))

--- a/src/local.jl
+++ b/src/local.jl
@@ -1,7 +1,6 @@
 # Determine the local system's time zone
 # Based upon Python's tzlocal https://pypi.python.org/pypi/tzlocal
-import Compat: @static, Sys, findnext, isequal, pushfirst!, read
-using Mocking
+using Mocking: Mocking, @mock
 
 if Sys.iswindows()
     import TimeZones.WindowsTimeZoneIDs: WINDOWS_TRANSLATION

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -1,4 +1,4 @@
-import Compat.Dates: guess
+using Dates: guess
 
 """
     guess(start::ZonedDateTime, finish::ZonedDateTime, step) -> Integer
@@ -6,6 +6,6 @@ import Compat.Dates: guess
 Given a start and end date, indicates how many steps/periods are between them. Defining this
 function allows `StepRange`s to be defined for `ZonedDateTime`s.
 """
-function guess(start::ZonedDateTime, finish::ZonedDateTime, step)
+function Dates.guess(start::ZonedDateTime, finish::ZonedDateTime, step)
     guess(start.utc_datetime, finish.utc_datetime, step)
 end

--- a/src/rounding.jl
+++ b/src/rounding.jl
@@ -1,4 +1,4 @@
-import Compat.Dates: Period, DatePeriod, TimePeriod
+using Dates: Period, DatePeriod, TimePeriod
 
 function Base.floor(zdt::ZonedDateTime, p::DatePeriod)
     return ZonedDateTime(floor(localtime(zdt), p), timezone(zdt))

--- a/src/tzdata/TZData.jl
+++ b/src/tzdata/TZData.jl
@@ -1,11 +1,8 @@
 module TZData
 
-using Compat
-using Compat: occursin, @info, @warn
-import Compat: Sys
-using Compat.Printf
 using Nullables
-import ...TimeZones: DEPS_DIR
+using Printf
+using ...TimeZones: DEPS_DIR
 
 # Note: The tz database is made up of two parts: code and data. TimeZones.jl only requires
 # the "tzdata" archive or more specifically the "tz source" files within the archive

--- a/src/tzdata/TZData.jl
+++ b/src/tzdata/TZData.jl
@@ -1,6 +1,5 @@
 module TZData
 
-using Nullables
 using Printf
 using ...TimeZones: DEPS_DIR
 

--- a/src/tzdata/archive.jl
+++ b/src/tzdata/archive.jl
@@ -1,5 +1,3 @@
-import Compat: @static, devnull
-
 """
     extract(archive, directory, [files]; [verbose=false]) -> Void
 

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -18,11 +18,12 @@ function build(
     compiled_dir::AbstractString="";
     verbose::Bool=false,
 )
-    # Avoids spaming remote servers requesting the latest version
+    # Avoids spamming remote servers requesting the latest version
     if version == "latest"
-        version = get(latest_version(), "latest")
+        v = latest_version()
 
-        if version != "latest"
+        if v !== nothing
+            version = v
             @info "Latest tzdata is $version"
         end
     end

--- a/src/tzdata/compile.jl
+++ b/src/tzdata/compile.jl
@@ -1,10 +1,11 @@
-using Compat.Dates, Compat.Serialization
-import Compat.Dates: parse_components
+using Dates
+using Serialization
+using Dates: parse_components
 
-import ...TimeZones: TIME_ZONES
-import ...TimeZones: TimeZone, FixedTimeZone, VariableTimeZone, Transition
-import ..TZData: TimeOffset, ZERO, MIN_GMT_OFFSET, MAX_GMT_OFFSET,
-    MIN_SAVE, MAX_SAVE, ABS_DIFF_OFFSET
+using ...TimeZones: TIME_ZONES
+using ...TimeZones: TimeZone, FixedTimeZone, VariableTimeZone, Transition
+using ..TZData: TimeOffset, ZERO, MIN_GMT_OFFSET, MAX_GMT_OFFSET, MIN_SAVE, MAX_SAVE,
+    ABS_DIFF_OFFSET
 
 # Zone type maps to an Olson Timezone database entity
 struct Zone

--- a/src/tzdata/download.jl
+++ b/src/tzdata/download.jl
@@ -1,6 +1,5 @@
-import TimeZones: DEPS_DIR
-using Compat: isassigned, mv
-using Compat.Dates
+using Dates
+using TimeZones: DEPS_DIR
 
 const LATEST_FILE = joinpath(DEPS_DIR, "latest")
 const LATEST_FORMAT = Dates.DateFormat("yyyy-mm-ddTHH:MM:SS")

--- a/src/tzdata/download.jl
+++ b/src/tzdata/download.jl
@@ -38,11 +38,11 @@ function latest_version(now_utc::DateTime=now(Dates.UTC))
         latest_version, latest_retrieved_utc = LATEST[]
 
         if now_utc - latest_retrieved_utc < LATEST_DELAY
-            return Nullable{AbstractString}(latest_version)
+            return latest_version
         end
     end
 
-    return Nullable{AbstractString}()
+    return nothing
 end
 
 """
@@ -78,8 +78,8 @@ function tzdata_download(version::AbstractString="latest", dir::AbstractString=t
     now_utc = now(Dates.UTC)
     if version == "latest"
         v = latest_version(now_utc)
-        if !isnull(v)
-            archive = joinpath(dir, "tzdata$(unsafe_get(v)).tar.gz")
+        if v !== nothing
+            archive = joinpath(dir, "tzdata$(v).tar.gz")
             isfile(archive) && return archive
         end
     end

--- a/src/tzdata/timeoffset.jl
+++ b/src/tzdata/timeoffset.jl
@@ -1,6 +1,4 @@
-import Base: convert, promote_rule, string, print, show
-import Compat.Dates: Period, TimePeriod, Week, Day, Hour, Minute, Second, Millisecond,
-    value, toms, hour, minute, second
+using Dates: Dates, TimePeriod, Week, Day, Hour, Minute, Second, Millisecond, value
 
 # Convenience type for working with HH:MM:SS durations which can be negative or exceed
 # 24-hours.
@@ -36,12 +34,12 @@ function TimeOffset(s::AbstractString)
 end
 
 # TimePeriod methods
-value(t::TimeOffset) = t.seconds
-toms(t::TimeOffset) = value(t) * 1000
+Dates.value(t::TimeOffset) = t.seconds
+Dates.toms(t::TimeOffset) = value(t) * 1000
 
-hour(t::TimeOffset) = div(value(t), 3600)
-minute(t::TimeOffset) = rem(div(value(t), 60), 60)
-second(t::TimeOffset) = rem(value(t), 60)
+Dates.hour(t::TimeOffset) = div(value(t), 3600)
+Dates.minute(t::TimeOffset) = rem(div(value(t), 60), 60)
+Dates.second(t::TimeOffset) = rem(value(t), 60)
 
 function hourminutesecond(t::TimeOffset)
     h, r = divrem(value(t), 3600)
@@ -49,19 +47,19 @@ function hourminutesecond(t::TimeOffset)
     return h, m, s
 end
 
-convert(::Type{Second}, t::TimeOffset) = Second(value(t))
-convert(::Type{Millisecond}, t::TimeOffset) = Millisecond(value(t) * 1000)
-promote_rule(::Type{<:Union{Week,Day,Hour,Minute,Second}}, ::Type{TimeOffset}) = Second
-promote_rule(::Type{Millisecond}, ::Type{TimeOffset}) = Millisecond
+Base.convert(::Type{Second}, t::TimeOffset) = Second(value(t))
+Base.convert(::Type{Millisecond}, t::TimeOffset) = Millisecond(value(t) * 1000)
+Base.promote_rule(::Type{<:Union{Week,Day,Hour,Minute,Second}}, ::Type{TimeOffset}) = Second
+Base.promote_rule(::Type{Millisecond}, ::Type{TimeOffset}) = Millisecond
 
 # https://en.wikipedia.org/wiki/ISO_8601#Times
-function string(t::TimeOffset)
+function Base.string(t::TimeOffset)
     neg = value(t) < 0 ? "-" : ""
     h, m, s = map(abs, hourminutesecond(t))
     @sprintf("%s%02d:%02d:%02d", neg, h, m, s)
 end
-print(io::IO, t::TimeOffset) = print(io, string(t))
-show(io::IO, t::TimeOffset) = print(io, t)
+Base.print(io::IO, t::TimeOffset) = print(io, string(t))
+Base.show(io::IO, t::TimeOffset) = print(io, t)
 
 
 # min/max offsets across all zones and all time.

--- a/src/tzdata/version.jl
+++ b/src/tzdata/version.jl
@@ -1,5 +1,3 @@
-import Compat: read
-
 # Note: A tz code or data version consists of a year and letter while a release consists of
 # a pair of tz code and data versions. In recent releases the tz code and data use the same
 # version.

--- a/src/tzfile.jl
+++ b/src/tzfile.jl
@@ -144,9 +144,9 @@ function read_tzfile_internal(io::IO, name::AbstractString, force_version::Char=
         # Note: that without knowing that additional transitions do exist beyond the last
         # stored transition we cannot determine with perfect accuracy what the cutoff should
         # be.
-        cutoff = Nullable{DateTime}()
+        cutoff = nothing
         if DateTime(2037) <= last(transitions).utc_datetime < TZFILE_MAX
-            cutoff = Nullable(TZFILE_MAX)
+            cutoff = TZFILE_MAX
         end
 
         timezone = VariableTimeZone(name, transitions, cutoff)

--- a/src/tzfile.jl
+++ b/src/tzfile.jl
@@ -2,8 +2,6 @@
 # - http://man7.org/linux/man-pages/man5/tzfile.5.html
 # - ftp://ftp.iana.org/tz/code/tzfile.5.txt
 
-import Compat: read, unsafe_string
-
 const TZFILE_MAX = unix2datetime(typemax(Int32))
 
 struct TransitionTimeInfo

--- a/src/utcoffset.jl
+++ b/src/utcoffset.jl
@@ -1,5 +1,4 @@
-import Base: +, -, isequal, isless, print, show
-import Compat.Dates: AbstractTime, Second, value
+using Dates: AbstractTime, Second, value
 
 # Note: The IANA time zone database rounds offset precision to the nearest second
 # See "America/New_York" notes in tzdata file "northamerica" for an example.
@@ -22,21 +21,21 @@ function UTCOffset(std_offset::Integer, dst_offset::Integer=0)
     UTCOffset(Second(std_offset), Second(dst_offset))
 end
 
-value(offset::UTCOffset) = value(offset.std + offset.dst)
+Dates.value(offset::UTCOffset) = value(offset.std + offset.dst)
 
-(+)(dt::DateTime, offset::UTCOffset) = dt + (offset.std + offset.dst)
-(-)(dt::DateTime, offset::UTCOffset) = dt - (offset.std + offset.dst)
-(-)(a::UTCOffset, b::UTCOffset) = UTCOffset(a.std - b.std, a.dst - b.dst)
+Base.:(+)(dt::DateTime, offset::UTCOffset) = dt + (offset.std + offset.dst)
+Base.:(-)(dt::DateTime, offset::UTCOffset) = dt - (offset.std + offset.dst)
+Base.:(-)(a::UTCOffset, b::UTCOffset) = UTCOffset(a.std - b.std, a.dst - b.dst)
 
 # Determines if the given `UTCOffset` is an offset for daylight saving time.
 isdst(offset::UTCOffset) = offset.dst != Second(0)
 
 # Two `UTCOffset`s can be considered equal if the total offset is the same and they are
 # both either offsets for standard time or daylight saving time.
-function isequal(x::UTCOffset, y::UTCOffset)
+function Base.isequal(x::UTCOffset, y::UTCOffset)
     x == y || value(x) == value(y) && isdst(x) == isdst(y)
 end
-isless(x::UTCOffset, y::UTCOffset) = isless(value(x), value(y))
+Base.isless(x::UTCOffset, y::UTCOffset) = isless(value(x), value(y))
 
 function offset_string(seconds::Second, iso8601::Bool=false)
     val = value(seconds)
@@ -57,8 +56,8 @@ function offset_string(offset::UTCOffset, iso8601::Bool=false)
     offset_string(offset.std + offset.dst, iso8601)
 end
 
-print(io::IO, o::UTCOffset) = print(io, offset_string(o, true))
-function show(io::IO, o::UTCOffset)
+Base.print(io::IO, o::UTCOffset) = print(io, offset_string(o, true))
+function Base.show(io::IO, o::UTCOffset)
     # Show DST as a separate offset since we want to distinguish between normal hourly
     # daylight saving time offsets and exotic DST offsets (e.g. midsummer time).
     print(io, "UTC", offset_string(o.std), "/", offset_string(o.dst))

--- a/src/winzone/WindowsTimeZoneIDs.jl
+++ b/src/winzone/WindowsTimeZoneIDs.jl
@@ -1,8 +1,6 @@
 module WindowsTimeZoneIDs
 
-using Compat: @info, findall
-
-import ...TimeZones: DEPS_DIR
+using ...TimeZones: DEPS_DIR
 using EzXML
 
 # A mapping of Windows timezone names to Olson timezone names.
@@ -20,12 +18,7 @@ function compile(xml_file::AbstractString)
     doc = readxml(xml_file)
 
     # Territory "001" is the global default
-    # Note: `findall` deprecation added in EzXML v0.8 which only works on Julia 0.7 and above
-    if VERSION < v"0.7"
-        map_zones = findall(doc, "//mapZone[@territory='001']")
-    else
-        map_zones = findall("//mapZone[@territory='001']", doc)
-    end
+    map_zones = findall("//mapZone[@territory='001']", doc)
 
     # TODO: Eliminate the Etc/* POSIX names here? See Windows section of `localzone`
 

--- a/test/TimeZones.jl
+++ b/test/TimeZones.jl
@@ -45,7 +45,7 @@ if lowercase(get(ENV, "CI", "false")) == "true"
     warsaw = TimeZone("Europe/Warsaw")
 
     @test last(warsaw.transitions).utc_datetime == DateTime(2037, 10, 25, 1)
-    @test get(warsaw.cutoff) == DateTime(2038, 3, 28, 1)
+    @test warsaw.cutoff == DateTime(2038, 3, 28, 1)
     @test_throws TimeZones.UnhandledTimeError ZonedDateTime(DateTime(2039), warsaw)
 
     TimeZones.TZData.compile(max_year=2200)
@@ -53,7 +53,7 @@ if lowercase(get(ENV, "CI", "false")) == "true"
 
     @test warsaw !== new_warsaw
     @test last(new_warsaw.transitions).utc_datetime == DateTime(2200, 10, 26, 1)
-    @test get(new_warsaw.cutoff) == DateTime(2201, 3, 29, 1)
+    @test new_warsaw.cutoff == DateTime(2201, 3, 29, 1)
     ZonedDateTime(2100, new_warsaw)  # Test this doesn't throw an exception
 
     @test_throws TimeZones.UnhandledTimeError ZonedDateTime(2100, warsaw)
@@ -62,6 +62,6 @@ if lowercase(get(ENV, "CI", "false")) == "true"
     # Using the tz string macro which runs at parse time means that the resulting TimeZone
     # will not reflect changes made from compile or new builds during runtime.
     @test tz"Africa/Windhoek" != TimeZone("Africa/Windhoek")
-    @test get(tz"Africa/Windhoek".cutoff, typemax(DateTime)) != DateTime(2201, 4, 5)
-    @test get(TimeZone("Africa/Windhoek").cutoff) == DateTime(2201, 4, 5)
+    @test tz"Africa/Windhoek".cutoff != DateTime(2201, 4, 5)
+    @test TimeZone("Africa/Windhoek").cutoff == DateTime(2201, 4, 5)
 end

--- a/test/accessors.jl
+++ b/test/accessors.jl
@@ -1,5 +1,5 @@
-import Compat.Dates
-import Compat.Dates: Second, Millisecond
+import Dates
+using Dates: Second, Millisecond
 
 warsaw = resolve("Europe/Warsaw", tzdata["europe"]...)
 fixed = FixedTimeZone("Fixed", -7200, 3600)

--- a/test/adjusters.jl
+++ b/test/adjusters.jl
@@ -1,4 +1,4 @@
-using Compat.Dates
+using Dates
 
 # Basic truncation
 warsaw = resolve("Europe/Warsaw", tzdata["europe"]...)

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -1,4 +1,4 @@
-import Compat.Dates: Day, Hour
+using Dates: Day, Hour
 
 warsaw = resolve("Europe/Warsaw", tzdata["europe"]...)
 

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -1,4 +1,4 @@
-import Compat.Dates
+import Dates
 using Mocking
 
 utc = FixedTimeZone("UTC")

--- a/test/discovery.jl
+++ b/test/discovery.jl
@@ -1,5 +1,5 @@
-import TimeZones: timezone_names
-import Compat.Dates: Millisecond
+using TimeZones: timezone_names
+using Dates: Millisecond
 
 
 names = timezone_names()

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -1,9 +1,8 @@
 # Utility functions for testing
-import Compat
 
 function ignore_output(body::Function; stdout::Bool=true, stderr::Bool=true)
-    out_old = Compat.stdout
-    err_old = Compat.stderr
+    out_old = Base.stdout
+    err_old = Base.stderr
 
     if stdout
         (out_rd, out_wr) = redirect_stdout()

--- a/test/local.jl
+++ b/test/local.jl
@@ -1,5 +1,4 @@
-import TimeZones: TimeZone, localzone, parse_tz_format
-import Compat: Sys
+using TimeZones: TimeZone, localzone, parse_tz_format
 
 # Parse the TZ environment variable format
 # Should mirror the behaviour of running:

--- a/test/local_mocking.jl
+++ b/test/local_mocking.jl
@@ -1,7 +1,6 @@
-import TimeZones: TimeZone, localzone
-import Mocking: @patch, apply
-import Base: AbstractCmd
-import Compat: Sys, read
+using Base: AbstractCmd
+using Mocking: @patch, apply
+using TimeZones: TimeZone, localzone
 
 # For mocking make sure we are actually changing the time zone
 name = string(localzone()) == "Europe/Warsaw" ? "Pacific/Apia" : "Europe/Warsaw"

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1,4 +1,4 @@
-import Compat.Dates: parse_components, default_format
+using Dates: parse_components, default_format
 
 @testset "parse" begin
     @test isequal(
@@ -26,11 +26,11 @@ end
 @testset "tryparse" begin
     @test isequal(
         tryparse(ZonedDateTime, "2013-03-20 11:00:00+04:00", dateformat"y-m-d H:M:SSz"),
-        TimeZones.nullable(ZonedDateTime, ZonedDateTime(2013, 3, 20, 11, tz"UTC+04")),
+        ZonedDateTime(2013, 3, 20, 11, tz"UTC+04"),
     )
     @test isequal(
         tryparse(ZonedDateTime, "2016-04-11 08:00 EST", dateformat"yyyy-mm-dd HH:MM zzz"),
-        TimeZones.nullable(ZonedDateTime, nothing),
+        nothing,
     )
 end
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1,4 +1,4 @@
-import Compat.Dates: Day, Hour, Minute
+using Dates: Day, Hour, Minute
 
 
 utc = FixedTimeZone("UTC", 0)
@@ -94,12 +94,8 @@ range = ZonedDateTime(2015, 11, 1, dst):Dates.Hour(1):ZonedDateTime(2015, 11, 3,
 ]
 
 # default step for a ZonedDateTime range
-if VERSION < v"0.7.0-DEV.2778"
-    range = ZonedDateTime(2017, 10, 1, 9, utc):ZonedDateTime(2017, 12, 8, 23, utc)
-    @test step(range) == Dates.Day(1)
-elseif VERSION < v"0.7-DEV+"  # Currently failing on Julia 0.7-DEV. Disabling for now.
-    @test_warn(
-        "colon(start::T, stop::T) where T <: ZonedDateTime is deprecated, use start:Day(1):stop instead.",
-        ZonedDateTime(2017, 10, 1, 9, utc):ZonedDateTime(2017, 12, 8, 23, utc)
-    )
-end
+# Currently unable to test the deprecation
+# @test_warn(
+#     "colon(start::T, stop::T) where T <: ZonedDateTime is deprecated, use start:Day(1):stop instead.",
+#     ZonedDateTime(2017, 10, 1, 9, utc):ZonedDateTime(2017, 12, 8, 23, utc)
+# )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,13 +2,13 @@ using Mocking
 Mocking.enable(force=true)
 const compiled_modules_enabled = false
 
-import Compat: Sys, occursin, @info, @warn
-using Compat.Unicode
-using Compat.Test
-using TimeZones
-import TimeZones: PKG_DIR
-import TimeZones.TZData: ARCHIVE_DIR, ZoneDict, RuleDict, tzparse, resolve, build
 using Nullables
+using Test
+using TimeZones
+using Unicode
+
+using TimeZones: PKG_DIR
+using TimeZones.TZData: ARCHIVE_DIR, ZoneDict, RuleDict, tzparse, resolve, build
 
 const TZDATA_VERSION = "2016j"
 const TZ_SOURCE_DIR = get(ENV, "TZ_SOURCE_DIR", joinpath(PKG_DIR, "test", "tzsource"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using Mocking
 Mocking.enable(force=true)
 const compiled_modules_enabled = false
 
-using Nullables
 using Test
 using TimeZones
 using Unicode

--- a/test/types.jl
+++ b/test/types.jl
@@ -1,5 +1,5 @@
-import TimeZones: Transition
-import Compat.Dates: Hour, Second, UTM
+using TimeZones: Transition
+using Dates: Hour, Second, UTM
 
 
 # Constructor FixedTimeZone from a string.

--- a/test/tzdata/archive.jl
+++ b/test/tzdata/archive.jl
@@ -1,4 +1,4 @@
-import TimeZones.TZData: ARCHIVE_DIR, isarchive, readarchive, extract
+using TimeZones.TZData: ARCHIVE_DIR, isarchive, readarchive, extract
 
 const ARCHIVE_PATH = let
     archives = filter(file -> endswith(file, "tar.gz"), readdir(ARCHIVE_DIR))

--- a/test/tzdata/compile.jl
+++ b/test/tzdata/compile.jl
@@ -1,6 +1,6 @@
-import TimeZones: Transition
-import TimeZones.TZData: ZoneDict, RuleDict, zoneparse, ruleparse, resolve, parse_date, order_rules
-import Compat.Dates: Hour, Minute, Second, DateTime, Date
+using TimeZones: Transition
+using TimeZones.TZData: ZoneDict, RuleDict, zoneparse, ruleparse, resolve, parse_date, order_rules
+using Dates: Hour, Minute, Second, DateTime, Date
 
 ### parse_date ###
 

--- a/test/tzdata/compile.jl
+++ b/test/tzdata/compile.jl
@@ -175,7 +175,7 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
         @test tz.transitions[7] == Transition(DateTime(1947,6,8,12,30), zone["HST_NEW"])
 
         @test length(tz.transitions) == 7
-        @test isnull(tz.cutoff)
+        @test tz.cutoff === nothing
     end
 
     # Zone Pacific/Apia contains the following properties which make it good for testing:
@@ -291,7 +291,7 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
 
         @test tz.transitions[1] == Transition(typemin(DateTime), zone["CUT-1"])
         @test tz.transitions[2] == Transition(DateTime(1933,4,1,12), zone["CUT-2"])
-        @test isnull(tz.cutoff)
+        @test tz.cutoff === nothing
 
         tz = resolve("Pacific/Cutoff", zones, rules, max_year=1900)
 
@@ -299,7 +299,7 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
         # when a cutoff is included.
         @test isa(tz, VariableTimeZone)
         @test length(tz.transitions) == 1
-        @test get(tz.cutoff) == DateTime(1933,4,1,12)
+        @test tz.cutoff == DateTime(1933,4,1,12)
     end
 
     # Behaviour of mixing "RULES" as a String and as a Time. In reality this behaviour has never

--- a/test/tzdata/download.jl
+++ b/test/tzdata/download.jl
@@ -1,4 +1,4 @@
-import TimeZones.TZData: tzdata_url, tzdata_download, isarchive, LATEST_FILE, read_latest
+using TimeZones.TZData: tzdata_url, tzdata_download, isarchive, LATEST_FILE, read_latest
 
 @test tzdata_url("2016j") == "https://www.iana.org/time-zones/repository/releases/tzdata2016j.tar.gz"
 @test tzdata_url("latest") == "https://www.iana.org/time-zones/repository/tzdata-latest.tar.gz"

--- a/test/tzdata/timeoffset.jl
+++ b/test/tzdata/timeoffset.jl
@@ -1,4 +1,4 @@
-import TimeZones.TZData: TimeOffset, value, hour, minute, second, hourminutesecond
+using TimeZones.TZData: TimeOffset, value, hour, minute, second, hourminutesecond
 
 # Time seconds constructor
 t = TimeOffset(5025)

--- a/test/tzdata/version.jl
+++ b/test/tzdata/version.jl
@@ -1,6 +1,6 @@
-import TimeZones.TZData: ARCHIVE_DIR, TZDATA_VERSION_REGEX, TZDATA_NEWS_REGEX
-import TimeZones.TZData: read_news, extract, tzdata_version_dir, tzdata_version_archive
-import TimeZones.TZData: active_version, active_archive
+using TimeZones.TZData: ARCHIVE_DIR, TZDATA_VERSION_REGEX, TZDATA_NEWS_REGEX
+using TimeZones.TZData: read_news, extract, tzdata_version_dir, tzdata_version_archive
+using TimeZones.TZData: active_version, active_archive
 
 for year = ("12", "1234"), letter = ("", "z")
     version = year * letter

--- a/test/tzfile.jl
+++ b/test/tzfile.jl
@@ -1,5 +1,4 @@
-import Compat: findall
-import TimeZones: Transition, TZFILE_MAX
+using TimeZones: Transition, TZFILE_MAX
 
 
 abbrs = b"LMT\0WSST\0SDT\0WSDT\0"  # Pacific/Apia

--- a/test/tzfile.jl
+++ b/test/tzfile.jl
@@ -46,7 +46,7 @@ open(joinpath(TZFILE_DIR, "Europe", "Warsaw")) do f
     @test string(tz) == "Europe/Warsaw"
     @test first(tz.transitions).utc_datetime == DateTime(1915,8,4,22,36)
     @test last(tz.transitions).utc_datetime == DateTime(2037,10,25,1)
-    @test get(tz.cutoff) == TZFILE_MAX
+    @test tz.cutoff == TZFILE_MAX
     @test ==(overlap(tz.transitions, warsaw.transitions)...)
 end
 
@@ -57,7 +57,7 @@ open(joinpath(TZFILE_DIR, "Europe", "Warsaw (Version 2)")) do f
     @test string(tz) == "Europe/Warsaw"
     @test first(tz.transitions).utc_datetime == typemin(DateTime)
     @test last(tz.transitions).utc_datetime == DateTime(2037,10,25,1)
-    @test get(tz.cutoff) == TZFILE_MAX
+    @test tz.cutoff == TZFILE_MAX
 
     # File skips 1879-12-31T22:36:00
     @test ==(overlap(tz.transitions, warsaw.transitions[3:end])...)
@@ -69,7 +69,7 @@ open(joinpath(TZFILE_DIR, "Europe", "Warsaw (Version 2)")) do f
     @test string(tz) == "Europe/Warsaw"
     @test first(tz.transitions).utc_datetime == typemin(DateTime)
     @test last(tz.transitions).utc_datetime == DateTime(2037,10,25,1)
-    @test get(tz.cutoff) == TZFILE_MAX
+    @test tz.cutoff == TZFILE_MAX
     @test ==(overlap(tz.transitions, warsaw.transitions)...)
 end
 
@@ -80,7 +80,7 @@ open(joinpath(TZFILE_DIR, "America", "Godthab")) do f
     @test string(tz) == "America/Godthab"
     @test first(tz.transitions).utc_datetime == DateTime(1916,7,28,3,26,56)
     @test last(tz.transitions).utc_datetime == DateTime(2037,10,25,1)
-    @test get(tz.cutoff) == TZFILE_MAX
+    @test tz.cutoff == TZFILE_MAX
     @test ==(overlap(tz.transitions, godthab.transitions)...)
 end
 
@@ -91,7 +91,7 @@ open(joinpath(TZFILE_DIR, "America", "Godthab (Version 3)")) do f
     @test string(tz) == "America/Godthab"
     @test first(tz.transitions).utc_datetime == typemin(DateTime)
     @test last(tz.transitions).utc_datetime == DateTime(2037,10,25,1)
-    @test get(tz.cutoff) == TZFILE_MAX
+    @test tz.cutoff == TZFILE_MAX
     @test ==(overlap(tz.transitions, godthab.transitions)...)
 end
 
@@ -101,7 +101,7 @@ open(joinpath(TZFILE_DIR, "America", "Godthab (Version 3)")) do f
     @test string(tz) == "America/Godthab"
     @test first(tz.transitions).utc_datetime == typemin(DateTime)
     @test last(tz.transitions).utc_datetime == DateTime(2037,10,25,1)
-    @test get(tz.cutoff) == TZFILE_MAX
+    @test tz.cutoff == TZFILE_MAX
     @test ==(overlap(tz.transitions, godthab.transitions)...)
 end
 
@@ -115,7 +115,7 @@ open(joinpath(TZFILE_DIR, "Pacific", "Apia")) do f
     @test string(tz) == "Pacific/Apia"
     @test first(tz.transitions).utc_datetime == DateTime(1911,1,1,11,26,56)
     @test last(tz.transitions).utc_datetime == DateTime(2037,9,26,14)
-    @test get(tz.cutoff) == TZFILE_MAX
+    @test tz.cutoff == TZFILE_MAX
     @test ==(overlap(tz.transitions, apia.transitions)...)
 end
 
@@ -129,7 +129,7 @@ open(joinpath(TZFILE_DIR, "Europe", "Paris")) do f
     @test string(tz) == "Europe/Paris"
     @test first(tz.transitions).utc_datetime == DateTime(1911,3,10,23,51,39)
     @test last(tz.transitions).utc_datetime == DateTime(2037,10,25,1)
-    @test get(tz.cutoff) == TZFILE_MAX
+    @test tz.cutoff == TZFILE_MAX
 
     tz_transitions, paris_transitions = overlap(tz.transitions, paris.transitions)
 
@@ -147,7 +147,7 @@ open(joinpath(TZFILE_DIR, "Europe", "Madrid")) do f
     @test string(tz) == "Europe/Madrid"
     @test first(tz.transitions).utc_datetime == DateTime(1917,5,5,23)
     @test last(tz.transitions).utc_datetime == DateTime(2037,10,25,1)
-    @test get(tz.cutoff) == TZFILE_MAX
+    @test tz.cutoff == TZFILE_MAX
 
     tz_transitions, madrid_transitions = overlap(tz.transitions, madrid.transitions)
 
@@ -167,7 +167,7 @@ open(joinpath(TZFILE_DIR, "Australia", "Perth")) do f
     @test string(tz) == "Australia/Perth"
     @test first(tz.transitions).utc_datetime == DateTime(1916,12,31,16,1)
     @test last(tz.transitions).utc_datetime == DateTime(2009,3,28,18)
-    @test isnull(tz.cutoff)
+    @test tz.cutoff === nothing
 
     tz_transitions, perth_transitions = overlap(tz.transitions, perth.transitions)
 

--- a/test/utcoffset.jl
+++ b/test/utcoffset.jl
@@ -1,4 +1,4 @@
-import TimeZones: UTCOffset, value, isdst
+using TimeZones: UTCOffset, value, isdst
 
 @test value(UTCOffset(0, 0)) == 0
 @test value(UTCOffset(3600, 0)) == 3600

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,4 +1,4 @@
-import TimeZones: optional
+using TimeZones: optional
 
 function strip(ex::Expr)
     args = []

--- a/test/winzone/WindowsTimeZoneIDs.jl
+++ b/test/winzone/WindowsTimeZoneIDs.jl
@@ -1,4 +1,4 @@
-import TimeZones.WindowsTimeZoneIDs
+using TimeZones.WindowsTimeZoneIDs
 
 xml_file = TimeZones.WindowsTimeZoneIDs.WINDOWS_XML_FILE
 !isfile(xml_file) && error("Missing required XML file. Run Pkg.build(\"TimeZones\").")


### PR DESCRIPTION
I'm dropping support for Julia 0.6 as I want to change `VariableTimeZone` and `FixedTimeZone` to use `name::String` instead of `name::Symbol`. I originally used symbols here as strings in Julia 0.6 are not immutable but they are in Julia 0.7 and onwards. This PR just deals with cleaning out Julia 0.6 support.