### PR TITLE
Use compact element printing

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -92,8 +92,6 @@ function Base.show(io::IO, tz::VariableTimeZone)
 end
 
 function Base.show(io::IO, t::Transition)
-    # Note: Using combo of `:typeinfo` and `:limit` as a way of detecting when a vector of
-    # transitions is being printed in the REPL.
     if get(io, :compact, false) || get(io, :compact_el, false)
         print(io, t)
     else
@@ -103,8 +101,6 @@ function Base.show(io::IO, t::Transition)
 end
 
 function Base.show(io::IO, zdt::ZonedDateTime)
-    # Note: Using combo of `:typeinfo` and `:limit` as a way of detecting when a vector of
-    # ZonedDateTimes is being printed in the REPL.
     if get(io, :compact, false) || get(io, :compact_el, false)
         print(io, zdt)
     else
@@ -133,6 +129,8 @@ Base.show(io::IO, ::MIME"text/plain", zdt::ZonedDateTime) = print(io, zdt)
 # Use compact printing on certain element types
 for T in (:Transition, :ZonedDateTime)
     @eval function Base.show(io::IO, m::MIME"text/plain", X::AbstractArray{$T})
+        # Specify a custom IO context which we can use to perform compact printing of
+        # elements.
         io = IOContext(io, :compact_el => true)
         invoke(show, Tuple{IO, MIME"text/plain", AbstractArray}, io, m, X)
     end

--- a/test/io.jl
+++ b/test/io.jl
@@ -145,7 +145,7 @@ zdt = ZonedDateTime(dt, warsaw)
 
     @testset "REPL vector" begin
         expected_full = string(
-            TimeZones.Transition,
+            Transition,
             "[",
             join(map(t -> sprint(show, t, context=:compact => false), transitions), ", "),
             "]",
@@ -154,13 +154,13 @@ zdt = ZonedDateTime(dt, warsaw)
         # Note: The output here is different from the interactive REPL but is representative
         # of the output.
         expected_repl = string(
-            TimeZones.Transition,
+            Transition,
             "[",
             join(map(t -> sprint(show, t, context=:compact => true), transitions), ", "),
             "]",
         )
 
         @test sprint(show, transitions, context=:compact => false) == expected_full
-        @test sprint(show, transitions; context=:limit => true) == expected_repl
+        @test sprint(show, transitions; context=:compact_el => true) == expected_repl
     end
 end


### PR DESCRIPTION
Fixes an issue where docstring tests were broken in https://github.com/JuliaTime/TimeZones.jl/pull/194 due to `ZonedDateTime` vectors not having compact element printing.

An example of the failing doctest. The `filter` at the end was not using the compact printing

```julia
julia> warsaw = tz"Europe/Warsaw"
Europe/Warsaw (UTC+1/UTC+2)

julia> start = ZonedDateTime(2014, warsaw)
2014-01-01T00:00:00+01:00

julia> stop = ZonedDateTime(2015, warsaw)
2015-01-01T00:00:00+01:00

julia> filter(start:Dates.Hour(1):stop) do d
           Dates.dayofweek(d) == Dates.Wednesday &&
           Dates.hour(d) == 9 &&
           Dates.dayofweekofmonth(d) == 5
       end
5-element Array{ZonedDateTime,1}:
 2014-01-29T09:00:00+01:00
 2014-04-30T09:00:00+02:00
 2014-07-30T09:00:00+02:00
 2014-10-29T09:00:00+01:00
 2014-12-31T09:00:00+01:00
```