### PR TITLE
Remove use of `systemsetup` for macOS localzone

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeZones"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 authors = ["Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/local.jl
+++ b/src/local.jl
@@ -18,15 +18,7 @@ function localzone()
     mask = Class(:STANDARD) | Class(:LEGACY)
 
     @static if Sys.isapple()
-        name = @mock read(`systemsetup -gettimezone`, String)  # Appears to only work as root
-        if startswith(name, "Time Zone: ")
-            name = strip(replace(name, "Time Zone: " => ""))
-        else
-            # link will be something like /usr/share/zoneinfo/Europe/Warsaw
-            name = @mock readlink("/etc/localtime")
-            name = match(r"(?<=zoneinfo/).*$", name).match
-        end
-        return TimeZone(name, mask)
+        return TimeZone(readlink("/etc/localtime")[27:end], mask)
     elseif Sys.isunix()
         name = ""
 

--- a/src/local.jl
+++ b/src/local.jl
@@ -18,7 +18,10 @@ function localzone()
     mask = Class(:STANDARD) | Class(:LEGACY)
 
     @static if Sys.isapple()
-        return TimeZone(readlink("/etc/localtime")[27:end], mask)
+        # Link will point to something like "/usr/share/zoneinfo/Europe/Warsaw"
+        link = @mock readlink("/etc/localtime")
+        name = match(r"(?<=zoneinfo/).*$", link).match
+        return TimeZone(name, mask)
     elseif Sys.isunix()
         name = ""
 

--- a/test/local_mocking.jl
+++ b/test/local_mocking.jl
@@ -11,13 +11,9 @@ win_name = name == "Europe/Warsaw" ? "Central European Standard Time" : "Samoa S
 tz = TimeZone(name)
 
 if Sys.isapple()
-
     # Determine time zone from /etc/localtime.
-    patches = [
-        @patch read(cmd::AbstractCmd, ::Type{String}) = ""
-        @patch readlink(filename::AbstractString) = "/usr/share/zoneinfo/$name"
-    ]
-    apply(patches) do
+    patch = @patch readlink(filename::AbstractString) = "/usr/share/zoneinfo/$name"
+    apply(patch) do
         @test localzone() == tz
     end
 

--- a/test/local_mocking.jl
+++ b/test/local_mocking.jl
@@ -12,7 +12,7 @@ tz = TimeZone(name)
 
 if Sys.isapple()
     # Determine time zone from /etc/localtime.
-    patch = @patch readlink(filename::AbstractString) = "/usr/share/zoneinfo/$name"
+    patch = @patch readlink(::AbstractString) = "/usr/share/zoneinfo/$name"
     apply(patch) do
         @test localzone() == tz
     end
@@ -89,7 +89,7 @@ end
 function with_localzone(func::Function, name::AbstractString)
     @static if Sys.isapple()
         patches = [
-            @patch read(cmd::AbstractCmd, ::Type{String}) = "Time Zone:  $name\n"
+            @patch readlink(::AbstractString) = "/usr/share/zoneinfo/$name"
         ]
     elseif Sys.iswindows()
         patches = [

--- a/test/local_mocking.jl
+++ b/test/local_mocking.jl
@@ -11,11 +11,6 @@ win_name = name == "Europe/Warsaw" ? "Central European Standard Time" : "Samoa S
 tz = TimeZone(name)
 
 if Sys.isapple()
-    # Determine time zone via systemsetup.
-    patch = @patch read(cmd::AbstractCmd, ::Type{String}) = "Time Zone:  " * name * "\n"
-    apply(patch) do
-        @test localzone() == tz
-    end
 
     # Determine time zone from /etc/localtime.
     patches = [


### PR DESCRIPTION
Rather than using `sudo systemsetup -gettimezone` one can get the localzone on OSX based on `/etc/localtime` (i.e., no sudo required). Should fix issue with 
```
ERROR: IOError: could not spawn `systemsetup -gettimezone`: no such file or directory (ENOENT)
```
on various applications such as VS Code even with full disk privileges.