### PR TITLE
Simplify hash of VariableTimeZone

### DIFF
--- a/src/types/variabletimezone.jl
+++ b/src/types/variabletimezone.jl
@@ -38,4 +38,4 @@ function Base.isequal(a::VariableTimeZone, b::VariableTimeZone)
     )
 end
 
-Base.hash(tz::VariableTimeZone, h::UInt) = hash(tz.name, h)
+Base.hash(tz::VariableTimeZone, h::UInt) = hash(tz.name, hash(VariableTimeZone, h))

--- a/src/types/variabletimezone.jl
+++ b/src/types/variabletimezone.jl
@@ -38,4 +38,8 @@ function Base.isequal(a::VariableTimeZone, b::VariableTimeZone)
     )
 end
 
-Base.hash(tz::VariableTimeZone, h::UInt) = hash(tz.name, hash(VariableTimeZone, h))
+function Base.hash(tz::VariableTimeZone, h::UInt)
+    h = hash(:timezone, h)
+    h = hash(tz.name, h)
+    return h
+end

--- a/src/types/variabletimezone.jl
+++ b/src/types/variabletimezone.jl
@@ -38,9 +38,4 @@ function Base.isequal(a::VariableTimeZone, b::VariableTimeZone)
     )
 end
 
-function Base.hash(tz::VariableTimeZone, h::UInt)
-    h = hash(tz.name, h)
-    h = hash(tz.transitions, h)
-    h = hash(tz.cutoff, h)
-    return h
-end
+Base.hash(tz::VariableTimeZone, h::UInt) = hash(tz.name, h)

--- a/test/types/variabletimezone.jl
+++ b/test/types/variabletimezone.jl
@@ -46,4 +46,16 @@
         @test !isequal(a, b)
         @test hash(a) == hash(b)
     end
+    
+    @testset "hash using name" begin
+        a = first(compile("Europe/Warsaw", tzdata["europe"]))
+        b = VariableTimeZone("Europe/Warsaw", a.transitions[1:1], nothing)
+
+        # To be fast the `hash` function only uses the name. However, when a hash collision
+        # does occur it should be disambiguated by the `isequal` check which also considers
+        # the transition and the cutoff.
+        @test hash(a) == hash(b)
+        @test !isequal(a, b)
+        @test length(keys(Dict(a => :a, b => :b))) == 2  # Time zones use different keys
+    end
 end

--- a/test/types/variabletimezone.jl
+++ b/test/types/variabletimezone.jl
@@ -44,6 +44,6 @@
         @test a == b
         @test a !== b
         @test !isequal(a, b)
-        @test hash(a) != hash(b)
+        @test hash(a) == hash(b)
     end
 end


### PR DESCRIPTION
I think the gain we get out of reducing collisions for the case of two timezones with same name but different transitions and cutoffs is not worth the extra time that hashing takes.
