### PR TITLE
Date <-> ZonedDateTime

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeZones"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 authors = ["Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "0.10.5"
+version = "0.11.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/src/api-public.md
+++ b/docs/src/api-public.md
@@ -34,9 +34,12 @@ ZonedDateTime(::DateTime, ::VariableTimeZone, ::Integer)
 ZonedDateTime(::DateTime, ::VariableTimeZone, ::Bool)
 astimezone
 TimeZones.timezone(::ZonedDateTime)
-TimeZones.utc
-TimeZones.localtime
-DateTime(::ZonedDateTime)
+DateTime(::ZonedDateTime, ::Type{Local})
+DateTime(::ZonedDateTime, ::Type{UTC})
+Date(::ZonedDateTime, ::Type{Local})
+Date(::ZonedDateTime, ::Type{UTC})
+Time(::ZonedDateTime, ::Type{Local})
+Time(::ZonedDateTime, ::Type{UTC})
 ```
 
 ## Current Time

--- a/docs/src/api-public.md
+++ b/docs/src/api-public.md
@@ -34,12 +34,9 @@ ZonedDateTime(::DateTime, ::VariableTimeZone, ::Integer)
 ZonedDateTime(::DateTime, ::VariableTimeZone, ::Bool)
 astimezone
 TimeZones.timezone(::ZonedDateTime)
-DateTime(::ZonedDateTime, ::Type{Local})
-DateTime(::ZonedDateTime, ::Type{UTC})
-Date(::ZonedDateTime, ::Type{Local})
-Date(::ZonedDateTime, ::Type{UTC})
-Time(::ZonedDateTime, ::Type{Local})
-Time(::ZonedDateTime, ::Type{UTC})
+DateTime(::ZonedDateTime, ::Union{Type{Local}, Type{UTC}})
+Date(::ZonedDateTime, ::Union{Type{Local}, Type{UTC}})
+Time(::ZonedDateTime, ::Union{Type{Local}, Type{UTC}})
 ```
 
 ## Current Time

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -4,10 +4,12 @@ using Dates
 using Printf
 using Serialization
 using Unicode
-import Dates: TimeZone
+
+import Dates: TimeZone, UTC
 
 export TimeZone, @tz_str, istimezone, FixedTimeZone, VariableTimeZone, ZonedDateTime,
-    DateTime, TimeError, AmbiguousTimeError, NonExistentTimeError, UnhandledTimeError,
+    DateTime, Date, Time, UTC, Local, TimeError, AmbiguousTimeError, NonExistentTimeError,
+    UnhandledTimeError,
     # discovery.jl
     timezone_names, all_timezones, timezones_from_abbr, timezone_abbrs,
     next_transition_instant, show_next_transition,

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -1,34 +1,18 @@
 using Dates: Hour, Minute, Second, Millisecond, days, hour, minute, second, millisecond
 
 """
-    localtime(::ZonedDateTime) -> DateTime
-
-Creates a local or civil `DateTime` from the given `ZonedDateTime`. For example the
-`2014-05-30T08:11:24-04:00` would return `2014-05-30T08:11:24`.
-"""
-localtime(zdt::ZonedDateTime) = zdt.utc_datetime + zdt.zone.offset
-
-"""
-    utc(::ZonedDateTime) -> DateTime
-
-Creates a utc `DateTime` from the given `ZonedDateTime`. For example the
-`2014-05-30T08:11:24-04:00` would return `2014-05-30T12:11:24`.
-"""
-utc(zdt::ZonedDateTime) = zdt.utc_datetime
-
-"""
     timezone(::ZonedDateTime) -> TimeZone
 
 Returns the `TimeZone` used by the `ZonedDateTime`.
 """
 timezone(zdt::ZonedDateTime) = zdt.timezone
 
-Dates.days(zdt::ZonedDateTime) = days(localtime(zdt))
+Dates.days(zdt::ZonedDateTime) = days(DateTime(zdt, Local))
 
 for period in (:Hour, :Minute, :Second, :Millisecond)
     accessor = Symbol(lowercase(string(period)))
     @eval begin
-        Dates.$accessor(zdt::ZonedDateTime) = $accessor(localtime(zdt))
+        Dates.$accessor(zdt::ZonedDateTime) = $accessor(DateTime(zdt, Local))
         Dates.$period(zdt::ZonedDateTime) = $period($accessor(zdt))
     end
 end

--- a/src/adjusters.jl
+++ b/src/adjusters.jl
@@ -6,10 +6,10 @@ using Dates: DatePeriod, TimePeriod, firstdayofweek, lastdayofweek,
 # Truncation
 # TODO: Just utilize floor code for truncation?
 function Base.trunc(zdt::ZonedDateTime, ::Type{P}) where P <: DatePeriod
-    ZonedDateTime(trunc(localtime(zdt), P), timezone(zdt))
+    ZonedDateTime(trunc(DateTime(zdt, Local), P), timezone(zdt))
 end
 function Base.trunc(zdt::ZonedDateTime, ::Type{P}) where P <: TimePeriod
-    local_dt = trunc(localtime(zdt), P)
+    local_dt = trunc(DateTime(zdt, Local), P)
     utc_dt = local_dt - zdt.zone.offset
     ZonedDateTime(utc_dt, timezone(zdt); from_utc=true)
 end
@@ -18,7 +18,7 @@ Base.trunc(zdt::ZonedDateTime, ::Type{Millisecond}) = zdt
 # Adjusters
 for prefix in ("firstdayof", "lastdayof"), suffix in ("week", "month", "year", "quarter")
     func = Symbol(prefix * suffix)
-    @eval begin
-        Dates.$func(dt::ZonedDateTime) = ZonedDateTime($func(localtime(dt)), dt.timezone)
+    @eval function Dates.$func(zdt::ZonedDateTime)
+        ZonedDateTime($func(DateTime(zdt, Local)), zdt.timezone)
     end
 end

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -5,35 +5,35 @@ Base.:(+)(x::ZonedDateTime) = x
 Base.:(-)(x::ZonedDateTime, y::ZonedDateTime) = x.utc_datetime - y.utc_datetime
 
 function Base.:(+)(zdt::ZonedDateTime, p::DatePeriod)
-    return ZonedDateTime(localtime(zdt) + p, timezone(zdt))
+    return ZonedDateTime(DateTime(zdt, Local) + p, timezone(zdt))
 end
 function Base.:(+)(zdt::ZonedDateTime, p::TimePeriod)
-    return ZonedDateTime(zdt.utc_datetime + p, timezone(zdt); from_utc=true)
+    return ZonedDateTime(DateTime(zdt, UTC) + p, timezone(zdt); from_utc=true)
 end
 function Base.:(-)(zdt::ZonedDateTime, p::DatePeriod)
-    return ZonedDateTime(localtime(zdt) - p, timezone(zdt))
+    return ZonedDateTime(DateTime(zdt, Local) - p, timezone(zdt))
 end
 function Base.:(-)(zdt::ZonedDateTime, p::TimePeriod)
-    return ZonedDateTime(zdt.utc_datetime - p, timezone(zdt); from_utc=true)
+    return ZonedDateTime(DateTime(zdt, UTC) - p, timezone(zdt); from_utc=true)
 end
 
 function broadcasted(::typeof(+), r::StepRange{ZonedDateTime}, p::DatePeriod)
     start, step, stop = first(r), Base.step(r), last(r)
 
-    # Since the localtime + period can result in an invalid local datetime when working with
+    # Since the local time + period can result in an invalid local datetime when working with
     # VariableTimeZones we will use `first_valid` and `last_valid` which avoids issues with
     # non-existent and ambiguous dates.
 
     tz = timezone(start)
     if isa(tz, VariableTimeZone)
-        start = first_valid(localtime(start) + p, tz, step)
+        start = first_valid(DateTime(start, Local) + p, tz, step)
     else
         start = start + p
     end
 
     tz = timezone(stop)
     if isa(tz, VariableTimeZone)
-        stop = last_valid(localtime(stop) + p, tz, step)
+        stop = last_valid(DateTime(stop, Local) + p, tz, step)
     else
         stop = stop + p
     end

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -5,9 +5,9 @@ using Mocking: Mocking, @mock
 const utc_tz = FixedTimeZone("UTC")
 
 """
-    DateTime(::ZonedDateTime, ::Type{Local}) -> DateTime
+    DateTime(zdt::ZonedDateTime, ::Union{Type{Local}, Type{UTC}}) -> DateTime
 
-Create an implicit local time `DateTime` from the given `ZonedDateTime`.
+Create an implicit local/UTC `DateTime` from the given `ZonedDateTime`.
 
 # Example
 
@@ -17,33 +17,21 @@ julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
 
 julia> DateTime(zdt, Local)
 2014-05-30T21:00:00
-```
-"""
-Dates.DateTime(zdt::ZonedDateTime, ::Type{Local}) = zdt.utc_datetime + zdt.zone.offset
-
-
-"""
-    DateTime(::ZonedDateTime, ::Type{UTC}) -> DateTime
-
-Create an implicit utc `DateTime` from the given `ZonedDateTime`.
-
-# Example
-
-```jldoctest
-julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
-2014-05-30T21:00:00-04:00
 
 julia> DateTime(zdt, UTC)
 2014-05-31T01:00:00
 ```
 """
+DateTime(::ZonedDateTime, ::Union{Type{Local}, Type{UTC}})
+
+Dates.DateTime(zdt::ZonedDateTime, ::Type{Local}) = zdt.utc_datetime + zdt.zone.offset
 Dates.DateTime(zdt::ZonedDateTime, ::Type{UTC}) = zdt.utc_datetime
 
 
 """
-    Date(::ZonedDateTime, ::Type{Local}) -> DateTime
+    Date(zdt::ZonedDateTime, ::Union{Type{Local}, Type{UTC}}) -> Date
 
-Create an implicit local time `Date` from the given `ZonedDateTime`.
+Create an implicit local/UTC `Date` from the given `ZonedDateTime`.
 
 # Example
 
@@ -53,33 +41,21 @@ julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
 
 julia> Date(zdt, Local)
 2014-05-30
-```
-"""
-Dates.Date(zdt::ZonedDateTime, ::Type{Local}) = Date(DateTime(zdt, Local))
-
-
-"""
-    Date(::ZonedDateTime, ::Type{UTC}) -> DateTime
-
-Create an implicit utc `Date` from the given `ZonedDateTime`.
-
-# Example
-
-```jldoctest
-julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
-2014-05-30T21:00:00-04:00
 
 julia> Date(zdt, UTC)
 2014-05-31
 ```
 """
+Date(::ZonedDateTime, ::Union{Type{Local}, Type{UTC}})
+
+Dates.Date(zdt::ZonedDateTime, ::Type{Local}) = Date(DateTime(zdt, Local))
 Dates.Date(zdt::ZonedDateTime, ::Type{UTC}) = Date(DateTime(zdt, UTC))
 
 
 """
-    Time(::ZonedDateTime, ::Type{Local}) -> Time
+    Time(zdt::ZonedDateTime, ::Union{Type{Local}, Type{UTC}}) -> Time
 
-Create an implicit local `Time` from the given `ZonedDateTime`.
+Create an implicit local/UTC `Time` from the given `ZonedDateTime`.
 
 # Example
 
@@ -89,26 +65,14 @@ julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
 
 julia> Time(zdt, Local)
 21:00:00
-```
-"""
-Dates.Time(zdt::ZonedDateTime, ::Type{Local}) = Time(DateTime(zdt, Local))
-
-
-"""
-    Time(::ZonedDateTime, ::Type{UTC}) -> DateTime
-
-Create an implicit utc `Time` from the given `ZonedDateTime`.
-
-# Example
-
-```jldoctest
-julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
-2014-05-30T21:00:00-04:00
 
 julia> Time(zdt, UTC)
 01:00:00
 ```
 """
+Time(::ZonedDateTime, ::Union{Type{Local}, Type{UTC}})
+
+Dates.Time(zdt::ZonedDateTime, ::Type{Local}) = Time(DateTime(zdt, Local))
 Dates.Time(zdt::ZonedDateTime, ::Type{UTC}) = Time(DateTime(zdt, UTC))
 
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -5,18 +5,111 @@ using Mocking: Mocking, @mock
 const utc_tz = FixedTimeZone("UTC")
 
 """
-    DateTime(::ZonedDateTime) -> DateTime
+    DateTime(::ZonedDateTime, ::Type{Local}) -> DateTime
 
-Returns an equivalent `DateTime` without any `TimeZone` information.
+Create an implicit local time `DateTime` from the given `ZonedDateTime`.
+
+# Example
+
+```jldoctest
+julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
+2014-05-30T21:00:00-04:00
+
+julia> DateTime(zdt, Local)
+2014-05-30T21:00:00
+```
 """
-DateTime(zdt::ZonedDateTime) = localtime(zdt)
+Dates.DateTime(zdt::ZonedDateTime, ::Type{Local}) = zdt.utc_datetime + zdt.zone.offset
+
 
 """
-    Date(::ZonedDateTime) -> Date
+    DateTime(::ZonedDateTime, ::Type{UTC}) -> DateTime
 
-Returns an equivalent `Date` without any `TimeZone`, or time information.
+Create an implicit utc `DateTime` from the given `ZonedDateTime`.
+
+# Example
+
+```jldoctest
+julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
+2014-05-30T21:00:00-04:00
+
+julia> DateTime(zdt, UTC)
+2014-05-31T01:00:00
+```
 """
-Dates.Date(zdt::ZonedDateTime) = Date(DateTime(zdt))
+Dates.DateTime(zdt::ZonedDateTime, ::Type{UTC}) = zdt.utc_datetime
+
+
+"""
+    Date(::ZonedDateTime, ::Type{Local}) -> DateTime
+
+Create an implicit local time `Date` from the given `ZonedDateTime`.
+
+# Example
+
+```jldoctest
+julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
+2014-05-30T21:00:00-04:00
+
+julia> Date(zdt, Local)
+2014-05-30
+```
+"""
+Dates.Date(zdt::ZonedDateTime, ::Type{Local}) = Date(DateTime(zdt, Local))
+
+
+"""
+    Date(::ZonedDateTime, ::Type{UTC}) -> DateTime
+
+Create an implicit utc `Date` from the given `ZonedDateTime`.
+
+# Example
+
+```jldoctest
+julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
+2014-05-30T21:00:00-04:00
+
+julia> Date(zdt, UTC)
+2014-05-31
+```
+"""
+Dates.Date(zdt::ZonedDateTime, ::Type{UTC}) = Date(DateTime(zdt, UTC))
+
+
+"""
+    Time(::ZonedDateTime, ::Type{Local}) -> Time
+
+Create an implicit local `Time` from the given `ZonedDateTime`.
+
+# Example
+
+```jldoctest
+julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
+2014-05-30T21:00:00-04:00
+
+julia> Time(zdt, Local)
+21:00:00
+```
+"""
+Dates.Time(zdt::ZonedDateTime, ::Type{Local}) = Time(DateTime(zdt, Local))
+
+
+"""
+    Time(::ZonedDateTime, ::Type{UTC}) -> DateTime
+
+Create an implicit utc `Time` from the given `ZonedDateTime`.
+
+# Example
+
+```jldoctest
+julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
+2014-05-30T21:00:00-04:00
+
+julia> Time(zdt, UTC)
+01:00:00
+```
+"""
+Dates.Time(zdt::ZonedDateTime, ::Type{UTC}) = Time(DateTime(zdt, UTC))
 
 
 """
@@ -47,7 +140,7 @@ julia> today(tz"Pacific/Midway"), today(tz"Pacific/Apia")
 (2017-11-09, 2017-11-10)
 ```
 """
-Dates.today(tz::TimeZone) = Date(localtime(now(tz)))
+Dates.today(tz::TimeZone) = Date(now(tz), Local)
 
 """
     todayat(tod::Time, tz::TimeZone, [amb]) -> ZonedDateTime
@@ -86,7 +179,7 @@ function astimezone(zdt::ZonedDateTime, tz::VariableTimeZone)
     )
 
     if i == 0
-        throw(NonExistentTimeError(localtime(zdt), tz))
+        throw(NonExistentTimeError(DateTime(zdt, Local), tz))
     end
 
     zone = tz.transitions[i].zone
@@ -98,15 +191,15 @@ function astimezone(zdt::ZonedDateTime, tz::FixedTimeZone)
 end
 
 function zdt2julian(zdt::ZonedDateTime)
-    datetime2julian(utc(zdt))
+    datetime2julian(DateTime(zdt, UTC))
 end
 
 function zdt2julian(::Type{T}, zdt::ZonedDateTime) where T<:Integer
-    floor(T, datetime2julian(utc(zdt)))
+    floor(T, datetime2julian(DateTime(zdt, UTC)))
 end
 
 function zdt2julian(::Type{T}, zdt::ZonedDateTime) where T<:Real
-    convert(T, datetime2julian(utc(zdt)))
+    convert(T, datetime2julian(DateTime(zdt, UTC)))
 end
 
 function julian2zdt(jd::Real)
@@ -114,15 +207,15 @@ function julian2zdt(jd::Real)
 end
 
 function zdt2unix(zdt::ZonedDateTime)
-    datetime2unix(utc(zdt))
+    datetime2unix(DateTime(zdt, UTC))
 end
 
 function zdt2unix(::Type{T}, zdt::ZonedDateTime) where T<:Integer
-    floor(T, datetime2unix(utc(zdt)))
+    floor(T, datetime2unix(DateTime(zdt, UTC)))
 end
 
 function zdt2unix(::Type{T}, zdt::ZonedDateTime) where T<:Real
-    convert(T, datetime2unix(utc(zdt)))
+    convert(T, datetime2unix(DateTime(zdt, UTC)))
 end
 
 function unix2zdt(seconds::Real)

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -12,6 +12,14 @@ Returns an equivalent `DateTime` without any `TimeZone` information.
 DateTime(zdt::ZonedDateTime) = localtime(zdt)
 
 """
+    Date(::ZonedDateTime) -> Date
+
+Returns an equivalent `Date` without any `TimeZone`, or time information.
+"""
+Dates.Date(zdt::ZonedDateTime) = Date(DateTime(zdt))
+
+
+"""
     now(::TimeZone) -> ZonedDateTime
 
 Returns a `ZonedDateTime` corresponding to the user's system time in the specified `TimeZone`.

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -7,7 +7,9 @@ const utc_tz = FixedTimeZone("UTC")
 """
     DateTime(zdt::ZonedDateTime, ::Union{Type{Local}, Type{UTC}}) -> DateTime
 
-Create an implicit local/UTC `DateTime` from the given `ZonedDateTime`.
+Create a `DateTime` which is implicitly associated with a time zone. The result can be
+specified to either be in `UTC` or `Local` (relative to the provided `ZonedDateTime` and not
+user's system time zone).
 
 # Example
 
@@ -31,7 +33,9 @@ Dates.DateTime(zdt::ZonedDateTime, ::Type{UTC}) = zdt.utc_datetime
 """
     Date(zdt::ZonedDateTime, ::Union{Type{Local}, Type{UTC}}) -> Date
 
-Create an implicit local/UTC `Date` from the given `ZonedDateTime`.
+Create a `Date` which is implicitly associated with a time zone. The result can be
+specified to either be in `UTC` or `Local` (relative to the provided `ZonedDateTime` and not
+user's system time zone).
 
 # Example
 
@@ -55,7 +59,9 @@ Dates.Date(zdt::ZonedDateTime, ::Type{UTC}) = Date(DateTime(zdt, UTC))
 """
     Time(zdt::ZonedDateTime, ::Union{Type{Local}, Type{UTC}}) -> Time
 
-Create an implicit local/UTC `Time` from the given `ZonedDateTime`.
+Create a `Time` which is implicitly associated with a time zone. The result can be
+specified to either be in `UTC` or `Local` (relative to the provided `ZonedDateTime` and not
+user's system time zone).
 
 # Example
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,7 +1,9 @@
-using Base: @deprecate, @deprecate_binding
+using Base: @deprecate
 
-# BEGIN TimeZones 0.9 deprecations
+# BEGIN TimeZones 1.0 deprecations
 
-@deprecate build(version::AbstractString, regions; kwargs...) build(version; kwargs...) false
+@deprecate localtime(zdt::ZonedDateTime) DateTime(zdt, Local) false
+@deprecate utc(zdt::ZonedDateTime) DateTime(zdt, UTC) false
+@deprecate DateTime(zdt::ZonedDateTime) DateTime(zdt, Local)
 
-# END TimeZones 0.9 deprecations
+# END TimeZones 1.0 deprecations

--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -158,13 +158,13 @@ function next_transition_instant(zdt::ZonedDateTime)
 
     # Determine the index of the transition which occurs after the UTC datetime specified
     index = searchsortedfirst(
-        tz.transitions, TimeZones.utc(zdt),
+        tz.transitions, DateTime(zdt, UTC),
         by=el -> isa(el, TimeZones.Transition) ? el.utc_datetime : el,
     )
 
     index <= length(tz.transitions) || return nothing
 
-    # Use the UTC datetime of the transition and the offset information prior to the
+    # Use the UTC daftetime of the transition and the offset information prior to the
     # transition to create a `ZonedDateTime` which cannot be constructed with the high-level
     # constructors. The instant constructed is equivalent to the first instant after the
     # transition but visually appears to be before the transition. For example in a

--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -164,7 +164,7 @@ function next_transition_instant(zdt::ZonedDateTime)
 
     index <= length(tz.transitions) || return nothing
 
-    # Use the UTC daftetime of the transition and the offset information prior to the
+    # Use the UTC datetime of the transition and the offset information prior to the
     # transition to create a `ZonedDateTime` which cannot be constructed with the high-level
     # constructors. The instant constructed is equivalent to the first instant after the
     # transition but visually appears to be before the transition. For example in a

--- a/src/io.jl
+++ b/src/io.jl
@@ -50,7 +50,7 @@ function Base.print(io::IO, t::Transition)
     !isempty(t.zone.name) && print(io, " (", t.zone.name, ")")
 end
 
-Base.print(io::IO, zdt::ZonedDateTime) = print(io, localtime(zdt), zdt.zone.offset)
+Base.print(io::IO, zdt::ZonedDateTime) = print(io, DateTime(zdt, Local), zdt.zone.offset)
 
 
 function Base.show(io::IO, tz::FixedTimeZone)

--- a/src/rounding.jl
+++ b/src/rounding.jl
@@ -1,18 +1,18 @@
 using Dates: Period, DatePeriod, TimePeriod
 
 function Base.floor(zdt::ZonedDateTime, p::DatePeriod)
-    return ZonedDateTime(floor(localtime(zdt), p), timezone(zdt))
+    return ZonedDateTime(floor(DateTime(zdt, Local), p), timezone(zdt))
 end
 
 function Base.floor(zdt::ZonedDateTime, p::TimePeriod)
     # Rounding is done using the current fixed offset to avoid transitional ambiguities.
-    dt = floor(localtime(zdt), p)
+    dt = floor(DateTime(zdt, Local), p)
     utc_dt = dt - zdt.zone.offset
     return ZonedDateTime(utc_dt, timezone(zdt); from_utc=true)
 end
 
 function Base.ceil(zdt::ZonedDateTime, p::DatePeriod)
-    return ZonedDateTime(ceil(localtime(zdt), p), timezone(zdt))
+    return ZonedDateTime(ceil(DateTime(zdt, Local), p), timezone(zdt))
 end
 
 #function Dates.floorceil(zdt::ZonedDateTime, p::Dates.DatePeriod)

--- a/src/types/zoneddatetime.jl
+++ b/src/types/zoneddatetime.jl
@@ -145,6 +145,10 @@ function ZonedDateTime(parts::Union{Period,TimeZone}...)
     return ZonedDateTime(DateTime(periods...), tz)
 end
 
+function ZonedDateTime(date::Date, args...; kwargs...)
+    return ZonedDateTime(DateTime(date), args...; kwargs...)
+end
+
 # Promotion
 
 # Because of the promoting fallback definitions for TimeType, we need a special case for

--- a/test/accessors.jl
+++ b/test/accessors.jl
@@ -6,8 +6,6 @@ fixed = FixedTimeZone("Fixed", -7200, 3600)
 
 # ZonedDateTime accessors
 zdt = ZonedDateTime(DateTime(2014,6,12,23,59,58,57), fixed)
-@test TimeZones.localtime(zdt) == DateTime(2014,6,12,23,59,58,57)
-@test TimeZones.utc(zdt) == DateTime(2014,6,13,0,59,58,57)
 @test timezone(zdt) === fixed
 
 @test TimeZones.days(zdt) == 735396

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -6,7 +6,7 @@ warsaw = first(compile("Europe/Warsaw", tzdata["europe"]))
 apia = first(compile("Pacific/Apia", tzdata["australasia"]))
 midway = first(compile("Pacific/Midway", tzdata["australasia"]))
 
-@testset "Between ZonedDateTime and DateTime" begin
+@testset "Construct ZonedDateTime / DateTime" begin
     # Constructing a ZonedDateTime from a DateTime and the reverse
     dt = DateTime(2015, 1, 1, 0)
     zdt = ZonedDateTime(dt, warsaw)
@@ -14,6 +14,13 @@ midway = first(compile("Pacific/Midway", tzdata["australasia"]))
 
     # Converting from ZonedDateTime to DateTime isn't possible as it is always inexact.
     @test_throws MethodError convert(DateTime, zdt)
+end
+
+@testset "Construct Date / ZonedDateTime" begin
+    date = Date(2018, 6, 14)
+    zdt = ZonedDateTime(date, warsaw)
+    @test DateTime(zdt) == DateTime(2018, 6, 14)
+    @test Date(zdt) == Date(2018, 6, 14)
 end
 
 @testset "now" begin

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -6,28 +6,27 @@ warsaw = first(compile("Europe/Warsaw", tzdata["europe"]))
 apia = first(compile("Pacific/Apia", tzdata["australasia"]))
 midway = first(compile("Pacific/Midway", tzdata["australasia"]))
 
-# Converting a ZonedDateTime into a DateTime
-dt = DateTime(2015, 1, 1, 0)
-zdt = ZonedDateTime(dt, warsaw)
-@test DateTime(zdt) == dt
+@testset "Between ZonedDateTime and DateTime" begin
+    # Constructing a ZonedDateTime from a DateTime and the reverse
+    dt = DateTime(2015, 1, 1, 0)
+    zdt = ZonedDateTime(dt, warsaw)
+    @test DateTime(zdt) == dt
 
-# Converting from ZonedDateTime to DateTime isn't possible as it is always inexact.
-@test_throws MethodError convert(DateTime, zdt)
+    # Converting from ZonedDateTime to DateTime isn't possible as it is always inexact.
+    @test_throws MethodError convert(DateTime, zdt)
+end
 
-# Vectorized accessors
-n = 10
-arr = fill(zdt, n)
-@test Dates.DateTime.(arr) == fill(dt, n)
+@testset "now" begin
+    dt = now(Dates.UTC)::DateTime
+    zdt = now(warsaw)
+    @test zdt.timezone == warsaw
+    @test Dates.datetime2unix(TimeZones.utc(zdt)) ≈ Dates.datetime2unix(dt)
+end
 
-# now function
-dt = now(Dates.UTC)::DateTime
-zdt = now(warsaw)
-@test zdt.timezone == warsaw
-@test Dates.datetime2unix(TimeZones.utc(zdt)) ≈ Dates.datetime2unix(dt)
-
-# today function
-@test abs(today() - today(warsaw)) <= Dates.Day(1)
-@test today(apia) - today(midway) == Dates.Day(1)
+@testset "today" begin
+    @test abs(today() - today(warsaw)) <= Dates.Day(1)
+    @test today(apia) - today(midway) == Dates.Day(1)
+end
 
 @testset "todayat" begin
     @testset "current time" begin

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -23,10 +23,10 @@ fixed_range = ZonedDateTime(d, fixed):Hour(1):ZonedDateTime(d, fixed) + Day(1)
 @test length(fixed_range) == 25
 
 # Values in ZoneDateTime range should match raw DateTime range with appropriate offsets.
-@test TimeZones.utc.(utc_range) == raw_range
-@test TimeZones.utc.(dst_range) == raw_range .+ Hour(6)
-@test TimeZones.utc.(no_dst_range) == raw_range .+ Hour(6)
-@test TimeZones.utc.(fixed_range) == raw_range .+ Hour(5)
+@test DateTime.(utc_range, UTC) == raw_range
+@test DateTime.(dst_range, UTC) == raw_range .+ Hour(6)
+@test DateTime.(no_dst_range, UTC) == raw_range .+ Hour(6)
+@test DateTime.(fixed_range, UTC) == raw_range .+ Hour(5)
 
 
 # Test date ranges for the day of the DST "spring forward".
@@ -45,13 +45,13 @@ fixed_range = ZonedDateTime(d, fixed):Hour(1):ZonedDateTime(d, fixed) + Day(1)
 @test length(fixed_range) == 25
 
 # Values in ZoneDateTime range should match raw DateTime range with appropriate offsets.
-@test TimeZones.utc.(utc_range) == raw_range
-@test TimeZones.utc.(dst_range) == [
+@test DateTime.(utc_range, UTC) == raw_range
+@test DateTime.(dst_range, UTC) == [
     raw_range[1:2] .+ Hour(6);
     raw_range[4:end] .+ Hour(5)
 ]
-@test TimeZones.utc.(no_dst_range) == raw_range .+ Hour(6)
-@test TimeZones.utc.(fixed_range) == raw_range .+ Hour(5)
+@test DateTime.(no_dst_range, UTC) == raw_range .+ Hour(6)
+@test DateTime.(fixed_range, UTC) == raw_range .+ Hour(5)
 
 
 # Test date ranges for the day of the DST "fall back".
@@ -70,13 +70,13 @@ fixed_range = ZonedDateTime(d, fixed):Hour(1):ZonedDateTime(d, fixed) + Day(1)
 @test length(fixed_range) == 25
 
 # Values in ZoneDateTime range should match raw DateTime range with appropriate offsets.
-@test TimeZones.utc.(utc_range) == raw_range
-@test TimeZones.utc.(dst_range) == [
+@test DateTime.(utc_range, UTC) == raw_range
+@test DateTime.(dst_range, UTC) == [
     raw_range[1:2] .+ Hour(5);
     raw_range[2:end] .+ Hour(6);
 ]
-@test TimeZones.utc.(no_dst_range) == raw_range .+ Hour(6)
-@test TimeZones.utc.(fixed_range) == raw_range .+ Hour(5)
+@test DateTime.(no_dst_range, UTC) == raw_range .+ Hour(6)
+@test DateTime.(fixed_range, UTC) == raw_range .+ Hour(5)
 
 # filter behaviour with a non-existent hour
 range = ZonedDateTime(2015, 3, 8, dst):Dates.Hour(1):ZonedDateTime(2015, 3, 10, dst)

--- a/test/types/zoneddatetime.jl
+++ b/test/types/zoneddatetime.jl
@@ -354,7 +354,7 @@ using Dates: Hour, Second, UTM, @dateformat_str
 
         # A FixedTimeZone is effective for all of time where as a VariableTimeZone has as
         # start.
-        @test TimeZones.utc(early_utc) < warsaw.transitions[1].utc_datetime
+        @test DateTime(early_utc, UTC) < warsaw.transitions[1].utc_datetime
         @test_throws NonExistentTimeError astimezone(early_utc, warsaw)
     end
 


### PR DESCRIPTION
I got really tired of writing `Date(DateTime(zdt))` and `ZonedDateTime(DateTime(date))`

Fixes #222 and #209 

```
julia> zdt = ZonedDateTime(Date(2011, 6, 1), tz"America/Winnipeg")
2011-06-01T00:00:00-05:00

julia> Date(zdt)
2011-06-01

julia> DateTime(Date(2011, 6, 1))
2011-06-01T00:00:00
```

