### PR TITLE
Artifacts compat fix only applies to Julia 1.3.1

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,9 +1,8 @@
-if VERSION >= v"1.4"
-    using Pkg.Artifacts: @artifact_str
-elseif VERSION >= v"1.3"
+if VERSION == v"1.3.1"
     using Pkg.Artifacts: do_artifact_str, find_artifacts_toml, load_artifacts_toml
 
-    # A copy of `Pkg.Artifacts.@artifact_str` where `name` is properly escaped on Julia 1.3
+    # A copy of `Pkg.Artifacts.@artifact_str` where `name` is properly escaped on
+    # Julia 1.3.1
     # https://github.com/JuliaLang/Pkg.jl/issues/1912
     # https://github.com/JuliaLang/Pkg.jl/pull/1580
     macro artifact_str(name)
@@ -31,4 +30,8 @@ elseif VERSION >= v"1.3"
             Base.invokelatest(do_artifact_str, $(esc(name)), $(artifact_dict), $(artifacts_toml), $__module__)
         end
     end
+elseif VERSION >= v"1.3.0"
+    # Issue does not exist in 1.3.0, and >= 1.4.0. Also, assume that the issue would also be
+    # fixed on >= 1.3.2
+    using Pkg.Artifacts: @artifact_str
 end


### PR DESCRIPTION
The `@arifact_str` fix I made in https://github.com/JuliaTime/TimeZones.jl/pull/276 only applies to Julia 1.3.1. On Julia 1.3.0 it breaks as an imported function doesn't exist.

I verified that this fix works locally on Julia 1.3.0, 1.3.1, 1.4.0, 1.4.1, 1.4.2, and 1.5.0-rc1

Fixes: https://github.com/JuliaTime/TimeZones.jl/issues/277