### PR TITLE
Go back to using AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,13 @@ stages:
 # Note: At the moment `codecov: true` and `coveralls: true` are not working.
 language: julia
 os:
-  - linux
   - osx
-  - windows
+  - linux
 julia:
-  - 1.0  # LTS
-  - 1.3  # Latest release
+  - 1.0
+  - 1.1
+  - 1.2
+  - 1.3
   - nightly
 arch:
   - x64
@@ -86,3 +87,19 @@ after_success:
       Pkg.add("Coverage")
       using Coverage
       Codecov.submit(process_folder())'
+
+jobs:
+  include:
+    - <<: *doc_test
+      os: linux
+      julia: 1.0
+    - <<: *doc_test
+      os: linux
+      julia: nightly
+    - <<: *doc_test
+      os: osx
+      julia: 1.0
+    - <<: *doc_test
+      os: osx
+      julia: nightly
+    - <<: *doc_deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ os:
   - osx
 julia:
   - 1.0  # LTS
-  - 1.3  # Latest release
+  - 1.4  # Latest release
   - nightly
 arch:
   - x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ stages:
 language: julia
 os:
   - linux
+  # - windows  # Unable to use Windows on Travis due to: https://github.com/JuliaTime/TimeZones.jl/pull/251#issuecomment-600360127
   - osx
 julia:
   - 1.0  # LTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,11 @@ stages:
 # Note: At the moment `codecov: true` and `coveralls: true` are not working.
 language: julia
 os:
-  - osx
   - linux
+  - osx
 julia:
-  - 1.0
-  - 1.1
-  - 1.2
-  - 1.3
+  - 1.0  # LTS
+  - 1.3  # Latest release
   - nightly
 arch:
   - x64
@@ -87,19 +85,3 @@ after_success:
       Pkg.add("Coverage")
       using Coverage
       Codecov.submit(process_folder())'
-
-jobs:
-  include:
-    - <<: *doc_test
-      os: linux
-      julia: 1.0
-    - <<: *doc_test
-      os: linux
-      julia: nightly
-    - <<: *doc_test
-      os: osx
-      julia: 1.0
-    - <<: *doc_test
-      os: osx
-      julia: nightly
-    - <<: *doc_deploy

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ TimeZones.jl
 ============
 
 [![Travis CI](https://travis-ci.org/JuliaTime/TimeZones.jl.svg?branch=master)](https://travis-ci.org/JuliaTime/TimeZones.jl)
+[![AppVeyor](https://ci.appveyor.com/api/projects/status/ru96a9u8h83j9ixu/branch/master?svg=true)](https://ci.appveyor.com/project/omus/timezones-jl)
 [![codecov](https://codecov.io/gh/JuliaTime/TimeZones.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaTime/TimeZones.jl)
 <br/>
 [![Stable Documentation](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliatime.github.io/TimeZones.jl/stable)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,19 +2,11 @@ environment:
   JULIA_TZ_VERSION: "2016j"
 
   matrix:
-  - julia_version: 1.0
-  - julia_version: 1.1
-  - julia_version: 1.2
-  - julia_version: 1.3
+  - julia_version: 1.0  # LTS (1.0.x)
+  - julia_version: 1  # Latest release (1.x.y)
   - julia_version: latest
 
-matrix:
-  allow_failures:
-    # https://github.com/JuliaTime/TimeZones.jl/issues/218
-    - julia_version: latest
-
 platform:
-  - x86 # 32-bit
   - x64 # 64-bit
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   matrix:
   - julia_version: 1.0  # LTS (1.0.x)
   - julia_version: 1  # Latest release (1.x.y)
-  - julia_version: latest
+  - julia_version: nightly
 
 platform:
   - x64 # 64-bit

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+environment:
+  JULIA_TZ_VERSION: "2016j"
+
+  matrix:
+  - julia_version: 1.0
+  - julia_version: 1.1
+  - julia_version: 1.2
+  - julia_version: 1.3
+  - julia_version: latest
+
+matrix:
+  allow_failures:
+    # https://github.com/JuliaTime/TimeZones.jl/issues/218
+    - julia_version: latest
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+install:
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
+
+build_script:
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
+
+test_script:
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+on_success:
+  - echo "%JL_CODECOV_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"


### PR DESCRIPTION
Revert "Merge pull request #237 from JuliaTime/cv/drop-appveyor"
This reverts commit 01254a6d501062f2aaf140c485b8181f0c4ea37e.

Because of https://github.com/JuliaTime/TimeZones.jl/pull/251#issuecomment-600360127
> > Travis CI windows is failing to build Plots because FFMPEG
> 
> More precisely, it's Travis fault that has an incomplete Windows installation, see [JuliaIO/FFMPEG.jl#14](https://github.com/JuliaIO/FFMPEG.jl/issues/14) and references therein


