### PR TITLE
Fix UndefVarError in validargs

### DIFF
--- a/src/types/zoneddatetime.jl
+++ b/src/types/zoneddatetime.jl
@@ -116,9 +116,13 @@ end
     ZonedDateTime(DateTime(y,m,d,h,mi,s,ms), tz)
 end
 
-# Parsing constructor. Note we typically don't support passing in time zone information as a
-# string since we cannot do not know if we need to support resolving ambiguity.
-# Month Union issue: https://github.com/JuliaTime/TimeZones.jl/issues/187#issuecomment-473012078
+# Parsing constructor needed as part of the Dates parsing interface. Note we typically don't
+# support passing in time zone information as a string since we cannot do not know if we
+# need to support resolving ambiguity.
+#
+# Since we do not want users accidentially calling this function we'll use very specific
+# type assertions:
+# https://github.com/JuliaTime/TimeZones.jl/issues/187#issuecomment-473012078
 function ZonedDateTime(y::Int64, m::Union{Int32, Int64}, d::Int64, h::Int64, mi::Int64, s::Int64, ms::Int64, tz::AbstractString)
     ZonedDateTime(DateTime(y,m,d,h,mi,s,ms), TimeZone(tz))
 end
@@ -171,8 +175,9 @@ end
 Base.typemin(::Type{ZonedDateTime}) = ZonedDateTime(typemin(DateTime), utc_tz; from_utc=true)
 Base.typemax(::Type{ZonedDateTime}) = ZonedDateTime(typemax(DateTime), utc_tz; from_utc=true)
 
-function Dates.validargs(::Type{ZonedDateTime}, y::Int64, m::Int64, d::Int64, h::Int64, mi::Int64, s::Int64, ms::Int64, tz::AbstractString)
-    err = validargs(DateTime, y, m, d, h, mi, s, ms)
+# Note: The `validargs` function is as part of the Dates parsing interface.
+function Dates.validargs(::Type{ZonedDateTime}, y::Int64, m::Union{Int64, Int32}, d::Int64, h::Int64, mi::Int64, s::Int64, ms::Int64, tz::AbstractString)
+    err = validargs(DateTime, y, Int64(m), d, h, mi, s, ms)
     err === nothing || return err
     istimezone(tz) || return argerror("TimeZone: \"$tz\" is not a recognized time zone")
     return argerror()

--- a/src/types/zoneddatetime.jl
+++ b/src/types/zoneddatetime.jl
@@ -174,6 +174,6 @@ Base.typemax(::Type{ZonedDateTime}) = ZonedDateTime(typemax(DateTime), utc_tz; f
 function Dates.validargs(::Type{ZonedDateTime}, y::Int64, m::Int64, d::Int64, h::Int64, mi::Int64, s::Int64, ms::Int64, tz::AbstractString)
     err = validargs(DateTime, y, m, d, h, mi, s, ms)
     err === nothing || return err
-    istimezone(tz) || return argerror("TimeZone: \"$str\" is not a recognized time zone")
+    istimezone(tz) || return argerror("TimeZone: \"$tz\" is not a recognized time zone")
     return argerror()
 end

--- a/test/types/zoneddatetime.jl
+++ b/test/types/zoneddatetime.jl
@@ -6,40 +6,70 @@ using Dates: Hour, Second, UTM, @dateformat_str
     warsaw = first(compile("Europe/Warsaw", tzdata["europe"]))
 
     @testset "dateformat parsing" begin
-        # Make sure all dateformat codes parse correctly
-        # yYmuUdHMSseEzZ and yyyymmdd
-        zdt = ZonedDateTime(1, 2, 3, 4, 5, 6, 7, utc)
-        # Test y, u, d, H, M, S, s, Z
-        p_zdt = parse(
-            ZonedDateTime,
-            "Feb 3 1, 4:5:6.007 UTC",
-            dateformat"u d y, H:M:S.s Z",
-        )
-        @test zdt == p_zdt
+        @testset "successful parsing: $f" for f in (parse, tryparse)
+            # Make sure all dateformat codes parse correctly
+            # yYmuUdHMSseEzZ and yyyymmdd
+            zdt = ZonedDateTime(1, 2, 3, 4, 5, 6, 7, utc)
+            # Test y, u, d, H, M, S, s, Z
+            p_zdt = f(
+                ZonedDateTime,
+                "Feb 3 1, 4:5:6.007 UTC",
+                dateformat"u d y, H:M:S.s Z",
+            )
+            @test zdt == p_zdt
 
-        # Test m, e, Y, z
-        p_zdt = parse(
-            ZonedDateTime,
-            "2 mon 3 1, 4:5:6.007+00:00",
-            dateformat"m e d Y, H:M:S.s+z",
-        )
-        @test zdt == p_zdt
+            # Test m, e, Y, z
+            p_zdt = f(
+                ZonedDateTime,
+                "2 mon 3 1, 4:5:6.007+00:00",
+                dateformat"m e d Y, H:M:S.s+z",
+            )
+            @test zdt == p_zdt
 
-        # Test E, U
-        p_zdt = parse(
-            ZonedDateTime,
-            "February Monday 3 1 4:5:6.007 UTC",
-            dateformat"U E d y H:M:S.s Z",
-        )
-        @test zdt == p_zdt
+            # Test E, U
+            p_zdt = f(
+                ZonedDateTime,
+                "February Monday 3 1 4:5:6.007 UTC",
+                dateformat"U E d y H:M:S.s Z",
+            )
+            @test zdt == p_zdt
 
-        # Test yyyymmdd
-        p_zdt = parse(
-            ZonedDateTime,
-            "00010203 4:5:6.007 UTC",
-            dateformat"yyyymmdd H:M:S.s Z",
-        )
-        @test zdt == p_zdt
+            # Test yyyymmdd
+            p_zdt = f(
+                ZonedDateTime,
+                "00010203 4:5:6.007 UTC",
+                dateformat"yyyymmdd H:M:S.s Z",
+            )
+            @test zdt == p_zdt
+        end
+
+        @testset "failed parsing: parse" begin
+            @test_throws ArgumentError parse(
+                ZonedDateTime,
+                "2015-07-29 11:12:13.456 FakeTZ",
+                dateformat"yyyy-mm-dd HH:MM:SS.sss Z",
+            )
+
+            @test_throws ArgumentError parse(
+                ZonedDateTime,
+                "2015-07-29 11:12:13.456",
+                dateformat"yyyy-mm-dd HH:MM:SS.sss Z",
+            )
+        end
+
+        @testset "failed parsing: tryparse" begin
+            @test tryparse(
+                ZonedDateTime,
+                "2015-07-29 11:12:13.456 FakeTZ",
+                dateformat"yyyy-mm-dd HH:MM:SS.sss Z",
+            ) === nothing
+
+            @test tryparse(
+                ZonedDateTime,
+                "2015-07-29 11:12:13.456",
+                dateformat"yyyy-mm-dd HH:MM:SS.sss Z",
+            ) === nothing
+        end
     end
 
     @testset "standard time" begin


### PR DESCRIPTION
Error which was fixed:

```
  UndefVarError: str not defined
  Stacktrace:
   [1] validargs(::Type{ZonedDateTime}, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::String) at /Users/ericdavies/.julia/packages/TimeZones/Z0kpK/src/types/zoneddatetime.jl:177
   [2] tryparse(::Type{ZonedDateTime}, ::String, ::DateFormat{Symbol("yyyy-mm-dd HH:MM:SS.sss Z"),Tuple{Dates.DatePart{'y'},Dates.Delim{Char,1},Dates.DatePart{'m'},Dates.Delim{Char,1},Dates.DatePart{'d'},Dates.Delim{Char,1},Dates.DatePart{'H'},Dates.Delim{Char,1},Dates.DatePart{'M'},Dates.Delim{Char,1},Dates.DatePart{'S'},Dates.Delim{Char,1},Dates.DatePart{'s'},Dates.Delim{Char,1},Dates.DatePart{'Z'}}}) at /Users/ericdavies/repos/julia1p1/usr/share/julia/stdlib/v1.1/Dates/src/parse.jl:293
```

For some reason this only happened when _no_ time zone was present, and not when an invalid time zone was present. But AFAICT neither case was being tested.