### PR TITLE
Default to using 2019c tzdata

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,4 +3,4 @@ import TimeZones: build
 # ENV variable allows users to modify the default to be "latest". Do NOT use "latest"
 # as the default here as can make it difficult to debug to past versions of working code.
 # Note: Also allows us to only download a single tzdata version during CI jobs.
-build(get(ENV, "JULIA_TZ_VERSION", "2019b"))
+build(get(ENV, "JULIA_TZ_VERSION", "2019c"))


### PR DESCRIPTION
Release notes: https://mm.icann.org/pipermail/tz-announce/2019-September/000057.html

At the present time there is no [windowsZones.xml](https://github.com/unicode-org/cldr/blob/master/common/supplemental/windowsZones.xml) file update.