### PR TITLE
Add Plot Recipe for ZonedDateTime

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,8 +19,8 @@ RecipesBase = "0.8"
 julia = "1"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [targets]

--- a/Project.toml
+++ b/Project.toml
@@ -8,16 +8,20 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 EzXML = "0.9.1, 1"
 Mocking = "0.7"
+RecipesBase = "0.8"
 julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Plots", "UnicodePlots"]

--- a/Project.toml
+++ b/Project.toml
@@ -19,9 +19,7 @@ RecipesBase = "0.8"
 julia = "1"
 
 [extras]
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [targets]
-test = ["Test", "Plots", "UnicodePlots"]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeZones"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 authors = ["Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "1.0.1"
+version = "1.1.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -3,7 +3,7 @@ module TimeZones
 using Dates
 using Printf
 using Serialization
-using RecipesBase: @receipe
+using RecipesBase: RecipesBase, @recipe
 using Unicode
 
 import Dates: TimeZone, UTC

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -3,7 +3,7 @@ module TimeZones
 using Dates
 using Printf
 using Serialization
-using RecipesBase
+using RecipesBase: @receipe
 using Unicode
 
 import Dates: TimeZone, UTC
@@ -68,9 +68,7 @@ include("ranges.jl")
 include("discovery.jl")
 include("rounding.jl")
 include("parse.jl")
-
 include("plotting.jl")
-
 include("deprecated.jl")
 
 end # module

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -3,6 +3,7 @@ module TimeZones
 using Dates
 using Printf
 using Serialization
+using RecipesBase
 using Unicode
 
 import Dates: TimeZone, UTC
@@ -67,6 +68,9 @@ include("ranges.jl")
 include("discovery.jl")
 include("rounding.jl")
 include("parse.jl")
+
+include("plotting.jl")
+
 include("deprecated.jl")
 
 end # module

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,0 +1,5 @@
+#Note: recipes seem to need to use short-form functions
+@recipe f(::Type{T}, val::T) where {T<:ZonedDateTime} = (
+    zdt ->  Dates.value(DateTime(zdt, UTC)),
+    dt -> string(DateTime(Dates.UTM(dt))),
+)

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,4 +1,3 @@
-#==
 @recipe function f(xs::AbstractVector{<:ZonedDateTime}, ys)
     # if no zoned date times nothing to do but return empty list
     isempty(xs) && return xs
@@ -9,10 +8,3 @@
     xguide := strip(get(plotattributes, :xguide, "") * " (timezone: $tz)")
     new_xs, ys
 end
-
-==#
-
-@recipe f(::Type{T}, val::T) where {T<:ZonedDateTime} = (
-    zdt ->  Dates.value(DateTime(zdt, UTC)),
-    dt -> string(DateTime(Dates.UTM(dt))) * "+00:00",  # make clear we are in UTC
-)

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,4 +1,4 @@
-#Note: recipes seem to need to use short-form functions
+# Note: recipes seem to need to use short-form functions
 @recipe f(::Type{T}, val::T) where {T<:ZonedDateTime} = (
     zdt ->  Dates.value(DateTime(zdt, UTC)),
     dt -> string(DateTime(Dates.UTM(dt))),

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,5 +1,5 @@
 # Note: recipes seem to need to use short-form functions
 @recipe f(::Type{T}, val::T) where {T<:ZonedDateTime} = (
-    zdt ->  Dates.value(DateTime(zdt, UTC)),
+    zdt -> Dates.value(DateTime(zdt, UTC)),
     dt -> string(DateTime(Dates.UTM(dt))),
 )

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,5 +1,7 @@
-# Note: recipes seem to need to use short-form functions
-@recipe f(::Type{T}, val::T) where {T<:ZonedDateTime} = (
-    zdt -> Dates.value(DateTime(zdt, UTC)),
-    dt -> string(DateTime(Dates.UTM(dt))),
-)
+# Note: type-recipes seem to need to use short-form functions
+@recipe function f(::Type{<:ZonedDateTime}, val::ZonedDateTime)
+    return (
+        zdt -> Dates.value(DateTime(zdt, UTC)),
+        dt -> string(DateTime(Dates.UTM(dt))),
+    )
+end

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,3 +1,12 @@
+#==
+Plot ZonedDateTime, on x-axis.
+We convert it to DateTimes, in the local timezone,
+and we list that timezone in the x-axis label.
+
+This is just one of many options for how to display this info.
+See this PR: https://github.com/JuliaTime/TimeZones.jl/pull/251#issuecomment-603806198
+for details on the options and their tradeoffs.
+==#
 @recipe function f(xs::AbstractVector{<:ZonedDateTime}, ys)
     # if no zoned date times nothing to do but return empty list
     isempty(xs) && return xs

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,3 +1,4 @@
+#==
 @recipe function f(xs::AbstractVector{<:ZonedDateTime}, ys)
     # if no zoned date times nothing to do but return empty list
     isempty(xs) && return xs
@@ -8,3 +9,10 @@
     xguide := strip(get(plotattributes, :xguide, "") * " (timezone: $tz)")
     new_xs, ys
 end
+
+==#
+
+@recipe f(::Type{T}, val::T) where {T<:ZonedDateTime} = (
+    zdt ->  Dates.value(DateTime(zdt, UTC)),
+    dt -> string(DateTime(Dates.UTM(dt))) * "+00:00",  # make clear we are in UTC
+)

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -5,6 +5,10 @@
     new_xs = DateTime.(astimezone.(xs, tz), Local)
 
     # xguide is the proper name for xlabel
-    xguide := strip(get(plotattributes, :xguide, "") * " (timezone: $tz)")
+    label = get(plotattributes, :xguide, "")
+    if !isempty(label)
+        label *= " "  # leave space between original label and the timezone info
+    end
+    xguide := label *= "(timezone: $tz)"
     new_xs, ys
 end

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -15,9 +15,7 @@ for details on the options and their tradeoffs.
 
     # xguide is the proper name for xlabel
     label = get(plotattributes, :xguide, "")
-    if !isempty(label)
-        label *= " "  # leave space between original label and the timezone info
-    end
-    xguide := label *= "(timezone: $tz)"
+    label *= isempty(label) ? "Time zone: $tz" : " ($tz)" 
+    xguide := label
     new_xs, ys
 end

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,7 +1,10 @@
-# Note: type-recipes seem to need to use short-form functions
-@recipe function f(::Type{<:ZonedDateTime}, val::ZonedDateTime)
-    return (
-        zdt -> Dates.value(DateTime(zdt, UTC)),
-        dt -> string(DateTime(Dates.UTM(dt))),
-    )
+@recipe function f(xs::AbstractVector{<:ZonedDateTime}, ys)
+    # if no zoned date times nothing to do but return empty list
+    isempty(xs) && return xs
+    tz = timezone(first(xs))  # convert all to same timezone as first one
+    new_xs = DateTime.(astimezone.(xs, tz), Local)
+
+    # xguide is the proper name for xlabel
+    xguide := strip(get(plotattributes, :xguide, "") * " (timezone: $tz)")
+    new_xs, ys
 end

--- a/test/plotting.jl
+++ b/test/plotting.jl
@@ -10,30 +10,30 @@
     # what the point should be after recipe is applied
     expected_dates = DateTime.(zoned_dates, Local)
 
-    @testset "No label" begin
+    @testset "No label (should now say the Timezone)" begin
         # The below use of `apply_recipe` is equivelent to:
         # plot(zoned_dates, 1:11)
         result, = RecipesBase.apply_recipe(Dict{Symbol, Any}(), zoned_dates, 1:11)
         xs, ys = result.args
         @test xs == expected_dates
         @test ys == 1:11
-        @test result.plotattributes[:xguide] == "(timezone: EST)"
+        @test result.plotattributes[:xguide] == "Time zone: EST"
     end
 
     @testset "label (should append to it)" begin
         # The below use of `apply_recipe` is equivelent to:
         # plot(zoned_dates, 1:11; xguide="X-Axis")
-        result, = RecipesBase.apply_recipe(Dict{Symbol, Any}(:xguide=>"Hi"), zoned_dates, 1:11)
+        result, = RecipesBase.apply_recipe(Dict{Symbol, Any}(:xguide=>"X-Axis"), zoned_dates, 1:11)
         xs, ys = result.args
         @test xs == expected_dates
         @test ys == 1:11
-        @test result.plotattributes[:xguide] == "Hi (timezone: EST)"
+        @test result.plotattributes[:xguide] == "X-Axis (EST)"
     end
 
     @testset "No items" begin
         empty_xs = ZonedDateTime[]
         empty_ys = 0:-1
-        result = RecipesBase.apply_recipe(Dict{Symbol, Any}(:xguide=>"Hi"), empty_xs, empty_ys)
+        result = RecipesBase.apply_recipe(Dict{Symbol, Any}(:xguide=>"X-Axis"), empty_xs, empty_ys)
         @test true  # we are just making sure it it didn't error
     end
 end

--- a/test/plotting.jl
+++ b/test/plotting.jl
@@ -1,33 +1,39 @@
 @testset "ZonedDateTime plot recipe" begin
+    # Note: in these tests we use `RecipesBase.apply_recipe` rather than `plot` as it
+    # lets use avoid a Plots.jl dependency and issues with running that during tests.
+    # `RecipesBase.apply_recipe` is not a documented API, but is fairly usable.
+    # Comments above each use show the matching `plot` function command
     start_zdt = ZonedDateTime(2017,1,1,0,0,0, tz"EST")
     end_zdt = ZonedDateTime(2017,1,1,10,30,0, tz"EST")
     zoned_dates = start_zdt:Hour(1):end_zdt
 
-    function check_extrema(x_axis)
-        date_val(zdt) = Dates.value(DateTime(zdt, Local))
-
-        @test x_axis[:extrema].emin ≈ date_val(start_zdt) rtol=0.000_000_1
-        @test x_axis[:extrema].emax ≈ date_val(end_zdt) rtol=0.000_000_1
-    end
+    # what the point should be after recipe is applied
+    expected_dates = DateTime.(zoned_dates, Local)
 
     @testset "No label" begin
-        result = scatter(zoned_dates, 1:11)
-        x_axis = result.subplots[1][:xaxis]
-        check_extrema(x_axis)
-        @test x_axis[:guide] == "(timezone: EST)"
+        # The below use of `apply_recipe` is equivelent to:
+        # plot(zoned_dates, 1:11)
+        result, = RecipesBase.apply_recipe(Dict{Symbol, Any}(), zoned_dates, 1:11)
+        xs, ys = result.args
+        @test xs == expected_dates
+        @test ys == 1:11
+        @test result.plotattributes[:xguide] == "(timezone: EST)"
     end
 
     @testset "label (should append to it)" begin
-        result = scatter(zoned_dates, 1:11; xlabel="Hi")
-        x_axis = result.subplots[1][:xaxis]
-        check_extrema(x_axis)
-        @test x_axis[:guide] == "Hi (timezone: EST)"
+        # The below use of `apply_recipe` is equivelent to:
+        # plot(zoned_dates, 1:11; xguide="X-Axis")
+        result, = RecipesBase.apply_recipe(Dict{Symbol, Any}(:xguide=>"Hi"), zoned_dates, 1:11)
+        xs, ys = result.args
+        @test xs == expected_dates
+        @test ys == 1:11
+        @test result.plotattributes[:xguide] == "Hi (timezone: EST)"
     end
 
     @testset "No items" begin
         empty_xs = ZonedDateTime[]
         empty_ys = 0:-1
-        result = scatter(empty_xs, empty_ys; xlabel="Hi")
-        @test result isa Plots.Plot  # make sure doesn't error
+        result = RecipesBase.apply_recipe(Dict{Symbol, Any}(:xguide=>"Hi"), empty_xs, empty_ys)
+        @test true  # we are just making sure it it didn't error
     end
 end

--- a/test/plotting.jl
+++ b/test/plotting.jl
@@ -3,10 +3,31 @@
     end_zdt = ZonedDateTime(2017,1,1,10,30,0, tz"EST")
     zoned_dates = start_zdt:Hour(1):end_zdt
 
-    result = scatter(zoned_dates, 1:11)
+    function check_extrema(x_axis)
+        date_val(zdt) = Dates.value(DateTime(zdt, Local))
 
-    date_val(zdt) = Dates.value(DateTime(zdt, UTC))
-    x_axis = result.subplots[1][:xaxis]
-    @test x_axis[:extrema].emin ≈ date_val(start_zdt) rtol=0.000_000_1
-    @test x_axis[:extrema].emax ≈ date_val(end_zdt) rtol=0.000_000_1
+        @test x_axis[:extrema].emin ≈ date_val(start_zdt) rtol=0.000_000_1
+        @test x_axis[:extrema].emax ≈ date_val(end_zdt) rtol=0.000_000_1
+    end
+
+    @testset "No label" begin
+        result = scatter(zoned_dates, 1:11)
+        x_axis = result.subplots[1][:xaxis]
+        check_extrema(x_axis)
+        @test x_axis[:guide] == "(timezone: EST)"
+    end
+
+    @testset "label" begin
+        result = scatter(zoned_dates, 1:11; xlabel="Hi")
+        x_axis = result.subplots[1][:xaxis]
+        check_extrema(x_axis)
+        @test x_axis[:guide] == "Hi (timezone: EST)"
+    end
+
+    @testset "No items" begin
+        empty_xs = ZonedDateTime[]
+        empty_ys = 0:-1
+        result = scatter(empty_xs, empty_ys; xlabel="Hi")
+        @test result isa Plots.Plot  # make sure doesn't error
+    end
 end

--- a/test/plotting.jl
+++ b/test/plotting.jl
@@ -1,16 +1,20 @@
 @testset "ZonedDateTime plot recipe" begin
-    # This time period crosses a DST transition where clocks are set back 1 hour
-    start_zdt = ZonedDateTime(2017,10, 28, 12, 1, 1, tz"Europe/London")
-    end_zdt = ZonedDateTime(2017,10, 29, 12, 1, 1, tz"Europe/London")
+    start_zdt = ZonedDateTime(2017,1,1,0,0,0, tz"EST")
+    end_zdt = ZonedDateTime(2017,1,1,10,30,0, tz"EST")
     zoned_dates = start_zdt:Hour(1):end_zdt
 
-    @testset "Base case" begin
-        result = scatter(zoned_dates, 1:11)
-        
-        x_axis = result.subplots[1][:xaxis]
+    function check_extrema(x_axis)
         date_val(zdt) = Dates.value(DateTime(zdt, Local))
+
         @test x_axis[:extrema].emin ≈ date_val(start_zdt) rtol=0.000_000_1
         @test x_axis[:extrema].emax ≈ date_val(end_zdt) rtol=0.000_000_1
+    end
+
+    @testset "No label" begin
+        result = scatter(zoned_dates, 1:11)
+        x_axis = result.subplots[1][:xaxis]
+        check_extrema(x_axis)
+        @test x_axis[:guide] == "(timezone: EST)"
     end
 
     @testset "label" begin

--- a/test/plotting.jl
+++ b/test/plotting.jl
@@ -17,7 +17,7 @@
         @test x_axis[:guide] == "(timezone: EST)"
     end
 
-    @testset "label" begin
+    @testset "label (should append to it)" begin
         result = scatter(zoned_dates, 1:11; xlabel="Hi")
         x_axis = result.subplots[1][:xaxis]
         check_extrema(x_axis)

--- a/test/plotting.jl
+++ b/test/plotting.jl
@@ -1,0 +1,12 @@
+@testset "ZonedDateTime plot recipe" begin
+    start_zdt = ZonedDateTime(2017,1,1,0,0,0, tz"EST")
+    end_zdt = ZonedDateTime(2017,1,1,10,30,0, tz"EST")
+    zoned_dates = start_zdt:Hour(1):end_zdt
+
+    result = scatter(zoned_dates, 1:11)
+
+    date_val(zdt) = Dates.value(DateTime(zdt, UTC))
+    x_axis = result.subplots[1][:xaxis]
+    @test x_axis[:extrema].emin ≈ date_val(start_zdt) rtol=0.000_000_1
+    @test x_axis[:extrema].emax ≈ date_val(end_zdt) rtol=0.000_000_1
+end

--- a/test/plotting.jl
+++ b/test/plotting.jl
@@ -1,20 +1,16 @@
 @testset "ZonedDateTime plot recipe" begin
-    start_zdt = ZonedDateTime(2017,1,1,0,0,0, tz"EST")
-    end_zdt = ZonedDateTime(2017,1,1,10,30,0, tz"EST")
+    # This time period crosses a DST transition where clocks are set back 1 hour
+    start_zdt = ZonedDateTime(2017,10, 28, 12, 1, 1, tz"Europe/London")
+    end_zdt = ZonedDateTime(2017,10, 29, 12, 1, 1, tz"Europe/London")
     zoned_dates = start_zdt:Hour(1):end_zdt
 
-    function check_extrema(x_axis)
+    @testset "Base case" begin
+        result = scatter(zoned_dates, 1:11)
+        
+        x_axis = result.subplots[1][:xaxis]
         date_val(zdt) = Dates.value(DateTime(zdt, Local))
-
         @test x_axis[:extrema].emin ≈ date_val(start_zdt) rtol=0.000_000_1
         @test x_axis[:extrema].emax ≈ date_val(end_zdt) rtol=0.000_000_1
-    end
-
-    @testset "No label" begin
-        result = scatter(zoned_dates, 1:11)
-        x_axis = result.subplots[1][:xaxis]
-        check_extrema(x_axis)
-        @test x_axis[:guide] == "(timezone: EST)"
     end
 
     @testset "label" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Mocking
 
+using Plots
 using Test
 using TimeZones
 using TimeZones: PKG_DIR
@@ -7,6 +8,8 @@ using TimeZones.TZData: ARCHIVE_DIR, TZSource, compile, build
 using Unicode
 
 Mocking.activate()
+unicodeplots()  # so don't need X11 to test plotting
+
 
 const TZDATA_VERSION = "2016j"
 const TZ_SOURCE_DIR = get(ENV, "TZ_SOURCE_DIR", joinpath(PKG_DIR, "test", "tzsource"))
@@ -66,6 +69,8 @@ include("helpers.jl")
     include("discovery.jl")
     include("rounding.jl")
     include("parse.jl")
+
+    include("plotting.jl")
 
     # Note: Run the build tests last to ensure that re-compiling the time zones files
     # doesn't interfere with other tests.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,7 +69,6 @@ include("helpers.jl")
     include("discovery.jl")
     include("rounding.jl")
     include("parse.jl")
-
     include("plotting.jl")
 
     # Note: Run the build tests last to ensure that re-compiling the time zones files

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Mocking
 
-using Plots
+using RecipesBase
 using Test
 using TimeZones
 using TimeZones: PKG_DIR
@@ -8,7 +8,6 @@ using TimeZones.TZData: ARCHIVE_DIR, TZSource, compile, build
 using Unicode
 
 Mocking.activate()
-unicodeplots()  # so don't need X11 to test plotting
 
 
 const TZDATA_VERSION = "2016j"


### PR DESCRIPTION
Closes https://github.com/JuliaTime/TimeZones.jl/issues/184

It converts everything to UTC `DateTimes`, because that is the generally sensibly option.
and is the easiest.

More fancy we could convert everything in the vector to the majority timezone,
and then add the timezone to the axis title?
But am not that fancy.
Maybe a follow up PR