### PR TITLE
Doctest failures now cause CI to fail

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -2,10 +2,10 @@
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryProvider]]
-deps = ["Libdl", "Pkg", "SHA", "Test"]
-git-tree-sha1 = "055eb2690182ebc31087859c3dd8598371d3ef9e"
+deps = ["Libdl", "SHA"]
+git-tree-sha1 = "c7361ce8a2129f20b0e05a89f7070820cfed6648"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-version = "0.5.3"
+version = "0.5.4"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
@@ -32,10 +32,10 @@ uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.7.0"
 
 [[Documenter]]
-deps = ["Base64", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "Pkg", "REPL", "Random", "Test", "Unicode"]
-git-tree-sha1 = "e09c7cbf0192113723bc3ba2e736652ede46d516"
+deps = ["Base64", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Unicode"]
+git-tree-sha1 = "38509269fc99a9bc450fdb9e17e805021f3e5b1b"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.22.0"
+version = "0.22.4"
 
 [[EzXML]]
 deps = ["BinaryProvider", "Libdl", "Pkg", "Printf", "Test"]
@@ -124,7 +124,7 @@ uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 deps = ["Dates", "EzXML", "Mocking", "Printf", "Serialization", "Unicode"]
 path = ".."
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
-version = "0.8.5+"
+version = "0.9.0+"
 
 [[UUIDs]]
 deps = ["Random"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
-Documenter = "~0.22"
+Documenter = "~0.22.4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,8 +2,8 @@ using Dates, Documenter, TimeZones
 
 makedocs(
     modules=[TimeZones],
-    format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
-    pages = [
+    format=Documenter.HTML(prettyurls=get(ENV, "CI", nothing) == "true"),
+    pages=[
         "Introduction" => "index.md",
         "Types" => "types.md",
         "Converting" => "conversions.md",


### PR DESCRIPTION
Was an issue with Documenter which was fixed in version 0.22.4: https://github.com/JuliaDocs/Documenter.jl/pull/1014

Closes: https://github.com/JuliaTime/TimeZones.jl/issues/196