### PR TITLE
Support RecipesBase 0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [compat]
 EzXML = "0.9.1, 1"
 Mocking = "0.7"
-RecipesBase = "0.8, 1.0"
+RecipesBase = "0.7, 0.8, 1"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
Tested locally on macOS that RecipesBase 0.7.0 passes tests.