### PR TITLE
Improve messaging when TimeZones fails to build

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,3 @@
-import TimeZones: build
+using TimeZones: build
 
-# ENV variable allows users to modify the default to be "latest". Do NOT use "latest"
-# as the default here as can make it difficult to debug to past versions of working code.
-# Note: Also allows us to only download a single tzdata version during CI jobs.
-build(get(ENV, "JULIA_TZ_VERSION", "2019c"))
+build()

--- a/src/build.jl
+++ b/src/build.jl
@@ -1,11 +1,13 @@
+using TimeZones.TZData: DEFAULT_TZDATA_VERSION, tzdata_version
+
 """
-    build(version="latest"; force=false) -> Nothing
+    build(version="$DEFAULT_TZDATA_VERSION"; force=false) -> Nothing
 
 Builds the TimeZones package with the specified tzdata `version` and `regions`. The
-`version` is typically a 4-digit year followed by a lowercase ASCII letter (e.g. "2016j").
-The `force` flag is used to re-download tzdata archives.
+`version` is typically a 4-digit year followed by a lowercase ASCII letter
+(e.g. "$DEFAULT_TZDATA_VERSION"). The `force` flag is used to re-download tzdata archives.
 """
-function build(version::AbstractString="latest"; force::Bool=false)
+function build(version::AbstractString=tzdata_version(); force::Bool=false)
     TimeZones.TZData.build(version)
 
     if Sys.iswindows()

--- a/src/types/timezone.jl
+++ b/src/types/timezone.jl
@@ -50,6 +50,12 @@ function TimeZone(str::AbstractString, mask::Class=Class(:DEFAULT))
             open(deserialize, tz_path, "r")
         elseif occursin(FIXED_TIME_ZONE_REGEX, str)
             FixedTimeZone(str), Class(:FIXED)
+        elseif !isdir(TZData.COMPILED_DIR) || isempty(readdir(TZData.COMPILED_DIR))
+            # Note: Julia 1.0 supresses the build logs which can hide issues in time zone
+            # compliation which result in no tzdata time zones being available.
+            throw(ArgumentError(
+                "Unable to find time zone \"$str\". Try running `TimeZones.build()`."
+            ))
         else
             throw(ArgumentError("Unknown time zone \"$str\""))
         end

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -68,7 +68,7 @@ function build(
     return version
 end
 
-function build(version::AbstractString="latest")
+function build(version::AbstractString=tzdata_version())
     isdir(ARCHIVE_DIR) || mkdir(ARCHIVE_DIR)
     isdir(TZ_SOURCE_DIR) || mkdir(TZ_SOURCE_DIR)
     isdir(COMPILED_DIR) || mkdir(COMPILED_DIR)

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -55,7 +55,7 @@ function build(
     end
 
     if !isempty(tz_source_dir)
-        @info "Extracting tzdata archive"
+        @info "Extracting $version tzdata archive"
         extract(archive, tz_source_dir, setdiff(regions, CUSTOM_REGIONS), verbose=verbose)
     end
 

--- a/src/tzdata/version.jl
+++ b/src/tzdata/version.jl
@@ -1,3 +1,10 @@
+# Default tzdata version to use if the environmental variable "JULIA_TZ_VERSION" is not set.
+# We want to use a specific version here to ensure that specific revisions of the
+# TimeZones.jl package always use the same revision of tzdata. Doing so ensure that we can
+# always use older revisions of this package and always reproduce the same results.
+const DEFAULT_TZDATA_VERSION = "2019c"  # Do not use floating revision "latest" here
+
+
 # Note: A tz code or data version consists of a year and letter while a release consists of
 # a pair of tz code and data versions. In recent releases the tz code and data use the same
 # version.
@@ -23,6 +30,7 @@ const TZDATA_NEWS_REGEX = r"""
 """x
 
 const ACTIVE_VERSION_FILE = joinpath(DEPS_DIR, "active_version")
+
 
 """
     read_news(news, [limit]) -> Vector{AbstractString}
@@ -88,6 +96,8 @@ function tzdata_version_archive(archive::AbstractString)
         tzdata_version_dir(temp_dir)
     end
 end
+
+tzdata_version() = get(ENV, "JULIA_TZ_VERSION", DEFAULT_TZDATA_VERSION)
 
 function active_version()
     if !isfile(ACTIVE_VERSION_FILE)


### PR DESCRIPTION
Avoid confusing users with:
```
ERROR: InitError: ArgumentError: Unknown time zone "Europe/London"
```
which is usually caused from a failed build. Unfortunately Julia 1.0 hides the log messages which makes it very non-obvious what is going on.