### PR TITLE
Set project version to 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeZones"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 authors = ["Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "0.11.0"
+version = "1.0.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,9 +1,4 @@
 using Base: @deprecate
 
 # BEGIN TimeZones 1.0 deprecations
-
-@deprecate localtime(zdt::ZonedDateTime) DateTime(zdt, Local) false
-@deprecate utc(zdt::ZonedDateTime) DateTime(zdt, UTC) false
-@deprecate DateTime(zdt::ZonedDateTime) DateTime(zdt, Local)
-
 # END TimeZones 1.0 deprecations


### PR DESCRIPTION
I [previously thought](https://github.com/JuliaTime/TimeZones.jl/pull/231#issuecomment-561340976) it was time to bump the package version to 1.0 as I needed to do another minor release. This PR follows through on that promise.