### PR TITLE
optimise check of UTC / GMT during parsing

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,3 +1,15 @@
+# https://github.com/JuliaLang/julia/pull/35973
+if v"1.3.0" <= VERSION < v"1.6.0-DEV.84"
+    # Declare a new `==` function to avoid type piracy
+    function == end
+    @inline ==(a, b) = Base.:(==)(a, b)
+
+    function ==(a::Union{String, SubString{String}}, b::Union{String, SubString{String}})
+        s = sizeof(a)
+        s == sizeof(b) && 0 == Base._memcmp(a, b, s)
+    end
+end
+
 if VERSION == v"1.3.1"
     using Pkg.Artifacts: do_artifact_str, find_artifacts_toml, load_artifacts_toml
 

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,6 +1,6 @@
 # https://github.com/JuliaLang/julia/pull/35973
 if v"1.3.0" <= VERSION < v"1.6.0-DEV.84"
-    # Declare a new `==` function to avoid type piracy
+    # Declare a new `==` function to avoid type piracy & triggeing of loads of invalidations
     function == end
     @inline ==(a, b) = Base.:(==)(a, b)
 

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,6 +1,6 @@
 # https://github.com/JuliaLang/julia/pull/35973
 if v"1.3.0" <= VERSION < v"1.6.0-DEV.84"
-    # Declare a new `==` function to avoid type piracy & triggeing of loads of invalidations
+    # Declare a new `==` function to avoid type piracy and triggering invalidations
     function == end
     @inline ==(a, b) = Base.:(==)(a, b)
 

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -1,14 +1,6 @@
 using Dates: DateFormat, DatePart, min_width, max_width, tryparsenext_base10
 using TimeZones.TZData: MIN_YEAR, MAX_YEAR
 
-# https://github.com/JuliaLang/julia/pull/35973
-if v"1.3.0" <= VERSION < v"1.6.0-DEV.84"
-    function Base.:(==)(a::Union{String, SubString{String}}, b::Union{String, SubString{String}})
-        s = sizeof(a)
-        s == sizeof(b) && 0 == Base._memcmp(a, b, s)
-    end
-end
-
 function tryparsenext_fixedtz(str, i, len, min_width::Int=1, max_width::Int=0)
     i == len && str[i] === 'Z' && return ("Z", i+1)
 

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -57,21 +57,12 @@ function tryparsenext_tz(str, i, len, min_width::Int=1, max_width::Int=0)
         # If the time zone is recognized make sure that it is well-defined. For our
         # purposes we'll treat all abbreviations except for UTC and GMT as ambiguous.
         # e.g. "MST": "Mountain Standard Time" (UTC-7) or "Moscow Summer Time" (UTC+3:31).
-        if is_UTC_or_GMT(name) || '/' in name
+        if name == "UTC" || name == "GMT" || '/' in name
             return name, i
         else
             return nothing
         end
     end
-end
-
-function is_UTC_or_GMT(name::AbstractString)
-    # This is an optimized version of `name in ("UTC", "GMT").
-    # See benchmarks in https://github.com/JuliaTime/TimeZones.jl/issues/282
-    return length(name) === 3 && @inbounds(
-       (name[1]==='U' && name[2]==='T' && name[3]==='C') ||
-       (name[1]==='G' && name[2]==='M' && name[3]==='T')
-    );
 end
 
 function Dates.tryparsenext(d::DatePart{'z'}, str, i, len)

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -71,7 +71,7 @@ function is_UTC_or_GMT(name::AbstractString)
     return length(name) === 3 && @inbounds(
        (name[1]==='U' && name[2]==='T' && name[3]==='C') ||
        (name[1]==='G' && name[2]==='M' && name[3]==='T')
-   );
+    );
 end
 
 function Dates.tryparsenext(d::DatePart{'z'}, str, i, len)

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -2,7 +2,7 @@ using Dates: DateFormat, DatePart, min_width, max_width, tryparsenext_base10
 using TimeZones.TZData: MIN_YEAR, MAX_YEAR
 
 # https://github.com/JuliaLang/julia/pull/35973
-if VERSION < v"1.6.0-DEV.84"
+if v"1.3.0" <= VERSION < v"1.6.0-DEV.84"
     function Base.:(==)(a::Union{String, SubString{String}}, b::Union{String, SubString{String}})
         s = sizeof(a)
         s == sizeof(b) && 0 == Base._memcmp(a, b, s)

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -1,6 +1,14 @@
 using Dates: DateFormat, DatePart, min_width, max_width, tryparsenext_base10
 using TimeZones.TZData: MIN_YEAR, MAX_YEAR
 
+# https://github.com/JuliaLang/julia/pull/35973
+if VERSION < v"1.6.0-DEV.84"
+    function Base.:(==)(a::Union{String, SubString{String}}, b::Union{String, SubString{String}})
+        s = sizeof(a)
+        s == sizeof(b) && 0 == Base._memcmp(a, b, s)
+    end
+end
+
 function tryparsenext_fixedtz(str, i, len, min_width::Int=1, max_width::Int=0)
     i == len && str[i] === 'Z' && return ("Z", i+1)
 

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -57,12 +57,21 @@ function tryparsenext_tz(str, i, len, min_width::Int=1, max_width::Int=0)
         # If the time zone is recognized make sure that it is well-defined. For our
         # purposes we'll treat all abbreviations except for UTC and GMT as ambiguous.
         # e.g. "MST": "Mountain Standard Time" (UTC-7) or "Moscow Summer Time" (UTC+3:31).
-        if '/' in name || name in ("UTC", "GMT")
+        if is_UTC_or_GMT(name) || '/' in name
             return name, i
         else
             return nothing
         end
     end
+end
+
+function is_UTC_or_GMT(name::AbstractString)
+    # This is an optimized version of `name in ("UTC", "GMT").
+    # See benchmarks in https://github.com/JuliaTime/TimeZones.jl/issues/282
+    return length(name) === 3 && @inbounds(
+       (name[1]==='U' && name[2]==='T' && name[3]==='C') ||
+       (name[1]==='G' && name[2]==='M' && name[3]==='T')
+   );
 end
 
 function Dates.tryparsenext(d::DatePart{'z'}, str, i, len)


### PR DESCRIPTION
The last remaining one from #282 

This one is actually a fairly meaningful improvement over https://github.com/JuliaTime/TimeZones.jl/issues/282#issuecomment-687169225

```julia
julia> @btime parse(ZonedDateTime, "2017-11-14 11:03:53 +0100", dateformat"yyyy-mm-dd HH:MM:SS zzzzz");
  700.641 ns (13 allocations: 592 bytes)

julia> @btime parse(ZonedDateTime, "2016-04-11 08:00 UTC", dateformat"yyyy-mm-dd HH:MM ZZZ");
  612.665 ns (13 allocations: 592 bytes)

julia> @btime parse(ZonedDateTime, "2000+00", dateformat"yyyyz");
  463.898 ns (13 allocations: 496 bytes)

julia> @btime parse(ZonedDateTime, Test.GenericString("2018-01-01 00:00 UTC"), dateformat"yyyy-mm-dd HH:MM ZZZ");
  6.772 μs (107 allocations: 3.55 KiB)

julia> @btime tryparse(ZonedDateTime, "2013-03-20 11:00:00+04:00", dateformat"y-m-d H:M:SSz");
  883.522 ns (14 allocations: 640 bytes)

julia> @btime tryparse(ZonedDateTime, "2016-04-11 08:00 EST", dateformat"yyyy-mm-dd HH:MM zzz");
  92.074 ns (0 allocations: 0 bytes)

julia> @btime ZonedDateTime("2000-01-02T03:04:05.006+0700");
  825.240 ns (14 allocations: 688 bytes)

julia> @btime ZonedDateTime("2000-01-02T03:04:05.006Z");
  627.679 ns (9 allocations: 416 bytes)

julia> @btime ZonedDateTime("2018-11-01-0600", dateformat"yyyy-mm-ddzzzz");
  611.247 ns (13 allocations: 544 bytes)
```

Much more than I expected.
I guess because it removed allocations.
I wonder if there are other allocations that can be removed.