### PR TITLE
Default to using 2019a tzdata

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,4 +3,4 @@ import TimeZones: build
 # ENV variable allows users to modify the default to be "latest". Do NOT use "latest"
 # as the default here as can make it difficult to debug to past versions of working code.
 # Note: Also allows us to only download a single tzdata version during CI jobs.
-build(get(ENV, "JULIA_TZ_VERSION", "2018i"))
+build(get(ENV, "JULIA_TZ_VERSION", "2019a"))


### PR DESCRIPTION
Release notes: https://mm.icann.org/pipermail/tz-announce/2019-March/000055.html

At the present time there is no windowsZones.xml file update.