### PR TITLE
Support legacy time zones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ deps/compiled
 deps/local
 !deps/local/windowsZones.xml
 deps/active_version
+deps/STANDARD
+deps/LEGACY
 test/tzsource
 
 # PkgBenchmark

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@ deps/compiled
 deps/local
 !deps/local/windowsZones.xml
 deps/active_version
-deps/STANDARD
-deps/LEGACY
 test/tzsource
 
 # PkgBenchmark

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -12,9 +12,9 @@ According to [IANA](ftp://ftp.iana.org/tz/data/etcetera) the "Etc/\*" time zones
 
 ```jldoctest
 julia> TimeZone("Etc/GMT+4")
-ERROR: ArgumentError: The time zone "Etc/GMT+4" is of class `Class.LEGACY` which is currently not allowed by the mask: `Class.FIXED | Class.STANDARD`
+ERROR: ArgumentError: The time zone "Etc/GMT+4" is of class `Class(:LEGACY)` which is currently not allowed by the mask: `Class(:FIXED) | Class(:STANDARD)`
 
-julia> TimeZone("Etc/GMT+4", TimeZones.Class.LEGACY)
+julia> TimeZone("Etc/GMT+4", TimeZones.Class(:LEGACY))
 Etc/GMT+4 (UTC-4)
 ```
 

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -6,18 +6,16 @@ DocTestSetup = quote
 end
 ```
 
-## [Why are the "Etc/\*" time zones unsupported?](@id etc_tzs)
+## [Where are the "Etc/\*" time zones?](@id etc_tzs)
 
-According to [IANA](ftp://ftp.iana.org/tz/data/etcetera) the "Etc/\*" time zones are only included in the tz database for "historical reasons". Furthermore the time zones offsets provided the Etc/GMT±HH can be misleading. For example the Etc/GMT+4 time zone is 4 hours **behind** UTC rather than 4 hours **ahead** as most people expect. Since TimeZones.jl already provides an easy way of constructing fixed offset time zones using `FixedTimeZone` it was decided to leave these time zones out.
+According to [IANA](ftp://ftp.iana.org/tz/data/etcetera) the "Etc/\*" time zones are only included in the tz database for "historical reasons". Furthermore the time zones offsets provided the Etc/GMT±HH can be misleading. For example the Etc/GMT+4 time zone is 4 hours _behind_ UTC rather than 4 hours _ahead_ as most people expect. Since TimeZones.jl already provides an easy way of constructing fixed offset time zones using `FixedTimeZone` it was decided to only allow users to create these time zones if they explicitly ask for them.
 
-If you truly do want to include the "Etc/\*" time zones you just need to download the tz source file and re-compile:
+```jldoctest
+julia> TimeZone("Etc/GMT+4")
+ERROR: ArgumentError: The time zone "Etc/GMT+4" is of class `Class.LEGACY` which is currently not allowed by the mask: `Class.FIXED | Class.STANDARD`
 
-```@example
-using TimeZones; # hide
-import TimeZones.TZData: TZ_SOURCE_DIR, extract, active_archive, compile
-extract(active_archive(), TZ_SOURCE_DIR, "etcetera")
-compile()
-nothing; # hide
+julia> TimeZone("Etc/GMT+4", TimeZones.Class.LEGACY)
+Etc/GMT+4 (UTC-4)
 ```
 
 ## [Far-future ZonedDateTime with VariableTimeZone](@id future_tzs)

--- a/docs/src/faq.md
+++ b/docs/src/faq.md
@@ -12,7 +12,7 @@ According to [IANA](ftp://ftp.iana.org/tz/data/etcetera) the "Etc/\*" time zones
 
 ```jldoctest
 julia> TimeZone("Etc/GMT+4")
-ERROR: ArgumentError: The time zone "Etc/GMT+4" is of class `Class(:LEGACY)` which is currently not allowed by the mask: `Class(:FIXED) | Class(:STANDARD)`
+ERROR: ArgumentError: The time zone "Etc/GMT+4" is of class `TimeZones.Class(:LEGACY)` which is currently not allowed by the mask: `TimeZones.Class(:FIXED) | TimeZones.Class(:STANDARD)`
 
 julia> TimeZone("Etc/GMT+4", TimeZones.Class(:LEGACY))
 Etc/GMT+4 (UTC-4)

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -40,9 +40,14 @@ function __init__()
     )
 
     global ISOZonedDateTimeFormat = DateFormat("yyyy-mm-ddTHH:MM:SS.ssszzz")
+
+    # Note: Keeping names sorted for use in `timezone_names`
+    TIME_ZONE_NAMES[STANDARD] = sort!(readlines(joinpath(DEPS_DIR, _class_name(STANDARD))))
+    TIME_ZONE_NAMES[LEGACY] = sort!(readlines(joinpath(DEPS_DIR, _class_name(LEGACY))))
 end
 
 include("utils.jl")
+include("class.jl")
 include("utcoffset.jl")
 include(joinpath("types", "timezone.jl"))
 include(joinpath("types", "fixedtimezone.jl"))

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -40,12 +40,6 @@ function __init__()
     )
 
     global ISOZonedDateTimeFormat = DateFormat("yyyy-mm-ddTHH:MM:SS.ssszzz")
-
-    # Note: Keeping names sorted for use in `timezone_names`
-    for class in (Class.STANDARD, Class.LEGACY)
-        path = joinpath(DEPS_DIR, string(class))
-        TIME_ZONE_NAMES[class] = isfile(path) ? sort!(readlines(path)) : String[]
-    end
 end
 
 include("utils.jl")

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -42,8 +42,10 @@ function __init__()
     global ISOZonedDateTimeFormat = DateFormat("yyyy-mm-ddTHH:MM:SS.ssszzz")
 
     # Note: Keeping names sorted for use in `timezone_names`
-    TIME_ZONE_NAMES[STANDARD] = sort!(readlines(joinpath(DEPS_DIR, _class_name(STANDARD))))
-    TIME_ZONE_NAMES[LEGACY] = sort!(readlines(joinpath(DEPS_DIR, _class_name(LEGACY))))
+    for class in (Class.STANDARD, Class.LEGACY)
+        path = joinpath(DEPS_DIR, string(class))
+        TIME_ZONE_NAMES[class] = isfile(path) ? sort!(readlines(path)) : String[]
+    end
 end
 
 include("utils.jl")

--- a/src/build.jl
+++ b/src/build.jl
@@ -6,7 +6,7 @@ Builds the TimeZones package with the specified tzdata `version` and `regions`. 
 The `force` flag is used to re-download tzdata archives.
 """
 function build(version::AbstractString="latest"; force::Bool=false)
-    version, tz_category = TimeZones.TZData.build(version)
+    TimeZones.TZData.build(version)
 
     if Sys.iswindows()
         TimeZones.WindowsTimeZoneIDs.build(force=force)
@@ -14,10 +14,6 @@ function build(version::AbstractString="latest"; force::Bool=false)
 
     # Reset cached information
     empty!(TIME_ZONE_CACHE)
-    empty!(TIME_ZONE_NAMES)
-    for (class, tz_names) in tz_category
-        TIME_ZONE_NAMES[class] = sort!(tz_names)
-    end
 
     @info "Successfully built TimeZones"
 end

--- a/src/build.jl
+++ b/src/build.jl
@@ -1,16 +1,12 @@
-using .TZData: REGIONS
-
 """
-    build(version="latest", regions=REGIONS; force=false) -> Nothing
+    build(version="latest"; force=false) -> Nothing
 
 Builds the TimeZones package with the specified tzdata `version` and `regions`. The
 `version` is typically a 4-digit year followed by a lowercase ASCII letter (e.g. "2016j").
-Users can also specify which `regions`, or tz source files, should be compiled. Available
-regions are listed under `TimeZones.REGIONS` and `TimeZones.LEGACY_REGIONS`. The `force`
-flag is used to re-download tzdata archives.
+The `force` flag is used to re-download tzdata archives.
 """
-function build(version::AbstractString="latest", regions=REGIONS; force::Bool=false)
-    TimeZones.TZData.build(version, regions)
+function build(version::AbstractString="latest"; force::Bool=false)
+    TimeZones.TZData.build(version)
 
     if Sys.iswindows()
         TimeZones.WindowsTimeZoneIDs.build(force=force)

--- a/src/build.jl
+++ b/src/build.jl
@@ -6,10 +6,17 @@ Builds the TimeZones package with the specified tzdata `version` and `regions`. 
 The `force` flag is used to re-download tzdata archives.
 """
 function build(version::AbstractString="latest"; force::Bool=false)
-    TimeZones.TZData.build(version)
+    version, tz_category = TimeZones.TZData.build(version)
 
     if Sys.iswindows()
         TimeZones.WindowsTimeZoneIDs.build(force=force)
+    end
+
+    # Reset cached information
+    empty!(TIME_ZONE_CACHE)
+    empty!(TIME_ZONE_NAMES)
+    for (class, tz_names) in tz_category
+        TIME_ZONE_NAMES[class] = sort!(tz_names)
     end
 
     @info "Successfully built TimeZones"

--- a/src/class.jl
+++ b/src/class.jl
@@ -36,7 +36,7 @@ function Base.getproperty(::Type{Class}, field::Symbol)
     end
 end
 
-function classify(str::AbstractString, regions::AbstractSet{<:AbstractString})
+function Class(str::AbstractString, regions::AbstractSet{<:AbstractString})
     class = Class.NONE
     occursin(FIXED_TIME_ZONE_REGEX, str) && (class |= Class.FIXED)
     !isempty(intersect(regions, TZData.STANDARD_REGIONS)) && (class |= Class.STANDARD)
@@ -44,7 +44,7 @@ function classify(str::AbstractString, regions::AbstractSet{<:AbstractString})
     return class
 end
 
-classify(str::AbstractString, regions::AbstractVector) = classify(str, Set{String}(regions))
+Class(str::AbstractString, regions::AbstractVector) = Class(str, Set{String}(regions))
 
 Base.:(|)(a::Class, b::Class) = Class(a.val | b.val)
 Base.:(&)(a::Class, b::Class) = Class(a.val & b.val)

--- a/src/class.jl
+++ b/src/class.jl
@@ -19,17 +19,17 @@ struct Class
 end
 
 function Base.getproperty(::Type{Class}, field::Symbol)
-    if field == :NONE
+    if field === :NONE
         Class(0x00)
-    elseif field == :FIXED
+    elseif field === :FIXED
         Class(0x01)
-    elseif field == :STANDARD
+    elseif field === :STANDARD
         Class(0x02)
-    elseif field == :LEGACY
+    elseif field === :LEGACY
         Class(0x04)
-    elseif field == :DEFAULT
+    elseif field === :DEFAULT
         Class.FIXED | Class.STANDARD
-    elseif field == :ALL
+    elseif field === :ALL
         Class.FIXED | Class.STANDARD | Class.LEGACY
     else
         getfield(Class, field)
@@ -49,15 +49,24 @@ Class(str::AbstractString, regions::AbstractVector) = Class(str, Set{String}(reg
 Base.:(|)(a::Class, b::Class) = Class(a.val | b.val)
 Base.:(&)(a::Class, b::Class) = Class(a.val & b.val)
 Base.:(==)(a::Class, b::Class) = a.val == b.val
+Base.:(~)(a::Class) = Class(~a.val)
 
 function labels(mask::Class)
+    mask == Class.NONE && return ["NONE"]
+
     names = String[]
     mask & Class.FIXED == Class.FIXED && push!(names, "FIXED")
     mask & Class.STANDARD == Class.STANDARD && push!(names, "STANDARD")
     mask & Class.LEGACY == Class.LEGACY && push!(names, "LEGACY")
-    mask == Class.NONE && push!(names, "NONE")
+
+    unused = mask & ~Class.ALL
+    unused != Class.NONE && push!(names, "Class($(repr(unused.val)))")
+
     return names
 end
 
 Base.print(io::IO, mask::Class) = join(io, labels(mask), " | ")
-Base.show(io::IO, mask::Class) = join(io, string.("Class.", labels(mask)), " | ")
+
+function Base.show(io::IO, mask::Class)
+    join(io, [startswith(l, "Class") ? l : "Class.$l" for l in labels(mask)], " | ")
+end

--- a/src/class.jl
+++ b/src/class.jl
@@ -51,22 +51,17 @@ Base.:(&)(a::Class, b::Class) = Class(a.val & b.val)
 Base.:(==)(a::Class, b::Class) = a.val == b.val
 Base.:(~)(a::Class) = Class(~a.val)
 
-function labels(mask::Class)
-    mask == Class(:NONE) && return ["NONE"]
+function Base.show(io::IO, mask::Class)
+    C = repr(Class)
+    mask == Class(:NONE) && return print(io, "$C(:NONE)")
 
     names = String[]
-    mask & Class(:FIXED) == Class(:FIXED) && push!(names, "FIXED")
-    mask & Class(:STANDARD) == Class(:STANDARD) && push!(names, "STANDARD")
-    mask & Class(:LEGACY) == Class(:LEGACY) && push!(names, "LEGACY")
+    mask & Class(:FIXED) == Class(:FIXED) && push!(names, "$C(:FIXED)")
+    mask & Class(:STANDARD) == Class(:STANDARD) && push!(names, "$C(:STANDARD)")
+    mask & Class(:LEGACY) == Class(:LEGACY) && push!(names, "$C(:LEGACY)")
 
     unused = mask & ~Class(:ALL)
-    unused != Class(:NONE) && push!(names, "Class($(repr(unused.val)))")
+    unused != Class(:NONE) && push!(names, "$C($(repr(unused.val)))")
 
-    return names
-end
-
-Base.print(io::IO, mask::Class) = join(io, labels(mask), " | ")
-
-function Base.show(io::IO, mask::Class)
-    join(io, [startswith(l, "Class") ? l : "Class(:$l)" for l in labels(mask)], " | ")
+    join(io, names, " | ")
 end

--- a/src/class.jl
+++ b/src/class.jl
@@ -23,32 +23,28 @@ function Base.getproperty(::Type{Class}, field::Symbol)
         Class(0x00)
     elseif field == :FIXED
         Class(0x01)
-    elseif field == :VARIABLE
-        Class(0x02)
     elseif field == :STANDARD
-        Class(0x04)
+        Class(0x02)
     elseif field == :LEGACY
-        Class(0x08)
+        Class(0x04)
     elseif field == :DEFAULT
         Class.FIXED | Class.STANDARD
     elseif field == :ALL
-        Class.FIXED | Class.VARIABLE | Class.STANDARD | Class.LEGACY
+        Class.FIXED | Class.STANDARD | Class.LEGACY
     else
         getfield(Class, field)
     end
 end
 
-function classify(tz::TimeZone, regions::AbstractSet{<:AbstractString}=Set{String}())
+function classify(str::AbstractString, regions::AbstractSet{<:AbstractString})
     class = Class.NONE
-    tz isa FixedTimeZone && (class |= Class.FIXED)
-    tz isa VariableTimeZone && (class |= Class.VARIABLE)
+    occursin(FIXED_TIME_ZONE_REGEX, str) && (class |= Class.FIXED)
     !isempty(intersect(regions, TZData.STANDARD_REGIONS)) && (class |= Class.STANDARD)
     !isempty(intersect(regions, TZData.LEGACY_REGIONS)) && (class |= Class.LEGACY)
     return class
 end
 
-classify(tz::TimeZone, regions::AbstractVector) = classify(tz, Set(regions))
-classify(tz::TimeZone, region::AbstractString) = classify(tz, [region])
+classify(str::AbstractString, regions::AbstractVector) = classify(str, Set{String}(regions))
 
 Base.:(|)(a::Class, b::Class) = Class(a.val | b.val)
 Base.:(&)(a::Class, b::Class) = Class(a.val & b.val)
@@ -57,7 +53,6 @@ Base.:(==)(a::Class, b::Class) = a.val == b.val
 function labels(mask::Class)
     names = String[]
     mask & Class.FIXED == Class.FIXED && push!(names, "FIXED")
-    mask & Class.VARIABLE == Class.VARIABLE && push!(names, "VARIABLE")
     mask & Class.STANDARD == Class.STANDARD && push!(names, "STANDARD")
     mask & Class.LEGACY == Class.LEGACY && push!(names, "LEGACY")
     mask == Class.NONE && push!(names, "NONE")

--- a/src/class.jl
+++ b/src/class.jl
@@ -1,0 +1,37 @@
+const NONE     = 0x00
+const FIXED    = 0x01
+const STANDARD = 0x02
+const LEGACY   = 0x04
+
+const DEFAULT_MASK = STANDARD | FIXED
+
+"""
+    _timezone_class(str::AbstractString) -> UInt8
+
+Classifies the provided time zone string.
+"""
+function _timezone_class(str::AbstractString)
+    if occursin(FIXED_TIME_ZONE_REGEX, str)
+        FIXED
+    elseif str in TIME_ZONE_NAMES[STANDARD]
+        STANDARD
+    elseif str in TIME_ZONE_NAMES[LEGACY]
+        LEGACY
+    else
+        NONE
+    end
+end
+
+function _class_name(class::UInt8)
+    if class == NONE
+        "NONE"
+    elseif class == FIXED
+        "FIXED"
+    elseif class == STANDARD
+        "STANDARD"
+    elseif class == LEGACY
+        "LEGACY"
+    else
+        "UNKNOWN"
+    end
+end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -9,3 +9,9 @@ if VERSION < v"1.0.0-DEV.44"
 end
 
 # END TimeZones 0.6 deprecations
+
+# BEGIN TimeZones 0.9 deprecations
+
+@deprecate build(version::AbstractString, regions; kwargs...) build(version; kwargs...) false
+
+# END TimeZones 0.9 deprecations

--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -1,19 +1,29 @@
 using Mocking: Mocking, @mock
 
 """
-    timezone_names(mask::Class=Class.DEFAULT) -> Vector{String}
+    timezone_names() -> Vector{String}
 
-Returns a sorted list of all of the valid names for constructing a `TimeZone` that are
-classified within `mask`.
+Returns a sorted list of all of the pre-computed time zone names.
 """
-function timezone_names(mask::Class=Class.DEFAULT)
+function timezone_names()
     names = String[]
-    if mask & Class.STANDARD == Class.STANDARD
-        append!(names, TIME_ZONE_NAMES[Class.STANDARD])
+    check = Tuple{String,String}[(TZData.COMPILED_DIR, "")]
+
+    for (dir, partial) in check
+        for filename in readdir(dir)
+            startswith(filename, ".") && continue
+
+            path = joinpath(dir, filename)
+            name = partial == "" ? filename : join([partial, filename], "/")
+
+            if isdir(path)
+                push!(check, (path, name))
+            else
+                push!(names, name)
+            end
+        end
     end
-    if mask & Class.LEGACY == Class.LEGACY
-        append!(names, TIME_ZONE_NAMES[Class.LEGACY])
-    end
+
     return sort!(names)
 end
 

--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -1,18 +1,18 @@
 using Mocking: Mocking, @mock
 
 """
-    timezone_names(class_mask::UInt8=DEFAULT_MASK) -> Vector{String}
+    timezone_names(mask::Class=Class.DEFAULT) -> Vector{String}
 
 Returns a sorted list of all of the valid names for constructing a `TimeZone` that are
-classified within `class_mask`.
+classified within `mask`.
 """
-function timezone_names(class_mask::UInt8=DEFAULT_MASK)
+function timezone_names(mask::Class=Class.DEFAULT)
     names = String[]
-    if class_mask & STANDARD == STANDARD
-        append!(names, TIME_ZONE_NAMES[STANDARD])
+    if mask & Class.STANDARD == Class.STANDARD
+        append!(names, TIME_ZONE_NAMES[Class.STANDARD])
     end
-    if class_mask & LEGACY == LEGACY
-        append!(names, TIME_ZONE_NAMES[LEGACY])
+    if mask & Class.LEGACY == Class.LEGACY
+        append!(names, TIME_ZONE_NAMES[Class.LEGACY])
     end
     return sort!(names)
 end

--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -35,7 +35,7 @@ Returns all pre-computed `TimeZone`s.
 function all_timezones()
     results = TimeZone[]
     for name in timezone_names()
-        push!(results, TimeZone(name, Class.ALL))
+        push!(results, TimeZone(name, Class(:ALL)))
     end
     return results
 end

--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -35,7 +35,7 @@ Returns all pre-computed `TimeZone`s.
 function all_timezones()
     results = TimeZone[]
     for name in timezone_names()
-        push!(results, TimeZone(name))
+        push!(results, TimeZone(name, Class.ALL))
     end
     return results
 end

--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -1,30 +1,19 @@
 using Mocking: Mocking, @mock
 
 """
-    timezone_names() -> Vector{String}
+    timezone_names(class_mask::UInt8=DEFAULT_MASK) -> Vector{String}
 
-Returns a sorted list of all of the valid names for constructing a `TimeZone`.
+Returns a sorted list of all of the valid names for constructing a `TimeZone` that are
+classified within `class_mask`.
 """
-function timezone_names()
-    # Note: IANA time zone names are typically encoded only in ASCII.
+function timezone_names(class_mask::UInt8=DEFAULT_MASK)
     names = String[]
-    check = Tuple{String,String}[(TZData.COMPILED_DIR, "")]
-
-    for (dir, partial) in check
-        for filename in readdir(dir)
-            startswith(filename, ".") && continue
-
-            path = joinpath(dir, filename)
-            name = partial == "" ? filename : join([partial, filename], "/")
-
-            if isdir(path)
-                push!(check, (path, name))
-            else
-                push!(names, name)
-            end
-        end
+    if class_mask & STANDARD == STANDARD
+        append!(names, TIME_ZONE_NAMES[STANDARD])
     end
-
+    if class_mask & LEGACY == LEGACY
+        append!(names, TIME_ZONE_NAMES[LEGACY])
+    end
     return sort!(names)
 end
 

--- a/src/local.jl
+++ b/src/local.jl
@@ -15,7 +15,7 @@ function localzone()
     # Only allow creating a TimeZone using standard and legacy IANA time zone database
     # names. We allow the use of legacy names here as most operating systems still use the
     # legacy names.
-    mask = Class.STANDARD | Class.LEGACY
+    mask = Class(:STANDARD) | Class(:LEGACY)
 
     @static if Sys.isapple()
         name = @mock read(`systemsetup -gettimezone`, String)  # Appears to only work as root

--- a/src/local.jl
+++ b/src/local.jl
@@ -15,7 +15,7 @@ function localzone()
     # Only allow creating a TimeZone using standard and legacy IANA time zone database
     # names. We allow the use of legacy names here as most operating systems still use the
     # legacy names.
-    mask = STANDARD | LEGACY
+    mask = Class.STANDARD | Class.LEGACY
 
     @static if Sys.isapple()
         name = @mock read(`systemsetup -gettimezone`, String)  # Appears to only work as root

--- a/src/types/timezone.jl
+++ b/src/types/timezone.jl
@@ -1,15 +1,45 @@
 const TIME_ZONE_CACHE = Dict{String,Tuple{TimeZone,Class}}()
 
 """
-    TimeZone(str::AbstractString, mask::Class=Class.DEFAULT) -> TimeZone
+    TimeZone(str::AbstractString) -> TimeZone
 
-Constructs a `TimeZone` subtype based upon the string and the provided `mask`. If the
-string is a recognized time zone name then data is loaded from the compiled IANA time zone
-database. Otherwise the string is assumed to be a fixed time zone.
+Constructs a `TimeZone` subtype based upon the string. If the string is a recognized
+standard time zone name then data is loaded from the compiled IANA time zone database.
+Otherwise the string is parsed as a fixed time zone.
 
-A list of recognized time zones names is available from `timezone_names()`. Supported fixed
-time zone string formats can be found in docstring for: `FixedTimeZone(::AbstractString)`.
+A list of recognized standard and legacy time zones names can is available by running
+`timezone_names()`. Supported fixed time zone string formats can be found in docstring for
+[`FixedTimeZone(::AbstractString)`](@ref).
+
+## Examples
+```jldoctest
+julia> TimeZone("Europe/Warsaw")
+Europe/Warsaw (UTC+1/UTC+2)
+
+julia> TimeZone("UTC")
+UTC
+```
 """
+TimeZone(::AbstractString)
+
+"""
+    TimeZone(str::AbstractString, mask::Class) -> TimeZone
+
+Similar to [`TimeZone(::AbstractString)`](@ref) but allows you to control what time zone
+classes are allowed to be constructed with `mask`. Can be used to construct time zones
+which are classified as "legacy".
+
+## Examples
+```jldoctest
+julia> TimeZone("US/Pacific")
+ERROR: ArgumentError: The time zone "US/Pacific" is of class `Class.LEGACY` which is currently not allowed by the mask: `Class.FIXED | Class.STANDARD`
+
+julia> TimeZone("US/Pacific", TimeZones.Class.LEGACY)
+US/Pacific (UTC-8/UTC-7)
+```
+"""
+TimeZone(::AbstractString, ::Class)
+
 function TimeZone(str::AbstractString, mask::Class=Class.DEFAULT)
     # Note: If the class `mask` does not match the time zone we'll still load the
     # information into the cache to ensure the result is consistent.

--- a/src/types/timezone.jl
+++ b/src/types/timezone.jl
@@ -1,25 +1,25 @@
-const TIME_ZONE_NAMES = Dict{UInt8,Vector{String}}()
-const TIME_ZONE_CACHE = Dict{String,Tuple{TimeZone,UInt8}}()
+const TIME_ZONE_NAMES = Dict{Class,Vector{String}}()
+const TIME_ZONE_CACHE = Dict{String,Tuple{TimeZone,Class}}()
 
 """
-    TimeZone(str::AbstractString, class_mask::UInt8=DEFAULT_MASK) -> TimeZone
+    TimeZone(str::AbstractString, mask::Class=Class.DEFAULT) -> TimeZone
 
-Constructs a `TimeZone` subtype based upon the string and the provided `class_mask`. If the
+Constructs a `TimeZone` subtype based upon the string and the provided `mask`. If the
 string is a recognized time zone name then data is loaded from the compiled IANA time zone
 database. Otherwise the string is assumed to be a fixed time zone.
 
 A list of recognized time zones names is available from `timezone_names()`. Supported fixed
 time zone string formats can be found in docstring for: `FixedTimeZone(::AbstractString)`.
 """
-function TimeZone(str::AbstractString, class_mask::UInt8=DEFAULT_MASK)
-    # Note: If the `class_mask` does not match the time zone we'll still load the
+function TimeZone(str::AbstractString, mask::Class=Class.DEFAULT)
+    # Note: If the class `mask` does not match the time zone we'll still load the
     # information into the cache to ensure the result is consistent.
     tz, class = get!(TIME_ZONE_CACHE, str) do
-        class = _timezone_class(str)
+        class = classify(str)
 
-        tz = if class == FIXED
+        tz = if class == Class.FIXED
             FixedTimeZone(str)
-        elseif class == STANDARD || class == LEGACY
+        elseif class == Class.STANDARD || class == Class.LEGACY
             tz_path = joinpath(TZData.COMPILED_DIR, split(str, '/')...)
             open(deserialize, tz_path, "r")
         else
@@ -29,10 +29,10 @@ function TimeZone(str::AbstractString, class_mask::UInt8=DEFAULT_MASK)
         tz, class
     end
 
-    if iszero(class_mask & class)
+    if mask & class == Class.NONE
         throw(ArgumentError(
-            "The time zone \"$str\" is of class `$class` which is " *
-            "currently not allowed by the mask: `$class_mask`"
+            "The time zone \"$str\" is of class `$(repr(class))` which is " *
+            "currently not allowed by the mask: `$(repr(mask))`"
         ))
     end
 
@@ -55,16 +55,14 @@ macro tz_str(str)
 end
 
 """
-    istimezone(str::AbstractString, class_mask::UInt8=DEFAULT_MASK) -> Bool
+    istimezone(str::AbstractString, mask::Class=Class.DEFAULT) -> Bool
 
-Check whether a string is a valid for constructing a `TimeZone` with the provided
-`class_mask`.
+Check whether a string is a valid for constructing a `TimeZone` with the provided `mask`.
 """
-function istimezone(str::AbstractString, class_mask::UInt8=DEFAULT_MASK)
-    # Note: Similar to `_timezone_class` but avoids computation with a limited `class_mask`
+function istimezone(str::AbstractString, mask::Class=Class.DEFAULT)
     return (
-        !iszero(class_mask & STANDARD) && str in TIME_ZONE_NAMES[STANDARD] ||
-        !iszero(class_mask & LEGACY) && str in TIME_ZONE_NAMES[LEGACY] ||
-        !iszero(class_mask & FIXED) && occursin(FIXED_TIME_ZONE_REGEX, str)
+        mask & Class.STANDARD != Class.NONE && str in TIME_ZONE_NAMES[Class.STANDARD] ||
+        mask & Class.LEGACY != Class.NONE && str in TIME_ZONE_NAMES[Class.LEGACY] ||
+        mask & Class.FIXED != Class.NONE && occursin(FIXED_TIME_ZONE_REGEX, str)
     )
 end

--- a/src/types/timezone.jl
+++ b/src/types/timezone.jl
@@ -1,28 +1,42 @@
-const TIME_ZONES = Dict{String,TimeZone}()
+const TIME_ZONE_NAMES = Dict{UInt8,Vector{String}}()
+const TIME_ZONE_CACHE = Dict{String,Tuple{TimeZone,UInt8}}()
 
 """
-    TimeZone(str::AbstractString) -> TimeZone
+    TimeZone(str::AbstractString, class_mask::UInt8=DEFAULT_MASK) -> TimeZone
 
-Constructs a `TimeZone` subtype based upon the string. If the string is a recognized time
-zone name then data is loaded from the compiled IANA time zone database. Otherwise the
-string is assumed to be a static time zone.
+Constructs a `TimeZone` subtype based upon the string and the provided `class_mask`. If the
+string is a recognized time zone name then data is loaded from the compiled IANA time zone
+database. Otherwise the string is assumed to be a fixed time zone.
 
-A list of recognized time zones names is available from `timezone_names()`. Supported static
-time zone string formats can be found in `FixedTimeZone(::AbstractString)`.
+A list of recognized time zones names is available from `timezone_names()`. Supported fixed
+time zone string formats can be found in docstring for: `FixedTimeZone(::AbstractString)`.
 """
-function TimeZone(str::AbstractString)
-    return get!(TIME_ZONES, str) do
-        if occursin(FIXED_TIME_ZONE_REGEX, str)
-            return FixedTimeZone(str)
+function TimeZone(str::AbstractString, class_mask::UInt8=DEFAULT_MASK)
+    # Note: If the `class_mask` does not match the time zone we'll still load the
+    # information into the cache to ensure the result is consistent.
+    tz, class = get!(TIME_ZONE_CACHE, str) do
+        class = _timezone_class(str)
+
+        tz = if class == FIXED
+            FixedTimeZone(str)
+        elseif class == STANDARD || class == LEGACY
+            tz_path = joinpath(TZData.COMPILED_DIR, split(str, '/')...)
+            open(deserialize, tz_path, "r")
+        else
+            throw(ArgumentError("Unknown time zone \"$str\""))
         end
 
-        tz_path = joinpath(TZData.COMPILED_DIR, split(str, "/")...)
-        isfile(tz_path) || throw(ArgumentError("Unknown time zone \"$str\""))
-
-        open(tz_path, "r") do fp
-            return deserialize(fp)
-        end
+        tz, class
     end
+
+    if iszero(class_mask & class)
+        throw(ArgumentError(
+            "The time zone \"$str\" is of class `$class` which is " *
+            "currently not allowed by the mask: `$class_mask`"
+        ))
+    end
+
+    return tz
 end
 
 """
@@ -41,14 +55,16 @@ macro tz_str(str)
 end
 
 """
-    istimezone(str::AbstractString) -> Bool
+    istimezone(str::AbstractString, class_mask::UInt8=DEFAULT_MASK) -> Bool
 
-Tests whether a string is a valid name for constructing a `TimeZone`.
+Check whether a string is a valid for constructing a `TimeZone` with the provided
+`class_mask`.
 """
-function istimezone(str::AbstractString)
+function istimezone(str::AbstractString, class_mask::UInt8=DEFAULT_MASK)
+    # Note: Similar to `_timezone_class` but avoids computation with a limited `class_mask`
     return (
-        haskey(TIME_ZONES, str) ||
-        occursin(FIXED_TIME_ZONE_REGEX, str) ||
-        isfile(joinpath(TZData.COMPILED_DIR, split(str, "/")...))
+        !iszero(class_mask & STANDARD) && str in TIME_ZONE_NAMES[STANDARD] ||
+        !iszero(class_mask & LEGACY) && str in TIME_ZONE_NAMES[LEGACY] ||
+        !iszero(class_mask & FIXED) && occursin(FIXED_TIME_ZONE_REGEX, str)
     )
 end

--- a/src/types/timezone.jl
+++ b/src/types/timezone.jl
@@ -32,7 +32,7 @@ which are classified as "legacy".
 ## Examples
 ```jldoctest
 julia> TimeZone("US/Pacific")
-ERROR: ArgumentError: The time zone "US/Pacific" is of class `Class(:LEGACY)` which is currently not allowed by the mask: `Class(:FIXED) | Class(:STANDARD)`
+ERROR: ArgumentError: The time zone "US/Pacific" is of class `TimeZones.Class(:LEGACY)` which is currently not allowed by the mask: `TimeZones.Class(:FIXED) | TimeZones.Class(:STANDARD)`
 
 julia> TimeZone("US/Pacific", TimeZones.Class(:LEGACY))
 US/Pacific (UTC-8/UTC-7)

--- a/src/types/variabletimezone.jl
+++ b/src/types/variabletimezone.jl
@@ -30,6 +30,14 @@ function Base.:(==)(a::VariableTimeZone, b::VariableTimeZone)
     a.name == b.name && a.transitions == b.transitions
 end
 
+function Base.isequal(a::VariableTimeZone, b::VariableTimeZone)
+    return (
+        isequal(a.name, b.name) &&
+        isequal(a.transitions, b.transitions) &&
+        isequal(a.cutoff, b.cutoff)
+    )
+end
+
 function Base.hash(tz::VariableTimeZone, h::UInt)
     h = hash(tz.name, h)
     h = hash(tz.transitions, h)

--- a/src/tzdata/TZData.jl
+++ b/src/tzdata/TZData.jl
@@ -25,5 +25,6 @@ include("version.jl")
 include("download.jl")
 include("compile.jl")
 include("build.jl")
+include("deprecated.jl")
 
 end

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -1,3 +1,5 @@
+using ...TimeZones: TimeZones, STANDARD, LEGACY
+
 # The default tz source files we care about. See "ftp://ftp.iana.org/tz/data/Makefile"
 # "PRIMARY_YDATA" for listing of tz source files to include.
 const STANDARD_REGIONS = [
@@ -26,7 +28,7 @@ function build(
     compiled_dir::AbstractString="";
     verbose::Bool=false,
 )
-    tz_category = Dict{Symbol,Vector{String}}()
+    tz_category = Dict{UInt8,Vector{String}}()
 
     # Avoids spamming remote servers requesting the latest version
     if version == "latest"
@@ -70,8 +72,8 @@ function build(
         legacy = TZSource(legacy_files)
 
         # Record the time zone names associated with the category
-        tz_category[:standard] = names(standard)
-        tz_category[:legacy] = setdiff(names(legacy), tz_category[:standard])
+        tz_category[STANDARD] = names(standard)
+        tz_category[LEGACY] = setdiff(names(legacy), tz_category[STANDARD])
 
         # Combine the sources as legacy links depend on standard time zones
         tz_source = merge!(standard, legacy)
@@ -100,8 +102,8 @@ function build(version::AbstractString="latest")
     write(ACTIVE_VERSION_FILE, version)
 
     # Save time zone category information
-    for (tag, tz_names) in tz_category
-        open(joinpath(DEPS_DIR, string(tag)), "w+") do io
+    for (class, tz_names) in tz_category
+        open(joinpath(DEPS_DIR, TimeZones._class_name(class)), "w+") do io
             for name in tz_names
                 println(io, name)
             end

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -1,4 +1,4 @@
-using ...TimeZones: TimeZones, STANDARD, LEGACY
+using ...TimeZones: Class
 
 # The default tz source files we care about. See "ftp://ftp.iana.org/tz/data/Makefile"
 # "PRIMARY_YDATA" for listing of tz source files to include.
@@ -28,7 +28,7 @@ function build(
     compiled_dir::AbstractString="";
     verbose::Bool=false,
 )
-    tz_category = Dict{UInt8,Vector{String}}()
+    tz_category = Dict{Class,Vector{String}}()
 
     # Avoids spamming remote servers requesting the latest version
     if version == "latest"
@@ -72,8 +72,8 @@ function build(
         legacy = TZSource(legacy_files)
 
         # Record the time zone names associated with the category
-        tz_category[STANDARD] = names(standard)
-        tz_category[LEGACY] = setdiff(names(legacy), tz_category[STANDARD])
+        tz_category[Class.STANDARD] = names(standard)
+        tz_category[Class.LEGACY] = setdiff(names(legacy), tz_category[Class.STANDARD])
 
         # Combine the sources as legacy links depend on standard time zones
         tz_source = merge!(standard, legacy)
@@ -103,7 +103,7 @@ function build(version::AbstractString="latest")
 
     # Save time zone category information
     for (class, tz_names) in tz_category
-        open(joinpath(DEPS_DIR, TimeZones._class_name(class)), "w+") do io
+        open(joinpath(DEPS_DIR, string(class)), "w+") do io
             for name in tz_names
                 println(io, name)
             end

--- a/src/tzdata/compile.jl
+++ b/src/tzdata/compile.jl
@@ -4,7 +4,7 @@ using Dates: parse_components
 
 using ...TimeZones: TIME_ZONE_CACHE
 using ...TimeZones: TimeZones, TimeZone, FixedTimeZone, VariableTimeZone, Transition, Class
-using ...TimeZones: classify, rename
+using ...TimeZones: rename
 using ..TZData: TimeOffset, ZERO, MIN_GMT_OFFSET, MAX_GMT_OFFSET, MIN_SAVE, MAX_SAVE,
     ABS_DIFF_OFFSET
 
@@ -604,12 +604,12 @@ function compile(name::AbstractString, tz_source::TZSource; kwargs...)
         # rename the time zone with the link name.
         zone_name = tz_source.links[name]
         tz = compile!(zone_name, tz_source, ordered; kwargs...)
-        class = classify(name, associated_regions(tz_source, name))
+        class = Class(name, associated_regions(tz_source, name))
 
         return rename(tz, name), class
     else
         tz = compile!(name, tz_source, ordered; kwargs...)
-        class = classify(name, associated_regions(tz_source, name))
+        class = Class(name, associated_regions(tz_source, name))
 
         return tz, class
     end
@@ -622,7 +622,7 @@ function compile(tz_source::TZSource; kwargs...)
 
     for zone_name in keys(tz_source.zones)
         tz = compile!(zone_name, tz_source, ordered; kwargs...)
-        class = classify(zone_name, associated_regions(tz_source, zone_name))
+        class = Class(zone_name, associated_regions(tz_source, zone_name))
 
         push!(results, (tz, class))
         lookup[zone_name] = tz
@@ -633,7 +633,7 @@ function compile(tz_source::TZSource; kwargs...)
         if !haskey(lookup, link_name) && haskey(lookup, target)
             target_tz = lookup[target]
             tz = rename(target_tz, link_name)
-            class = classify(link_name, associated_regions(tz_source, link_name))
+            class = Class(link_name, associated_regions(tz_source, link_name))
 
             push!(results, (tz, class))
         elseif !haskey(lookup, target)

--- a/src/tzdata/compile.jl
+++ b/src/tzdata/compile.jl
@@ -2,7 +2,7 @@ using Dates
 using Serialization
 using Dates: parse_components
 
-using ...TimeZones: TIME_ZONES
+using ...TimeZones: TIME_ZONE_CACHE
 using ...TimeZones: TimeZones, TimeZone, FixedTimeZone, VariableTimeZone, Transition, rename
 using ..TZData: TimeOffset, ZERO, MIN_GMT_OFFSET, MAX_GMT_OFFSET, MIN_SAVE, MAX_SAVE,
     ABS_DIFF_OFFSET
@@ -632,7 +632,7 @@ function compile(tz_source::TZSource, dest_dir::AbstractString; kwargs...)
     time_zones = compile(tz_source; kwargs...)
 
     isdir(dest_dir) || error("Destination directory doesn't exist")
-    empty!(TIME_ZONES)
+    empty!(TIME_ZONE_CACHE)
 
     for tz in time_zones
         parts = split(TimeZones.name(tz), '/')

--- a/src/tzdata/deprecated.jl
+++ b/src/tzdata/deprecated.jl
@@ -1,0 +1,7 @@
+using Base: @deprecate
+
+# BEGIN TimeZones 0.9 deprecations
+
+@deprecate build(version::AbstractString, regions) build(version) false
+
+# END TimeZones 0.9 deprecations

--- a/test/accessors.jl
+++ b/test/accessors.jl
@@ -1,7 +1,7 @@
 import Dates
 using Dates: Second, Millisecond
 
-warsaw = compile("Europe/Warsaw", tzdata["europe"])
+warsaw = first(compile("Europe/Warsaw", tzdata["europe"]))
 fixed = FixedTimeZone("Fixed", -7200, 3600)
 
 # ZonedDateTime accessors

--- a/test/adjusters.jl
+++ b/test/adjusters.jl
@@ -1,7 +1,7 @@
 using Dates
 
 # Basic truncation
-warsaw = compile("Europe/Warsaw", tzdata["europe"])
+warsaw = first(compile("Europe/Warsaw", tzdata["europe"]))
 zdt = ZonedDateTime(DateTime(2014,10,15,23,59,58,57), warsaw)
 
 @test trunc(zdt, Year) == ZonedDateTime(DateTime(2014), warsaw)
@@ -19,7 +19,7 @@ dt = DateTime(2014,10,26,2)
 @test trunc(ZonedDateTime(dt + Minute(59), warsaw, 2), Hour) == ZonedDateTime(dt, warsaw, 2)
 
 # Sub-hourly offsets (Issue #33)
-st_johns = compile("America/St_Johns", tzdata["northamerica"])   # UTC-3:30 or UTC-2:30
+st_johns = first(compile("America/St_Johns", tzdata["northamerica"])) # UTC-3:30 or UTC-2:30
 zdt = ZonedDateTime(DateTime(2016,8,18,17,57,56,513), st_johns)
 @test trunc(zdt, Hour) == ZonedDateTime(DateTime(2016,8,18,17), st_johns)
 

--- a/test/arithmetic.jl
+++ b/test/arithmetic.jl
@@ -1,6 +1,6 @@
 using Dates: Day, Hour
 
-warsaw = compile("Europe/Warsaw", tzdata["europe"])
+warsaw = first(compile("Europe/Warsaw", tzdata["europe"]))
 
 normal = DateTime(2015, 1, 1, 0)   # a 24 hour day in warsaw
 spring = DateTime(2015, 3, 29, 0)  # a 23 hour day in warsaw

--- a/test/ci.jl
+++ b/test/ci.jl
@@ -1,3 +1,5 @@
+using TimeZones: TZData
+
 # Note: These tests are only meant to be run in a CI environment as they will modify the
 # build time zones in the COMPILED_DIR.
 
@@ -17,22 +19,7 @@
 
     @test isdir(TZData.COMPILED_DIR)
     @test length(readdir(TZData.COMPILED_DIR)) > 0
-    @test readdir(TZData.TZ_SOURCE_DIR) == sort!([TZData.REGIONS; "utc"])
-
-
-    # Compile the "etcetera" tz source file. An example from the FAQ.
-    @test !isfile(joinpath(TZData.TZ_SOURCE_DIR, "etcetera"))
-
-    archive = TZData.active_archive()
-    TZData.extract(archive, TZData.TZ_SOURCE_DIR, "etcetera")
-
-    @test isfile(joinpath(TZData.TZ_SOURCE_DIR, "etcetera"))
-    TZData.compile()
-
-    @test TimeZone("Etc/GMT") == FixedTimeZone("Etc/GMT", 0)
-    @test TimeZone("Etc/GMT+12") == FixedTimeZone("Etc/GMT+12", -12 * 3600)
-    @test TimeZone("Etc/GMT-14") == FixedTimeZone("Etc/GMT-14", 14 * 3600)
-
+    @test readdir(TZData.TZ_SOURCE_DIR) == sort(TZData.REGIONS)
 
     # Compile tz source files with an extended max_year. An example from the FAQ.
     warsaw = TimeZone("Europe/Warsaw")

--- a/test/ci.jl
+++ b/test/ci.jl
@@ -13,7 +13,7 @@
     @test length(readdir(TZData.TZ_SOURCE_DIR)) == 1
 
     # Using a version we already have avoids triggering a download
-    TimeZones.build(TZDATA_VERSION, TZData.REGIONS)
+    TimeZones.build(TZDATA_VERSION)
 
     @test isdir(TZData.COMPILED_DIR)
     @test length(readdir(TZData.COMPILED_DIR)) > 0

--- a/test/class.jl
+++ b/test/class.jl
@@ -4,12 +4,11 @@ using TimeZones: Class, Transition
     @testset "construct" begin
         @test Class.NONE == Class(0x00)
         @test Class.FIXED == Class(0x01)
-        @test Class.VARIABLE == Class(0x02)
-        @test Class.STANDARD == Class(0x04)
-        @test Class.LEGACY == Class(0x08)
+        @test Class.STANDARD == Class(0x02)
+        @test Class.LEGACY == Class(0x04)
 
-        @test Class.DEFAULT == Class(0x01 | 0x04)
-        @test Class.ALL == Class(0x0f)
+        @test Class.DEFAULT == Class(0x01 | 0x02)
+        @test Class.ALL == Class(0x07)
     end
 
     @testset "getproperty field fallback" begin
@@ -18,20 +17,12 @@ using TimeZones: Class, Transition
     end
 
     @testset "classify" begin
-        fixed_tz = FixedTimeZone("UTC")
-        variable_tz = VariableTimeZone(
-            "Variable",
-            [Transition(DateTime(1900), FixedTimeZone("VST", 0, 0))],
-        )
-
-        @test TimeZones.classify(fixed_tz) == Class.FIXED
-        @test TimeZones.classify(variable_tz) == Class.VARIABLE
-
-        @test TimeZones.classify(fixed_tz, "northamerica") == Class.FIXED | Class.STANDARD
-        @test TimeZones.classify(fixed_tz, "etcetera") == Class.FIXED | Class.LEGACY
-        @test TimeZones.classify(fixed_tz, "backward") == Class.FIXED | Class.LEGACY
-
-        @test TimeZones.classify(fixed_tz, ["europe", "backward"]) == Class.FIXED | Class.STANDARD | Class.LEGACY
+        @test TimeZones.classify("Foobar", []) == Class.NONE
+        @test TimeZones.classify("UTC+1", []) == Class.FIXED
+        @test TimeZones.classify("Europe/Warsaw", ["europe"]) == Class.STANDARD
+        @test TimeZones.classify("US/Pacific", ["backward"]) == Class.LEGACY
+        @test TimeZones.classify("Etc/GMT-14", ["etcetera"]) == Class.LEGACY
+        @test TimeZones.classify("UTC", ["utc", "backward"]) == Class.FIXED | Class.STANDARD | Class.LEGACY
     end
 
     @testset "bitwise-or" begin
@@ -51,14 +42,13 @@ using TimeZones: Class, Transition
     @testset "labels" begin
         @test TimeZones.labels(Class.NONE) == ["NONE"]
         @test TimeZones.labels(Class.FIXED) == ["FIXED"]
-        @test TimeZones.labels(Class.VARIABLE) == ["VARIABLE"]
         @test TimeZones.labels(Class.STANDARD) == ["STANDARD"]
         @test TimeZones.labels(Class.LEGACY) == ["LEGACY"]
 
         @test TimeZones.labels(Class.DEFAULT) == ["FIXED", "STANDARD"]
         @test TimeZones.labels(Class.ALL) == ["FIXED", "STANDARD", "LEGACY"]
 
-        @test TimeZones.labels(Class(0x10)) == String[]
+        @test TimeZones.labels(Class(0x08)) == String[]
     end
 
     @testset "string" begin

--- a/test/class.jl
+++ b/test/class.jl
@@ -1,0 +1,59 @@
+using TimeZones: Class
+
+@testset "Class" begin
+    @testset "construct" begin
+        @test Class.NONE == Class(0x00)
+        @test Class.FIXED == Class(0x01)
+        @test Class.STANDARD == Class(0x02)
+        @test Class.LEGACY == Class(0x04)
+
+        @test Class.DEFAULT == Class(0x01 | 0x02)
+        @test Class.ALL == Class(0x07)
+    end
+
+    @testset "getproperty field fallback" begin
+        @test Class isa DataType
+        @test sprint(show, Class) == "Class"
+    end
+
+    @testset "classify" begin
+        @test TimeZones.classify("UTC") == Class.FIXED
+        @test TimeZones.classify("Europe/Warsaw") == Class.STANDARD
+        @test TimeZones.classify("US/Pacific") == Class.LEGACY
+        @test TimeZones.classify("Foobar") == Class.NONE
+    end
+
+    @testset "bitwise-or" begin
+        @test Class(0x00) | Class(0x00) == Class(0x00)
+        @test Class(0x00) | Class(0x01) == Class(0x01)
+        @test Class(0x01) | Class(0x00) == Class(0x01)
+        @test Class(0x01) | Class(0x01) == Class(0x01)
+    end
+
+    @testset "bitwise-and" begin
+        @test Class(0x00) & Class(0x00) == Class(0x00)
+        @test Class(0x00) & Class(0x01) == Class(0x00)
+        @test Class(0x01) & Class(0x00) == Class(0x00)
+        @test Class(0x01) & Class(0x01) == Class(0x01)
+    end
+
+    @testset "labels" begin
+        @test TimeZones.labels(Class.NONE) == ["NONE"]
+        @test TimeZones.labels(Class.FIXED) == ["FIXED"]
+        @test TimeZones.labels(Class.STANDARD) == ["STANDARD"]
+        @test TimeZones.labels(Class.LEGACY) == ["LEGACY"]
+
+        @test TimeZones.labels(Class.DEFAULT) == ["FIXED", "STANDARD"]
+        @test TimeZones.labels(Class.ALL) == ["FIXED", "STANDARD", "LEGACY"]
+
+        @test TimeZones.labels(Class(0x08)) == String[]
+    end
+
+    @testset "string" begin
+        @test string(Class.DEFAULT) == "FIXED | STANDARD"
+    end
+
+    @testset "repr" begin
+        @test repr(Class.DEFAULT) == "Class.FIXED | Class.STANDARD"
+    end
+end

--- a/test/class.jl
+++ b/test/class.jl
@@ -2,13 +2,13 @@ using TimeZones: Class, Transition
 
 @testset "Class" begin
     @testset "construct" begin
-        @test Class.NONE == Class(0x00)
-        @test Class.FIXED == Class(0x01)
-        @test Class.STANDARD == Class(0x02)
-        @test Class.LEGACY == Class(0x04)
+        @test Class(:NONE) == Class(0x00)
+        @test Class(:FIXED) == Class(0x01)
+        @test Class(:STANDARD) == Class(0x02)
+        @test Class(:LEGACY) == Class(0x04)
 
-        @test Class.DEFAULT == Class(0x01 | 0x02)
-        @test Class.ALL == Class(0x07)
+        @test Class(:DEFAULT) == Class(0x01 | 0x02)
+        @test Class(:ALL) == Class(0x07)
     end
 
     @testset "getproperty field fallback" begin
@@ -17,12 +17,12 @@ using TimeZones: Class, Transition
     end
 
     @testset "classify name/regions" begin
-        @test Class("Foobar", []) == Class.NONE
-        @test Class("UTC+1", []) == Class.FIXED
-        @test Class("Europe/Warsaw", ["europe"]) == Class.STANDARD
-        @test Class("US/Pacific", ["backward"]) == Class.LEGACY
-        @test Class("Etc/GMT-14", ["etcetera"]) == Class.LEGACY
-        @test Class("UTC", ["utc", "backward"]) == Class.FIXED | Class.STANDARD | Class.LEGACY
+        @test Class("Foobar", []) == Class(:NONE)
+        @test Class("UTC+1", []) == Class(:FIXED)
+        @test Class("Europe/Warsaw", ["europe"]) == Class(:STANDARD)
+        @test Class("US/Pacific", ["backward"]) == Class(:LEGACY)
+        @test Class("Etc/GMT-14", ["etcetera"]) == Class(:LEGACY)
+        @test Class("UTC", ["utc", "backward"]) == Class(:FIXED) | Class(:STANDARD) | Class(:LEGACY)
     end
 
     @testset "bitwise-or" begin
@@ -40,24 +40,24 @@ using TimeZones: Class, Transition
     end
 
     @testset "labels" begin
-        @test TimeZones.labels(Class.NONE) == ["NONE"]
-        @test TimeZones.labels(Class.FIXED) == ["FIXED"]
-        @test TimeZones.labels(Class.STANDARD) == ["STANDARD"]
-        @test TimeZones.labels(Class.LEGACY) == ["LEGACY"]
+        @test TimeZones.labels(Class(:NONE)) == ["NONE"]
+        @test TimeZones.labels(Class(:FIXED)) == ["FIXED"]
+        @test TimeZones.labels(Class(:STANDARD)) == ["STANDARD"]
+        @test TimeZones.labels(Class(:LEGACY)) == ["LEGACY"]
 
-        @test TimeZones.labels(Class.DEFAULT) == ["FIXED", "STANDARD"]
-        @test TimeZones.labels(Class.ALL) == ["FIXED", "STANDARD", "LEGACY"]
+        @test TimeZones.labels(Class(:DEFAULT)) == ["FIXED", "STANDARD"]
+        @test TimeZones.labels(Class(:ALL)) == ["FIXED", "STANDARD", "LEGACY"]
 
         @test TimeZones.labels(Class(0x08)) == ["Class(0x08)"]
     end
 
     @testset "string" begin
-        @test string(Class.DEFAULT) == "FIXED | STANDARD"
+        @test string(Class(:DEFAULT)) == "FIXED | STANDARD"
         @test string(Class(0x09)) == "FIXED | Class(0x08)"
     end
 
     @testset "repr" begin
-        @test repr(Class.DEFAULT) == "Class.FIXED | Class.STANDARD"
-        @test repr(Class(0x09)) == "Class.FIXED | Class(0x08)"
+        @test repr(Class(:DEFAULT)) == "Class(:FIXED) | Class(:STANDARD)"
+        @test repr(Class(0x09)) == "Class(:FIXED) | Class(0x08)"
     end
 end

--- a/test/class.jl
+++ b/test/class.jl
@@ -48,14 +48,16 @@ using TimeZones: Class, Transition
         @test TimeZones.labels(Class.DEFAULT) == ["FIXED", "STANDARD"]
         @test TimeZones.labels(Class.ALL) == ["FIXED", "STANDARD", "LEGACY"]
 
-        @test TimeZones.labels(Class(0x08)) == String[]
+        @test TimeZones.labels(Class(0x08)) == ["Class(0x08)"]
     end
 
     @testset "string" begin
         @test string(Class.DEFAULT) == "FIXED | STANDARD"
+        @test string(Class(0x09)) == "FIXED | Class(0x08)"
     end
 
     @testset "repr" begin
         @test repr(Class.DEFAULT) == "Class.FIXED | Class.STANDARD"
+        @test repr(Class(0x09)) == "Class.FIXED | Class(0x08)"
     end
 end

--- a/test/class.jl
+++ b/test/class.jl
@@ -16,13 +16,13 @@ using TimeZones: Class, Transition
         @test sprint(show, Class) == "Class"
     end
 
-    @testset "classify" begin
-        @test TimeZones.classify("Foobar", []) == Class.NONE
-        @test TimeZones.classify("UTC+1", []) == Class.FIXED
-        @test TimeZones.classify("Europe/Warsaw", ["europe"]) == Class.STANDARD
-        @test TimeZones.classify("US/Pacific", ["backward"]) == Class.LEGACY
-        @test TimeZones.classify("Etc/GMT-14", ["etcetera"]) == Class.LEGACY
-        @test TimeZones.classify("UTC", ["utc", "backward"]) == Class.FIXED | Class.STANDARD | Class.LEGACY
+    @testset "classify name/regions" begin
+        @test Class("Foobar", []) == Class.NONE
+        @test Class("UTC+1", []) == Class.FIXED
+        @test Class("Europe/Warsaw", ["europe"]) == Class.STANDARD
+        @test Class("US/Pacific", ["backward"]) == Class.LEGACY
+        @test Class("Etc/GMT-14", ["etcetera"]) == Class.LEGACY
+        @test Class("UTC", ["utc", "backward"]) == Class.FIXED | Class.STANDARD | Class.LEGACY
     end
 
     @testset "bitwise-or" begin

--- a/test/class.jl
+++ b/test/class.jl
@@ -39,25 +39,16 @@ using TimeZones: Class, Transition
         @test Class(0x01) & Class(0x01) == Class(0x01)
     end
 
-    @testset "labels" begin
-        @test TimeZones.labels(Class(:NONE)) == ["NONE"]
-        @test TimeZones.labels(Class(:FIXED)) == ["FIXED"]
-        @test TimeZones.labels(Class(:STANDARD)) == ["STANDARD"]
-        @test TimeZones.labels(Class(:LEGACY)) == ["LEGACY"]
-
-        @test TimeZones.labels(Class(:DEFAULT)) == ["FIXED", "STANDARD"]
-        @test TimeZones.labels(Class(:ALL)) == ["FIXED", "STANDARD", "LEGACY"]
-
-        @test TimeZones.labels(Class(0x08)) == ["Class(0x08)"]
-    end
-
-    @testset "string" begin
-        @test string(Class(:DEFAULT)) == "FIXED | STANDARD"
-        @test string(Class(0x09)) == "FIXED | Class(0x08)"
-    end
-
     @testset "repr" begin
+        @test repr(Class(:NONE)) == "Class(:NONE)"
+        @test repr(Class(:FIXED)) == "Class(:FIXED)"
+        @test repr(Class(:STANDARD)) == "Class(:STANDARD)"
+        @test repr(Class(:LEGACY)) == "Class(:LEGACY)"
+
         @test repr(Class(:DEFAULT)) == "Class(:FIXED) | Class(:STANDARD)"
+        @test repr(Class(:ALL)) == "Class(:FIXED) | Class(:STANDARD) | Class(:LEGACY)"
+
+        @test repr(Class(0x08)) == "Class(0x08)"
         @test repr(Class(0x09)) == "Class(:FIXED) | Class(0x08)"
     end
 end

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -2,9 +2,9 @@ import Dates
 using Mocking
 
 utc = FixedTimeZone("UTC")
-warsaw = compile("Europe/Warsaw", tzdata["europe"])
-apia = compile("Pacific/Apia", tzdata["australasia"])
-midway = compile("Pacific/Midway", tzdata["australasia"])
+warsaw = first(compile("Europe/Warsaw", tzdata["europe"]))
+apia = first(compile("Pacific/Apia", tzdata["australasia"]))
+midway = first(compile("Pacific/Midway", tzdata["australasia"]))
 
 # Converting a ZonedDateTime into a DateTime
 dt = DateTime(2015, 1, 1, 0)

--- a/test/discovery.jl
+++ b/test/discovery.jl
@@ -29,9 +29,9 @@ abbrs = timezone_abbrs()
 @test issorted(abbrs)
 
 
-wpg = compile("America/Winnipeg", tzdata["northamerica"])
-apia = compile("Pacific/Apia", tzdata["australasia"])
-paris = compile("Europe/Paris", tzdata["europe"])
+wpg = first(compile("America/Winnipeg", tzdata["northamerica"]))
+apia = first(compile("Pacific/Apia", tzdata["australasia"]))
+paris = first(compile("Europe/Paris", tzdata["europe"]))
 
 @testset "next_transition_instant" begin
     @testset "non-existent" begin

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1,5 +1,5 @@
 # Contains both positive and negative UTC offsets and observes daylight saving time.
-apia = compile("Pacific/Apia", tzdata["australasia"])
+apia = first(compile("Pacific/Apia", tzdata["australasia"]))
 
 ambiguous_pos = DateTime(2011,4,2,3)
 non_existent_pos = DateTime(2011,9,24,3)

--- a/test/io.jl
+++ b/test/io.jl
@@ -3,11 +3,11 @@ using TimeZones.TZData: parse_components
 null = FixedTimeZone("", 10800)
 fixed = FixedTimeZone("UTC+01:00")
 est = FixedTimeZone("EST", -18000)
-warsaw = compile("Europe/Warsaw", tzdata["europe"])
-apia = compile("Pacific/Apia", tzdata["australasia"])
-honolulu = compile("Pacific/Honolulu", tzdata["northamerica"])  # Uses cutoff
-ulyanovsk = compile("Europe/Ulyanovsk", tzdata["europe"])  # No named abbreviations
-new_york = compile("America/New_York", tzdata["northamerica"])  # Underscore in name
+warsaw = first(compile("Europe/Warsaw", tzdata["europe"]))
+apia = first(compile("Pacific/Apia", tzdata["australasia"]))
+honolulu = first(compile("Pacific/Honolulu", tzdata["northamerica"]))  # Uses cutoff
+ulyanovsk = first(compile("Europe/Ulyanovsk", tzdata["europe"]))  # No named abbreviations
+new_york = first(compile("America/New_York", tzdata["northamerica"]))  # Underscore in name
 dt = DateTime(1942,12,25,1,23,45)
 
 # TimeZones as a string

--- a/test/local_mocking.jl
+++ b/test/local_mocking.jl
@@ -123,14 +123,14 @@ end
 # https://github.com/JuliaTime/TimeZones.jl/issues/154
 @testset "legacy time zones" begin
     # "US/Pacific" is deprecated in favor of "America/Los_Angeles"
-    @test istimezone("US/Pacific", Class.LEGACY)
+    @test istimezone("US/Pacific", Class(:LEGACY))
     name = Sys.isunix() ? "US/Pacific" : "Pacific Standard Time"
     with_localzone(name) do
         @test localzone().transitions == tz"America/Los_Angeles".transitions
     end
 
     # "America/Montreal" is deprecated in favor of "America/Toronto"
-    @test istimezone("America/Montreal", Class.LEGACY)
+    @test istimezone("America/Montreal", Class(:LEGACY))
     if Sys.isunix()
         with_localzone("America/Montreal") do
             @test localzone().transitions == tz"America/Toronto".transitions
@@ -139,7 +139,7 @@ end
 
     # "America/Indianapolis" is deprecated in favor of "America/Indiana/Indianapolis"
     # Note: On Windows "US Eastern Standard Time" translates to "America/Indianapolis"
-    @test istimezone("America/Indianapolis", Class.LEGACY)
+    @test istimezone("America/Indianapolis", Class(:LEGACY))
     name = Sys.isunix() ? "America/Indianapolis" : "US Eastern Standard Time"
     with_localzone(name) do
         @test localzone().transitions == tz"America/Indiana/Indianapolis".transitions

--- a/test/local_mocking.jl
+++ b/test/local_mocking.jl
@@ -123,12 +123,14 @@ end
 # https://github.com/JuliaTime/TimeZones.jl/issues/154
 @testset "legacy time zones" begin
     # "US/Pacific" is deprecated in favor of "America/Los_Angeles"
+    @test istimezone("US/Pacific", Class.LEGACY)
     name = Sys.isunix() ? "US/Pacific" : "Pacific Standard Time"
     with_localzone(name) do
         @test localzone().transitions == tz"America/Los_Angeles".transitions
     end
 
     # "America/Montreal" is deprecated in favor of "America/Toronto"
+    @test istimezone("America/Montreal", Class.LEGACY)
     if Sys.isunix()
         with_localzone("America/Montreal") do
             @test localzone().transitions == tz"America/Toronto".transitions
@@ -137,6 +139,7 @@ end
 
     # "America/Indianapolis" is deprecated in favor of "America/Indiana/Indianapolis"
     # Note: On Windows "US Eastern Standard Time" translates to "America/Indianapolis"
+    @test istimezone("America/Indianapolis", Class.LEGACY)
     name = Sys.isunix() ? "America/Indianapolis" : "US Eastern Standard Time"
     with_localzone(name) do
         @test localzone().transitions == tz"America/Indiana/Indianapolis".transitions

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -2,8 +2,8 @@ using Dates: Day, Hour, Minute
 
 
 utc = FixedTimeZone("UTC", 0)
-dst = compile("America/Winnipeg", tzdata["northamerica"])
-no_dst = compile("America/Regina", tzdata["northamerica"])
+dst = first(compile("America/Winnipeg", tzdata["northamerica"]))
+no_dst = first(compile("America/Regina", tzdata["northamerica"]))
 fixed = FixedTimeZone("Fixed", -5 * 3600)
 
 

--- a/test/rounding.jl
+++ b/test/rounding.jl
@@ -1,9 +1,9 @@
 utc = FixedTimeZone("UTC")
 fixed = FixedTimeZone("UTC-06:00")
-winnipeg = compile("America/Winnipeg", tzdata["northamerica"])   # UTC-6:00 (or UTC-5:00)
-st_johns = compile("America/St_Johns", tzdata["northamerica"])   # UTC-3:30 (or UTC-2:30)
-eucla = compile("Australia/Eucla", tzdata["australasia"])        # UTC+8:45
-colombo = compile("Asia/Colombo", tzdata["asia"])                # See note below
+winnipeg = first(compile("America/Winnipeg", tzdata["northamerica"]))   # UTC-6:00 (or UTC-5:00)
+st_johns = first(compile("America/St_Johns", tzdata["northamerica"]))   # UTC-3:30 (or UTC-2:30)
+eucla = first(compile("Australia/Eucla", tzdata["australasia"]))        # UTC+8:45
+colombo = first(compile("Asia/Colombo", tzdata["asia"]))                # See note below
 
 # On 1996-05-25 at 00:00, the Asia/Colombo time zone in Sri Lanka moved from Indian Standard
 # Time (UTC+5:30) to Lanka Time (UTC+6:30). On 1996-10-26 at 00:30, Lanka Time was revised

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,7 @@ include("helpers.jl")
 
 @testset "TimeZones" begin
     include("utils.jl")
+    include("class.jl")
     include(joinpath("tzdata", "timeoffset.jl"))
     include(joinpath("tzdata", "archive.jl"))
     include(joinpath("tzdata", "version.jl"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ using TimeZones.TZData: ARCHIVE_DIR, TZSource, compile, build
 const TZDATA_VERSION = "2016j"
 const TZ_SOURCE_DIR = get(ENV, "TZ_SOURCE_DIR", joinpath(PKG_DIR, "test", "tzsource"))
 const TZFILE_DIR = joinpath(PKG_DIR, "test", "tzfile")
-const TEST_REGIONS = ("asia", "australasia", "europe", "northamerica")
+const TEST_REGIONS = ["asia", "australasia", "europe", "northamerica"]
 
 isdir(ARCHIVE_DIR) || mkdir(ARCHIVE_DIR)
 isdir(TZ_SOURCE_DIR) || mkdir(TZ_SOURCE_DIR)

--- a/test/types/timezone.jl
+++ b/test/types/timezone.jl
@@ -20,11 +20,11 @@ end
     @test !istimezone("Etc/GMT+12")
     @test !istimezone("Etc/GMT-14")
 
-    @test istimezone("Etc/GMT", Class.LEGACY)
-    @test istimezone("Etc/GMT+12", Class.LEGACY)
-    @test istimezone("Etc/GMT-14", Class.LEGACY)
+    @test istimezone("Etc/GMT", Class(:LEGACY))
+    @test istimezone("Etc/GMT+12", Class(:LEGACY))
+    @test istimezone("Etc/GMT-14", Class(:LEGACY))
 
-    @test TimeZone("Etc/GMT", Class.LEGACY) == FixedTimeZone("Etc/GMT", 0)
-    @test TimeZone("Etc/GMT+12", Class.LEGACY) == FixedTimeZone("Etc/GMT+12", -12 * 3600)
-    @test TimeZone("Etc/GMT-14", Class.LEGACY) == FixedTimeZone("Etc/GMT-14", 14 * 3600)
+    @test TimeZone("Etc/GMT", Class(:LEGACY)) == FixedTimeZone("Etc/GMT", 0)
+    @test TimeZone("Etc/GMT+12", Class(:LEGACY)) == FixedTimeZone("Etc/GMT+12", -12 * 3600)
+    @test TimeZone("Etc/GMT-14", Class(:LEGACY)) == FixedTimeZone("Etc/GMT-14", 14 * 3600)
 end

--- a/test/types/timezone.jl
+++ b/test/types/timezone.jl
@@ -1,4 +1,4 @@
-using TimeZones: TZData
+using TimeZones: Class
 
 @test istimezone("Europe/Warsaw")
 @test istimezone("UTC+02")
@@ -7,3 +7,19 @@ using TimeZones: TZData
 # Deserialization can cause us to have two immutables that are not using the same memory
 @test TimeZone("Europe/Warsaw") === TimeZone("Europe/Warsaw")
 @test tz"Africa/Nairobi" === TimeZone("Africa/Nairobi")
+
+@testset "etcetera" begin
+    # Note: In previous versions of TimeZones.jl the "etcetera" source file was not parsed
+    # by default.
+    @test !istimezone("Etc/GMT")
+    @test !istimezone("Etc/GMT+12")
+    @test !istimezone("Etc/GMT-14")
+
+    @test istimezone("Etc/GMT", Class.LEGACY)
+    @test istimezone("Etc/GMT+12", Class.LEGACY)
+    @test istimezone("Etc/GMT-14", Class.LEGACY)
+
+    @test TimeZone("Etc/GMT", Class.LEGACY) == FixedTimeZone("Etc/GMT", 0)
+    @test TimeZone("Etc/GMT+12", Class.LEGACY) == FixedTimeZone("Etc/GMT+12", -12 * 3600)
+    @test TimeZone("Etc/GMT-14", Class.LEGACY) == FixedTimeZone("Etc/GMT-14", 14 * 3600)
+end

--- a/test/types/timezone.jl
+++ b/test/types/timezone.jl
@@ -1,8 +1,13 @@
 using TimeZones: Class
 
-@test istimezone("Europe/Warsaw")
-@test istimezone("UTC+02")
-@test !istimezone("Europe/Camelot")
+@testset "istimezone" begin
+    # Invalidate the cache to ensure that `istimezone` works for non-loaded time zones.
+    empty!(TimeZones.TIME_ZONE_CACHE)
+
+    @test istimezone("Europe/Warsaw")
+    @test istimezone("UTC+02")
+    @test !istimezone("Europe/Camelot")
+end
 
 # Deserialization can cause us to have two immutables that are not using the same memory
 @test TimeZone("Europe/Warsaw") === TimeZone("Europe/Warsaw")
@@ -11,9 +16,9 @@ using TimeZones: Class
 @testset "etcetera" begin
     # Note: In previous versions of TimeZones.jl the "etcetera" source file was not parsed
     # by default.
-    @test !istimezone("Etc/GMT")
-    @test !istimezone("Etc/GMT+12")
-    @test !istimezone("Etc/GMT-14")
+    # @test !istimezone("Etc/GMT")
+    # @test !istimezone("Etc/GMT+12")
+    # @test !istimezone("Etc/GMT-14")
 
     @test istimezone("Etc/GMT", Class.LEGACY)
     @test istimezone("Etc/GMT+12", Class.LEGACY)

--- a/test/types/timezone.jl
+++ b/test/types/timezone.jl
@@ -16,9 +16,9 @@ end
 @testset "etcetera" begin
     # Note: In previous versions of TimeZones.jl the "etcetera" source file was not parsed
     # by default.
-    # @test !istimezone("Etc/GMT")
-    # @test !istimezone("Etc/GMT+12")
-    # @test !istimezone("Etc/GMT-14")
+    @test !istimezone("Etc/GMT")
+    @test !istimezone("Etc/GMT+12")
+    @test !istimezone("Etc/GMT-14")
 
     @test istimezone("Etc/GMT", Class.LEGACY)
     @test istimezone("Etc/GMT+12", Class.LEGACY)

--- a/test/types/variabletimezone.jl
+++ b/test/types/variabletimezone.jl
@@ -1,7 +1,7 @@
 @testset "VariableTimeZone" begin
     @testset "equality" begin
-        warsaw = compile("Europe/Warsaw", tzdata["europe"])
-        another_warsaw = compile("Europe/Warsaw", tzdata["europe"])
+        warsaw = first(compile("Europe/Warsaw", tzdata["europe"]))
+        another_warsaw = first(compile("Europe/Warsaw", tzdata["europe"]))
 
         @test warsaw == warsaw
         @test warsaw === warsaw
@@ -13,8 +13,8 @@
 
     @testset "links" begin
         # "Arctic/Longyearbyen" is a link to "Europe/Oslo"
-        oslo = compile("Europe/Oslo", tzdata["europe"])
-        longyearbyen = compile("Arctic/Longyearbyen", tzdata["europe"])
+        oslo = first(compile("Europe/Oslo", tzdata["europe"]))
+        longyearbyen = first(compile("Arctic/Longyearbyen", tzdata["europe"]))
 
         @test oslo.name != longyearbyen.name
         @test oslo.transitions == longyearbyen.transitions
@@ -27,7 +27,7 @@
     end
 
     @testset "cutoff differs" begin
-        a = compile("Europe/Warsaw", tzdata["europe"])
+        a = first(compile("Europe/Warsaw", tzdata["europe"]))
         b = VariableTimeZone(a.name, a.transitions, nothing)
 
         @test a.name == b.name

--- a/test/types/variabletimezone.jl
+++ b/test/types/variabletimezone.jl
@@ -10,4 +10,33 @@
         @test isequal(warsaw, another_warsaw)
         @test hash(warsaw) == hash(another_warsaw)
     end
+
+    @testset "links" begin
+        # "Arctic/Longyearbyen" is a link to "Europe/Oslo"
+        oslo = compile("Europe/Oslo", tzdata["europe"])
+        longyearbyen = compile("Arctic/Longyearbyen", tzdata["europe"])
+
+        @test oslo.name != longyearbyen.name
+        @test oslo.transitions == longyearbyen.transitions
+        @test oslo.cutoff == longyearbyen.cutoff
+
+        @test oslo != longyearbyen
+        @test oslo !== longyearbyen
+        @test !isequal(oslo, longyearbyen)
+        @test hash(oslo) != hash(longyearbyen)
+    end
+
+    @testset "cutoff differs" begin
+        a = compile("Europe/Warsaw", tzdata["europe"])
+        b = VariableTimeZone(a.name, a.transitions, nothing)
+
+        @test a.name == b.name
+        @test a.transitions == b.transitions
+        @test a.cutoff != b.cutoff
+
+        @test a == b
+        @test a !== b
+        @test !isequal(a, b)
+        @test hash(a) != hash(b)
+    end
 end

--- a/test/types/zoneddatetime.jl
+++ b/test/types/zoneddatetime.jl
@@ -3,7 +3,7 @@ using Dates: Hour, Second, UTM
 
 @testset "ZonedDateTime" begin
     utc = FixedTimeZone("UTC", 0, 0)
-    warsaw = compile("Europe/Warsaw", tzdata["europe"])
+    warsaw = first(compile("Europe/Warsaw", tzdata["europe"]))
 
     @testset "standard time" begin
         local_dt = DateTime(1916, 2, 1, 0)
@@ -113,7 +113,7 @@ using Dates: Hour, Second, UTM
 
     @testset "2-hour daylight saving time offset" begin
         # Check behaviour when the "save" offset is larger than an hour.
-        paris = compile("Europe/Paris", tzdata["europe"])
+        paris = first(compile("Europe/Paris", tzdata["europe"]))
 
         @test ZonedDateTime(DateTime(1945,4,2,1), paris).zone == FixedTimeZone("WEST", 0, 3600)
         @test_throws NonExistentTimeError ZonedDateTime(DateTime(1945,4,2,2), paris)
@@ -181,7 +181,7 @@ using Dates: Hour, Second, UTM
 
     @testset "skip an entire day" begin
         # Significant offset change: -11:00 -> 13:00.
-        apia = compile("Pacific/Apia", tzdata["australasia"])
+        apia = first(compile("Pacific/Apia", tzdata["australasia"]))
 
         # Skips an entire day.
         @test ZonedDateTime(DateTime(2011,12,29,23),apia).utc_datetime == DateTime(2011,12,30,9)
@@ -221,7 +221,7 @@ using Dates: Hour, Second, UTM
 
     @testset "equality" begin
         # Check equality between ZonedDateTimes
-        apia = compile("Pacific/Apia", tzdata["australasia"])
+        apia = first(compile("Pacific/Apia", tzdata["australasia"]))
 
         spring_utc = ZonedDateTime(DateTime(2010, 5, 1, 12), utc)
         spring_apia = ZonedDateTime(DateTime(2010, 5, 1, 1), apia)
@@ -303,7 +303,7 @@ using Dates: Hour, Second, UTM
     @testset "no cutoff" begin
         # TimeZones that no longer have any transitions after the max_year shouldn't have a cutoff
         # eg. Asia/Hong_Kong, Pacific/Honolulu, Australia/Perth
-        perth = compile("Australia/Perth", tzdata["australasia"])
+        perth = first(compile("Australia/Perth", tzdata["australasia"]))
         zdt = ZonedDateTime(DateTime(2200, 1, 1), perth, from_utc=true)
     end
 

--- a/test/tzdata/compile.jl
+++ b/test/tzdata/compile.jl
@@ -114,7 +114,7 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
 
 @testset "compile" begin
     @testset "Europe/Warsaw" begin
-        tz = compile("Europe/Warsaw", tzdata["europe"])
+        tz = first(compile("Europe/Warsaw", tzdata["europe"]))
 
         # Europe/Warsaw time zone has a combination of factors that requires computing
         # the abbreviation to be done in a specific way.
@@ -158,7 +158,7 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
     # - Zone abbreviation redefined: HST
     # - Is not cutoff
     @testset "Pacific/Honolulu" begin
-        tz = compile("Pacific/Honolulu", tzdata["northamerica"])
+        tz = first(compile("Pacific/Honolulu", tzdata["northamerica"]))
 
         zone = Dict{AbstractString,FixedTimeZone}()
         zone["LMT"] = FixedTimeZone("LMT", -37886, 0)
@@ -186,7 +186,7 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
     # - Changed zone format while in a non-standard transition
     # - Zone abbreviation redefined: LMT, WSST
     @testset "Pacific/Apia" begin
-        tz = compile("Pacific/Apia", tzdata["australasia"])
+        tz = first(compile("Pacific/Apia", tzdata["australasia"]))
 
         zone = Dict{AbstractString,FixedTimeZone}()
         zone["LMT_OLD"] = FixedTimeZone("LMT", 45184, 0)
@@ -215,7 +215,7 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
     # - End of midsummer time also switches both the UTC offset and the saving time
     # - In 1979-01-01 switches from "Spain" to "EU" rules which could create a redundant entry
     @testset "Europe/Madrid" begin
-        tz = compile("Europe/Madrid", tzdata["europe"])
+        tz = first(compile("Europe/Madrid", tzdata["europe"]))
 
         zone = Dict{AbstractString,FixedTimeZone}()
         zone["WET"] = FixedTimeZone("WET", 0, 0)
@@ -244,7 +244,7 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
     #   Alternatives include: Europe/London, Europe/Dublin, and Europe/Moscow.
     # - Observed war/peace time
     @testset "America/Anchorage" begin
-        tz = compile("America/Anchorage", tzdata["northamerica"])
+        tz = first(compile("America/Anchorage", tzdata["northamerica"]))
 
         zone = Dict{AbstractString,FixedTimeZone}()
         zone["CAT"] = FixedTimeZone("CAT", -36000, 0)
@@ -265,7 +265,7 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
     # - With the exception of LMT all Zone and Rule abbreviations are UTC offsets which should
     #   be treated as NULL.
     @testset "Europe/Ulyanovsk" begin
-        ulyanovsk = compile("Europe/Ulyanovsk", tzdata["europe"])
+        ulyanovsk = first(compile("Europe/Ulyanovsk", tzdata["europe"]))
         @test all(t -> string(t.zone.name) == "", ulyanovsk.transitions[2:end])
     end
 
@@ -285,7 +285,7 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
         ]
         tz_source = TZSource(zones, rules, links)
 
-        tz = compile("Pacific/Cutoff", tz_source)
+        tz = first(compile("Pacific/Cutoff", tz_source))
 
         zone = Dict{AbstractString,FixedTimeZone}()
         zone["CUT-1"] = FixedTimeZone("CUT-1", -36000)
@@ -295,7 +295,7 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
         @test tz.transitions[2] == Transition(DateTime(1933,4,1,12), zone["CUT-2"])
         @test tz.cutoff === nothing
 
-        tz = compile("Pacific/Cutoff", tz_source, max_year=1900)
+        tz = first(compile("Pacific/Cutoff", tz_source, max_year=1900))
 
         # Normally compiled TimeZones with a single transition are returned as a
         # FixedTimeZone except when a cutoff is included.
@@ -325,7 +325,7 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
         ]
         tz_source = TZSource(zones, rules, links)
 
-        tz = compile("Pacific/Test", tz_source)
+        tz = first(compile("Pacific/Test", tz_source))
 
         zone = Dict{AbstractString,FixedTimeZone}()
         zone["TST-1"] = FixedTimeZone("TST-1", -36000, 0)
@@ -360,8 +360,8 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
         @test  haskey(tzdata["europe"].links, "Arctic/Longyearbyen")
         @test tzdata["europe"].links["Arctic/Longyearbyen"] == "Europe/Oslo"
 
-        oslo = compile("Europe/Oslo", tzdata["europe"])
-        longyearbyen = compile("Arctic/Longyearbyen", tzdata["europe"])
+        oslo = first(compile("Europe/Oslo", tzdata["europe"]))
+        longyearbyen = first(compile("Arctic/Longyearbyen", tzdata["europe"]))
 
         @test longyearbyen.name != oslo.name
         @test longyearbyen.transitions == oslo.transitions
@@ -370,7 +370,7 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
 
     # Zones that don't include multiple lines and no rules should be treated as a FixedTimeZone.
     @testset "FixedTimeZone" begin
-        tz = compile("MST", tzdata["northamerica"])
+        tz = first(compile("MST", tzdata["northamerica"]))
         @test isa(tz, FixedTimeZone)
     end
 end

--- a/test/tzdata/compile.jl
+++ b/test/tzdata/compile.jl
@@ -356,16 +356,16 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
     # Link  Europe/Oslo  Arctic/Longyearbyen
     @testset "Link" begin
         # Make sure that that the link time zone was parsed.
-        @test !("Arctic/Longyearbyen" in keys(tzdata["europe"].zones))
-        @test "Arctic/Longyearbyen" in keys(tzdata["europe"].links)
+        @test !haskey(tzdata["europe"].zones, "Arctic/Longyearbyen")
+        @test  haskey(tzdata["europe"].links, "Arctic/Longyearbyen")
         @test tzdata["europe"].links["Arctic/Longyearbyen"] == "Europe/Oslo"
 
         oslo = compile("Europe/Oslo", tzdata["europe"])
         longyearbyen = compile("Arctic/Longyearbyen", tzdata["europe"])
 
-        @test longyearbyen != oslo
         @test longyearbyen.name != oslo.name
         @test longyearbyen.transitions == oslo.transitions
+        @test longyearbyen.cutoff == oslo.cutoff
     end
 
     # Zones that don't include multiple lines and no rules should be treated as a FixedTimeZone.

--- a/test/tzfile.jl
+++ b/test/tzfile.jl
@@ -40,7 +40,7 @@ open(joinpath(TZFILE_DIR, "Etc", "GMT-6")) do f
     @test tz == utc_plus_6
 end
 
-warsaw = compile("Europe/Warsaw", tzdata["europe"])
+warsaw = first(compile("Europe/Warsaw", tzdata["europe"]))
 open(joinpath(TZFILE_DIR, "Europe", "Warsaw")) do f
     tz = TimeZones.read_tzfile(f, "Europe/Warsaw")
     @test string(tz) == "Europe/Warsaw"
@@ -74,7 +74,7 @@ open(joinpath(TZFILE_DIR, "Europe", "Warsaw (Version 2)")) do f
 end
 
 
-godthab = compile("America/Godthab", tzdata["europe"])
+godthab = first(compile("America/Godthab", tzdata["europe"]))
 open(joinpath(TZFILE_DIR, "America", "Godthab")) do f
     tz = TimeZones.read_tzfile(f, "America/Godthab")
     @test string(tz) == "America/Godthab"
@@ -109,7 +109,7 @@ end
 # "Pacific/Apia" was the time zone I was thinking could be an issue for the
 # DST calculation. The entire day of 2011/12/30 was skipped when they changed from a
 # -11:00 GMT offset to 13:00 GMT offset
-apia = compile("Pacific/Apia", tzdata["australasia"])
+apia = first(compile("Pacific/Apia", tzdata["australasia"]))
 open(joinpath(TZFILE_DIR, "Pacific", "Apia")) do f
     tz = TimeZones.read_tzfile(f, "Pacific/Apia")
     @test string(tz) == "Pacific/Apia"
@@ -123,7 +123,7 @@ end
 # time then the resulting utc and dst might not be quite right. Most notably during
 # midsomer back in 1940's there were 2 different dst one after another, we get a
 # different utc and dst than Olson.
-paris = compile("Europe/Paris", tzdata["europe"])
+paris = first(compile("Europe/Paris", tzdata["europe"]))
 open(joinpath(TZFILE_DIR, "Europe", "Paris")) do f
     tz = TimeZones.read_tzfile(f, "Europe/Paris")
     @test string(tz) == "Europe/Paris"
@@ -141,7 +141,7 @@ open(joinpath(TZFILE_DIR, "Europe", "Paris")) do f
     @test all(map(issimilar, tz_transitions[neg_mask], paris_transitions[neg_mask]))
 end
 
-madrid = compile("Europe/Madrid", tzdata["europe"])
+madrid = first(compile("Europe/Madrid", tzdata["europe"]))
 open(joinpath(TZFILE_DIR, "Europe", "Madrid")) do f
     tz = TimeZones.read_tzfile(f, "Europe/Madrid")
     @test string(tz) == "Europe/Madrid"
@@ -161,7 +161,7 @@ end
 
 
 # "Australia/Perth" test processing a tzfile that should not contain a cutoff
-perth = compile("Australia/Perth", tzdata["australasia"])
+perth = first(compile("Australia/Perth", tzdata["australasia"]))
 open(joinpath(TZFILE_DIR, "Australia", "Perth")) do f
     tz = TimeZones.read_tzfile(f, "Australia/Perth")
     @test string(tz) == "Australia/Perth"


### PR DESCRIPTION
In order to address https://github.com/JuliaTime/TimeZones.jl/issues/154 we needed to compile the time zones which are included in the "backward"  tz source file. Previously these zones were not included as they are deemed as legacy time zones and should be phased out. As such I've introduced a `Class` type to restrict which time zones are allowed to be created by the `TimeZone` constructor. Doing this allows `localzone` to support both standard and legacy time zones while not allowing legacy time zones by default.

One other big change to note is that `VariableTimeZone`s are considered `==` if the transitions are the same. Previously the name was also required to be the same.

Fixes: https://github.com/JuliaTime/TimeZones.jl/issues/154