### PR TITLE
Apply `@artifact_str` fix to Julia 1.3.2-pre.0

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -10,7 +10,7 @@ if v"1.3.0" <= VERSION < v"1.6.0-DEV.84"
     end
 end
 
-if VERSION == v"1.3.1"
+if v"1.3.1-pre.18" <= VERSION < v"1.3.2"
     using Pkg.Artifacts: do_artifact_str, find_artifacts_toml, load_artifacts_toml
 
     # A copy of `Pkg.Artifacts.@artifact_str` where `name` is properly escaped on


### PR DESCRIPTION
Allows people who build from source on the `release-1.3` branch to be able to use TimeZones.jl. I also adjusted the lower bound which now includes the first version with the bad `@artifact_str` version (Julia commit 5e0653407f).

I'm still assuming a release of 1.3.2 would have a fixed Pkg (most likely that will never occur).