### PR TITLE
Revise tests to work with printing type aliases

### DIFF
--- a/docs/src/arithmetic.md
+++ b/docs/src/arithmetic.md
@@ -52,7 +52,7 @@ julia> spring + Day(1) + Hour(24)
 [Query](https://docs.julialang.org/en/v1/stdlib/Dates/#Query-Functions-1) and [adjuster functions](https://docs.julialang.org/en/v1/stdlib/Dates/#Adjuster-Functions-1) can be used as with `Date` and `DateTime`.
 We can use `filter` to apply a predicate to a `StepRange` of `TimeType`s to produce a vector of dates that fit certain inclusion criteria (for example, "every fifth Wednesday of the month in 2014 at 09:00"):
 
-```jldoctest spring
+```jldoctest spring; filter = r"Array\{ZonedDateTime,1\}|Vector\{ZonedDateTime\}"
 julia> warsaw = tz"Europe/Warsaw"
 Europe/Warsaw (UTC+1/UTC+2)
 
@@ -79,7 +79,7 @@ Note the transition from standard time to daylight saving time (and back again).
 
 It is possible to define a range `start:step:stop` such that `start` and `stop` have different time zones. In this case the resulting `ZonedDateTime`s will all share a time zone with `start` but the range will stop at the instant that corresponds to `stop` in `start`'s time zone. For example:
 
-```jldoctest spring
+```jldoctest spring; filter = r"Array\{ZonedDateTime,1\}|Vector\{ZonedDateTime\}"
 julia> start = ZonedDateTime(2016, 1, 1, 12, tz"UTC")
 2016-01-01T12:00:00+00:00
 

--- a/test/io.jl
+++ b/test/io.jl
@@ -73,10 +73,11 @@ zdt = ZonedDateTime(dt, warsaw)
 @test sprint(show, MIME("text/plain"), zdt) == "1942-12-25T01:23:45+01:00"
 
 # Note: Test can be removed once `:compact_el` code is eliminated
-@test sprint(show, MIME("text/plain"), [zdt]) == "1-element Array{ZonedDateTime,1}:\n 1942-12-25T01:23:45+01:00"
+zdt_vector = [zdt]
+@test sprint(show, MIME("text/plain"), zdt_vector) == summary(zdt_vector) * ":\n 1942-12-25T01:23:45+01:00"
 
 prefix = VERSION >= v"1.5.0-DEV.224" ? "" : "ZonedDateTime"
-@test sprint(show, [zdt]; context=:compact => true) == "$prefix[ZonedDateTime(1942, 12, 25, 1, 23, 45, tz\"Europe/Warsaw\")]"
+@test sprint(show, zdt_vector; context=:compact => true) == "$prefix[ZonedDateTime(1942, 12, 25, 1, 23, 45, tz\"Europe/Warsaw\")]"
 
 
 # TimeZone parsing


### PR DESCRIPTION
Failure was caused by `Array{T,1}` now being printed as `Vector{T}` via https://github.com/JuliaLang/julia/pull/36107