### PR TITLE
trailing 'Z' support

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -1,6 +1,8 @@
 using Dates: DateFormat, DatePart, min_width, max_width
 
 function tryparsenext_fixedtz(str, i, len, min_width::Int=1, max_width::Int=0)
+    i == len && str[i] == 'Z' && return ("Z", i+1)
+
     tz_start, tz_end = i, 0
     min_pos = min_width <= 0 ? i : i + min_width - 1
     max_pos = max_width <= 0 ? len : min(chr2ind(str, ind2chr(str,i) + max_width - 1), len)

--- a/src/types/fixedtimezone.jl
+++ b/src/types/fixedtimezone.jl
@@ -1,5 +1,7 @@
 const FIXED_TIME_ZONE_REGEX = r"""
     ^(?|
+        Z
+    |
         UTC
         (?:
             (?<sign>[+-])
@@ -46,6 +48,9 @@ function FixedTimeZone(name::AbstractString, utc_offset::Second, dst_offset::Sec
     FixedTimeZone(name, UTCOffset(utc_offset, dst_offset))
 end
 
+# https://en.wikipedia.org/wiki/ISO_8601#Coordinated_Universal_Time_(UTC)
+const UTC_ZERO = FixedTimeZone("Z", 0)
+
 """
     FixedTimeZone(::AbstractString) -> FixedTimeZone
 
@@ -65,6 +70,8 @@ UTC+15:45:21
 ```
 """
 function FixedTimeZone(s::AbstractString)
+    s == "Z" && return UTC_ZERO
+
     m = match(FIXED_TIME_ZONE_REGEX, s)
     m === nothing && throw(ArgumentError("Unrecognized time zone: $s"))
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -58,6 +58,10 @@ end
         ZonedDateTime(2000, 1, 2, 3, 4, 5, 6, tz"UTC+07")
     )
     @test isequal(
+        ZonedDateTime("2000-01-02T03:04:05.006Z"),
+        ZonedDateTime(2000, 1, 2, 3, 4, 5, 6, tz"UTC+00")
+    )
+    @test isequal(
         ZonedDateTime("2018-11-01-0600", dateformat"yyyy-mm-ddzzzz"),
         ZonedDateTime(2018, 11, 1, tz"UTC-06"),
     )


### PR DESCRIPTION
`ZonedDateTime("2019-11-01T15:09:13.978Z")` now throws

trailing `Z` should be equivalent to `+00:00`