### PR TITLE
Avoid using a redirecting URL

### DIFF
--- a/src/tzdata/download.jl
+++ b/src/tzdata/download.jl
@@ -51,22 +51,23 @@ end
     tzdata_url(version="latest") -> AbstractString
 
 Generates a HTTPS URL for the specified tzdata version. Typical version strings are
-formatted as 4-digit year followed by a lowercase ASCII letter. Available versions can be
-are listed on "ftp://ftp.iana.org/tz/releases/" which start with "tzdata".
+formatted as 4-digit year followed by a lowercase ASCII letter. Available versions start
+with "tzdata" and are listed on "https://data.iana.org/time-zones/releases/" or
+"ftp://ftp.iana.org/tz/releases/".
 
 # Examples
 ```julia
 julia> tzdata_url("2017a")
-"https://www.iana.org/time-zones/repository/releases/tzdata2017a.tar.gz"
+"https://data.iana.org/time-zones/releases/tzdata2017a.tar.gz"
 ```
 """
 function tzdata_url(version::AbstractString="latest")
     # Note: We could also support FTP but the IANA server is unreliable and likely
     # to break if working from behind a firewall.
     if version == "latest"
-        "https://www.iana.org/time-zones/repository/tzdata-latest.tar.gz"
+        "https://data.iana.org/time-zones/tzdata-latest.tar.gz"
     else
-        "https://www.iana.org/time-zones/repository/releases/tzdata$version.tar.gz"
+        "https://data.iana.org/time-zones/releases/tzdata$version.tar.gz"
     end
 end
 

--- a/test/tzdata/download.jl
+++ b/test/tzdata/download.jl
@@ -1,7 +1,7 @@
 import TimeZones.TZData: tzdata_url, tzdata_download, isarchive, LATEST_FILE, read_latest
 
-@test tzdata_url("2016j") == "https://www.iana.org/time-zones/repository/releases/tzdata2016j.tar.gz"
-@test tzdata_url("latest") == "https://www.iana.org/time-zones/repository/tzdata-latest.tar.gz"
+@test tzdata_url("2016j") == "https://data.iana.org/time-zones/releases/tzdata2016j.tar.gz"
+@test tzdata_url("latest") == "https://data.iana.org/time-zones/tzdata-latest.tar.gz"
 
 # Note: Try to keep the number of `tzdata_download` calls low to avoid unnecessary network traffic
 mktempdir() do temp_dir


### PR DESCRIPTION
Should fix: https://github.com/JuliaTime/TimeZones.jl/issues/180

I believe the issue there was that using the redirecting HTTPS URL resulted in the redirection failing. For some reason using HTTP didn't have this problem though. However since "http://data.iana.org/time-zones/releases" redirects to "https://data.iana.org/time-zones/releases" I don't this using HTTP will make a difference.