### PR TITLE
Use Windows Time Zone Utility for local time zone

### DIFF
--- a/src/local.jl
+++ b/src/local.jl
@@ -129,8 +129,17 @@ function localzone()
             end
         end
     elseif Sys.iswindows()
-        # Windows powershell should be available on Windows 7 and above
-        win_name = strip(@mock read(`powershell -Command "[TimeZoneInfo]::Local.Id"`, String))
+        # The Windows Time Zone Utility (tzutil) is pre-installed from Windows XP and later.
+        # This approach was used as it is the fastest without without adding additional
+        # package dependencies.
+        #
+        # https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/tzutil
+        # https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh875624(v=ws.11)
+        #
+        # Alternative approaches:
+        # - Call .NET via Powershell: `powershell -Command "[TimeZoneInfo]::Local.Id"`
+        # - Read the Windows registry
+        win_name = @mock read(`tzutil /g`, String)
 
         if haskey(WINDOWS_TRANSLATION, win_name)
             return TimeZone(WINDOWS_TRANSLATION[win_name], mask)
@@ -141,6 +150,8 @@ function localzone()
 
     error("Failed to find local time zone")
 end
+
+
 
 # Extract a time zone name from a path.
 # e.g. "/usr/share/zoneinfo/Europe/Warsaw" becomes "Europe/Warsaw"

--- a/test/local_mocking.jl
+++ b/test/local_mocking.jl
@@ -11,7 +11,7 @@ win_name = name == "Europe/Warsaw" ? "Central European Standard Time" : "Samoa S
 tz = TimeZone(name)
 
 if Sys.iswindows()
-    patch = @patch read(cmd::AbstractCmd, ::Type{String}) = "$win_name\r\n"
+    patch = @patch read(cmd::AbstractCmd, ::Type{String}) = win_name
     apply(patch) do
         @test localzone() == tz
     end
@@ -84,7 +84,7 @@ function with_localzone(func::Function, name::AbstractString)
         ]
     elseif Sys.iswindows()
         patches = [
-            @patch read(cmd::AbstractCmd, ::Type{String}) = "$name\r\n"
+            @patch read(cmd::AbstractCmd, ::Type{String}) = name
         ]
     elseif Sys.islinux()
         patches = [


### PR DESCRIPTION
While assisting in debugging https://github.com/lanl-ansi/PowerModels.jl/issues/711 I discovered the [Windows Time Zone Utility (tzutil)](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/tzutil). The utility seems to be [available on more versions of Windows](https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh875624(v=ws.11)) and executes faster (0.008920 seconds) than using Powershell (0.497168 seconds).

I investigated into using both commands by using a fallback when one failed but it doing that currently seems unnecessary until we find a scenario where `tzutil` isn't present.