### PR TITLE
Fix a stack overflow issue

### DIFF
--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -253,5 +253,4 @@ function show_next_transition(io::IO, tz::TimeZone=localzone())
     show_next_transition(io, @mock now(tz))
 end
 
-show_next_transition(io::IO, x...) = throw(MethodError(show_next_transition, (io, x...)))
-show_next_transition(x...) = show_next_transition(stdout, x...)
+show_next_transition(x) = show_next_transition(stdout, x)

--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -253,4 +253,5 @@ function show_next_transition(io::IO, tz::TimeZone=localzone())
     show_next_transition(io, @mock now(tz))
 end
 
+show_next_transition(io::IO, x...) = throw(MethodError(show_next_transition, (io, x...)))
 show_next_transition(x...) = show_next_transition(stdout, x...)

--- a/test/discovery.jl
+++ b/test/discovery.jl
@@ -150,4 +150,9 @@ end
         @test_logs (:warn, msg) show_next_transition(io, instant)
         @test isempty(read(seekstart(io), String))
     end
+
+    @testset "vararg stack overflow" begin
+        # Note: Would cause `Segmentation fault: 11` in Julia 1.0.5
+        @test_throws MethodError show_next_transition(1)
+    end
 end


### PR DESCRIPTION
I forgot what types this function took and tried `show_next_transition(Date(2019,6,1))` which resulted in a `Segmentation fault: 11` on Julia 1.0.5. 