### PR TITLE
Define broadcastable for scalars

### DIFF
--- a/src/types/timezone.jl
+++ b/src/types/timezone.jl
@@ -105,3 +105,11 @@ function istimezone(str::AbstractString, mask::Class=Class(:DEFAULT))
 
     return tz !== nothing && mask & class != Class(:NONE)
 end
+
+# After `broadcastable` was defined but before this was addressed in the `Dates` stdlib
+# - Broadcastable introduction: https://github.com/JuliaLang/julia/pull/26601
+# - Fixed in Dates: https://github.com/JuliaLang/julia/pull/30159
+# Note: The change was backported to 1.1 as well.
+if v"0.7.0-DEV.4743" <= VERSION < v"1.1.0-DEV.722" || v"1.2-" <= VERSION < v"1.2.0-DEV.114"
+    Base.broadcastable(tz::TimeZone) = Ref(tz)
+end

--- a/test/types/fixedtimezone.jl
+++ b/test/types/fixedtimezone.jl
@@ -35,4 +35,10 @@
     @test_throws ArgumentError FixedTimeZone("UTC1")
     @test_throws ArgumentError FixedTimeZone("+1")
     @test_throws ArgumentError FixedTimeZone("-2")
+
+    @testset "broadcastable" begin
+        # Validate that FixedTimeZone is treated as a scalar during broadcasting
+        fixed_tz = FixedTimeZone("UTC")
+        @test size(fixed_tz .== fixed_tz) == ()
+    end
 end

--- a/test/types/variabletimezone.jl
+++ b/test/types/variabletimezone.jl
@@ -11,6 +11,13 @@
         @test hash(warsaw) == hash(another_warsaw)
     end
 
+    @testset "broadcastable" begin
+        warsaw = first(compile("Europe/Warsaw", tzdata["europe"]))
+
+        # Validate that VariableTimeZone is treated as a scalar during broadcasting
+        @test size(warsaw .== warsaw) == ()
+    end
+
     @testset "links" begin
         # "Arctic/Longyearbyen" is a link to "Europe/Oslo"
         oslo = first(compile("Europe/Oslo", tzdata["europe"]))

--- a/test/types/zoneddatetime.jl
+++ b/test/types/zoneddatetime.jl
@@ -254,6 +254,12 @@ using Dates: Hour, Second, UTM
         @test hash(astimezone(fall_utc, apia)) == hash(fall_apia)
     end
 
+    @testset "broadcastable" begin
+        # Validate that ZonedDateTime is treated as a scalar during broadcasting
+        zdt = ZonedDateTime(2000, 1, 2, 3, utc)
+        @test size(zdt .== zdt) == ()
+    end
+
     @testset "deepcopy hash" begin
         # Issue #78
         x = ZonedDateTime(2017, 7, 6, 15, 44, 55, 28, warsaw)


### PR DESCRIPTION
Note: `AbstractDateTime` already had this defined.

Fixes: https://github.com/JuliaTime/TimeZones.jl/issues/175