### PR TITLE
Refactor `transition_range` and callers

### DIFF
--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -33,6 +33,10 @@ export TimeZone, @tz_str, istimezone, FixedTimeZone, VariableTimeZone, ZonedDate
 const PKG_DIR = normpath(joinpath(dirname(@__FILE__), ".."))
 const DEPS_DIR = joinpath(PKG_DIR, "deps")
 
+# TimeZone types used to disambiguate the context of a DateTime
+# abstract type UTC <: TimeZone end  # Already defined in the Dates stdlib
+abstract type Local <: TimeZone end
+
 function __init__()
     # Base extension needs to happen everytime the module is loaded (issue #24)
     Dates.CONVERSION_SPECIFIERS['z'] = TimeZone

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -45,8 +45,10 @@ function __init__()
     global ISOZonedDateTimeFormat = DateFormat("yyyy-mm-ddTHH:MM:SS.ssszzz")
 end
 
-include("utils.jl")
 include("compat.jl")
+include("utils.jl")
+include("indexable_generator.jl")
+
 include("class.jl")
 include("utcoffset.jl")
 include(joinpath("types", "timezone.jl"))

--- a/src/indexable_generator.jl
+++ b/src/indexable_generator.jl
@@ -1,0 +1,14 @@
+struct IndexableGenerator{I,F}
+    g::Base.Generator{I,F}
+end
+
+IndexableGenerator(args...) = IndexableGenerator(Base.Generator(args...))
+Base.iterate(ig::IndexableGenerator, s...) = iterate(ig.g, s...)
+
+Base.length(ig::IndexableGenerator) = length(ig.g)
+Base.size(ig::IndexableGenerator) = size(ig.g)
+Base.axes(ig::IndexableGenerator) = axes(ig.g)
+Base.ndims(ig::IndexableGenerator) = ndims(ig.g)
+
+Base.getindex(ig::IndexableGenerator, i::Integer) = ig.g.f(ig.g.iter[i])
+Base.lastindex(ig::IndexableGenerator) = lastindex(ig.g.iter)

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -69,19 +69,19 @@ transition_range(::DateTime, ::VariableTimeZone, ::Type{Union{Local,UTC}})
 function interpret(local_dt::DateTime, tz::VariableTimeZone, ::Type{Local})
     t = tz.transitions
     r = transition_range(local_dt, tz, Local)
-    return (ZonedDateTime(local_dt - t[i].zone.offset, tz, t[i].zone) for i in r)
+
+    possible = (ZonedDateTime(local_dt - t[i].zone.offset, tz, t[i].zone) for i in r)
+    return IndexableGenerator(possible)
 end
 
 function interpret(utc_dt::DateTime, tz::VariableTimeZone, ::Type{UTC})
     t = tz.transitions
     r = transition_range(utc_dt, tz, UTC)
     length(r) == 1 || error("Internal TimeZones error: A UTC DateTime should only have a single interpretation")
-    return (ZonedDateTime(utc_dt, tz, t[i].zone) for i in r)
-end
 
-# TODO: Temporary type-piracy to make generators indexable
-Base.getindex(g::Base.Generator, i::Integer) = g.f(g.iter[i])
-Base.lastindex(g::Base.Generator) = lastindex(g.iter)
+    possible = (ZonedDateTime(utc_dt, tz, t[i].zone) for i in r)
+    return IndexableGenerator(possible)
+end
 
 """
     interpret(dt::DateTime, tz::VariableTimeZone, context::Type{Union{Local,UTC}}) -> Array{ZonedDateTime}

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -24,7 +24,8 @@ function transition_range(local_dt::DateTime, tz::VariableTimeZone, ::Type{Local
     # Usually we'll begin by having `start` be larger than `finish` to create an empty
     # range by default. In the scenario where last transition applies to the `local_dt` we
     # can avoid a bounds by setting `start = finish`.
-    start = finish < length(tz.transitions) ? finish + 1 : finish
+    len = length(tz.transitions)
+    start = finish < len ? finish + 1 : len
 
     # To determine the first transition that applies to the `local_dt` we will work
     # backwards. Typically, this loop will only use single iteration as multiple iterations

--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -1,7 +1,3 @@
-# TimeZone concepts used to disambiguate context of DateTimes
-# abstract type UTC <: TimeZone end # Defined in Dates
-abstract type Local <: TimeZone end
-
 # Compare a local instant to a UTC transition instant by using the offset to make them both
 # into local time. We could just as easily convert both of them into UTC time.
 lt_local(local_dt::DateTime, t::Transition) = isless(local_dt, t.utc_datetime + t.zone.offset)

--- a/src/types/variabletimezone.jl
+++ b/src/types/variabletimezone.jl
@@ -3,7 +3,7 @@ struct Transition
     zone::FixedTimeZone
 end
 
-Base.isless(x::Transition,y::Transition) = isless(x.utc_datetime,y.utc_datetime)
+Base.isless(a::Transition, b::Transition) = isless(a.utc_datetime, b.utc_datetime)
 
 """
     VariableTimeZone

--- a/src/types/zoneddatetime.jl
+++ b/src/types/zoneddatetime.jl
@@ -32,29 +32,26 @@ keyword is true the given `DateTime` is assumed to be in UTC instead of in local
 converted to the specified `TimeZone`.  Note that when `from_utc` is true the given
 `DateTime` will always exists and is never ambiguous.
 """
-function ZonedDateTime(dt::DateTime, tz::TimeZone; from_utc::Bool=false)
-    _ZonedDateTime(dt, tz, from_utc ? UTC : Local)
-end
+function ZonedDateTime(dt::DateTime, tz::VariableTimeZone; from_utc::Bool=false)
+    # Note: Using a function barrier which reduces allocations
+    function construct(T::Type{<:Union{Local,UTC}})
+        possible = interpret(dt, tz, T)
 
-function _ZonedDateTime(dt::DateTime, tz::VariableTimeZone, T::Type{<:Union{Local,UTC}})
-    possible = interpret(dt, tz, T)
-
-    num = length(possible)
-    if num == 1
-        return first(possible)
-    elseif num == 0
-        throw(NonExistentTimeError(dt, tz))
-    else
-        throw(AmbiguousTimeError(dt, tz))
+        num = length(possible)
+        if num == 1
+            return first(possible)
+        elseif num == 0
+            throw(NonExistentTimeError(dt, tz))
+        else
+            throw(AmbiguousTimeError(dt, tz))
+        end
     end
+
+    return construct(from_utc ? UTC : Local)
 end
 
-function _ZonedDateTime(local_dt::DateTime, tz::FixedTimeZone, ::Type{Local})
-    utc_dt = local_dt - tz.offset
-    return ZonedDateTime(utc_dt, tz, tz)
-end
-
-function _ZonedDateTime(utc_dt::DateTime, tz::FixedTimeZone, ::Type{UTC})
+function ZonedDateTime(dt::DateTime, tz::FixedTimeZone; from_utc::Bool=false)
+    utc_dt = from_utc ? dt : dt - tz.offset
     return ZonedDateTime(utc_dt, tz, tz)
 end
 

--- a/src/types/zoneddatetime.jl
+++ b/src/types/zoneddatetime.jl
@@ -32,8 +32,12 @@ keyword is true the given `DateTime` is assumed to be in UTC instead of in local
 converted to the specified `TimeZone`.  Note that when `from_utc` is true the given
 `DateTime` will always exists and is never ambiguous.
 """
-function ZonedDateTime(dt::DateTime, tz::VariableTimeZone; from_utc::Bool=false)
-    possible = interpret(dt, tz, from_utc ? UTC : Local)
+function ZonedDateTime(dt::DateTime, tz::TimeZone; from_utc::Bool=false)
+    _ZonedDateTime(dt, tz, from_utc ? UTC : Local)
+end
+
+function _ZonedDateTime(dt::DateTime, tz::VariableTimeZone, T::Type{<:Union{Local,UTC}})
+    possible = interpret(dt, tz, T)
 
     num = length(possible)
     if num == 1
@@ -45,8 +49,12 @@ function ZonedDateTime(dt::DateTime, tz::VariableTimeZone; from_utc::Bool=false)
     end
 end
 
-function ZonedDateTime(dt::DateTime, tz::FixedTimeZone; from_utc::Bool=false)
-    utc_dt = from_utc ? dt : dt - tz.offset
+function _ZonedDateTime(local_dt::DateTime, tz::FixedTimeZone, ::Type{Local})
+    utc_dt = local_dt - tz.offset
+    return ZonedDateTime(utc_dt, tz, tz)
+end
+
+function _ZonedDateTime(utc_dt::DateTime, tz::FixedTimeZone, ::Type{UTC})
     return ZonedDateTime(utc_dt, tz, tz)
 end
 

--- a/test/indexable_generator.jl
+++ b/test/indexable_generator.jl
@@ -1,0 +1,23 @@
+@testset "IndexableGenerator" begin
+    @testset "basic" begin
+        generator = TimeZones.IndexableGenerator(Char(i) for i in (1:26) .+ 96)
+
+        @test length(generator) == 26
+        @test size(generator) == (26,)
+        @test axes(generator) == (Base.OneTo(26),)
+        @test ndims(generator) == 1
+
+        @test generator[26] == 'z'
+        @test lastindex(generator) == 26
+
+        @test collect(generator) == 'a':'z'
+    end
+
+    @testset "constructors" begin
+        generator = TimeZones.IndexableGenerator(i -> Char(i), (1:26) .+ 96)
+        @test collect(generator) == 'a':'z'
+
+        generator = TimeZones.IndexableGenerator(Char, (1:26) .+ 96)
+        @test collect(generator) == 'a':'z'
+    end
+end

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -92,23 +92,23 @@ non_existent_neg = DateTime(2012,9,30,3)
 @test_throws AmbiguousTimeError ZonedDateTime(ambiguous_neg, apia)
 @test_throws NonExistentTimeError ZonedDateTime(non_existent_neg, apia)
 
-@test TimeZones.shift_gap(ambiguous_pos, apia) == ZonedDateTime[]
-@test TimeZones.shift_gap(non_existent_pos, apia) == [
+@test isempty(TimeZones.shift_gap(ambiguous_pos, apia))
+@test TimeZones.shift_gap(non_existent_pos, apia) == (
     ZonedDateTime(2011, 9, 24, 2, 59, 59, 999, apia),
     ZonedDateTime(2011, 9, 24, 4, apia),
-]
-@test TimeZones.shift_gap(ambiguous_neg, apia) == ZonedDateTime[]
-@test TimeZones.shift_gap(non_existent_neg, apia) == [
+)
+@test isempty(TimeZones.shift_gap(ambiguous_neg, apia))
+@test TimeZones.shift_gap(non_existent_neg, apia) == (
     ZonedDateTime(2012, 9, 30, 2, 59, 59, 999, apia),
     ZonedDateTime(2012, 9, 30, 4, apia),
-]
+)
 
 # Valid local datetimes close to the non-existent hour should have no boundaries as are
 # already valid.
-@test TimeZones.shift_gap(non_existent_pos - Second(1), apia) == ZonedDateTime[]
-@test TimeZones.shift_gap(non_existent_pos + Hour(1), apia) == ZonedDateTime[]
-@test TimeZones.shift_gap(non_existent_neg - Second(1), apia) == ZonedDateTime[]
-@test TimeZones.shift_gap(non_existent_neg + Hour(1), apia) == ZonedDateTime[]
+@test isempty(TimeZones.shift_gap(non_existent_pos - Second(1), apia))
+@test isempty(TimeZones.shift_gap(non_existent_pos + Hour(1), apia))
+@test isempty(TimeZones.shift_gap(non_existent_neg - Second(1), apia))
+@test isempty(TimeZones.shift_gap(non_existent_neg + Hour(1), apia))
 
 
 # Create custom VariableTimeZones to test corner cases
@@ -138,13 +138,17 @@ non_existent_2 = DateTime(1935,4,1,3)
 # Both "long" and "hidden" are identical for the following tests
 for tz in (long, hidden)
     local tz
-    boundaries = [
+    boundaries = (
         ZonedDateTime(1935, 4, 1, 1, 59, 59, 999, tz),
         ZonedDateTime(1935, 4, 1, 4, tz),
-    ]
+    )
 
+    @test_throws NonExistentTimeError ZonedDateTime(DateTime(0), tz)
     @test_throws NonExistentTimeError ZonedDateTime(non_existent_1, tz)
     @test_throws NonExistentTimeError ZonedDateTime(non_existent_2, tz)
+
+    # Unhandled datetimes should not be treated as a gap
+    @test isempty(TimeZones.shift_gap(DateTime(0), tz))
 
     @test TimeZones.shift_gap(non_existent_1, tz) == boundaries
     @test TimeZones.shift_gap(non_existent_2, tz) == boundaries

--- a/test/interpret.jl
+++ b/test/interpret.jl
@@ -1,3 +1,84 @@
+using Dates: Millisecond
+using TimeZones: transition_range
+
+@testset "lt_local / lt_utc" begin
+    t = Transition(DateTime(1977, 5, 26, 1), FixedTimeZone("PDT", -8 * 3600, 3600))
+    ms = Millisecond(1)
+
+    @testset "lt_local" begin
+        local_dt = DateTime(1977, 5, 25, 18)
+
+        @test TimeZones.lt_local(local_dt - ms, t)
+        @test !TimeZones.lt_local(local_dt, t)
+        @test !TimeZones.lt_local(local_dt + ms, t)
+
+        @test !TimeZones.lt_local(t, local_dt - ms)
+        @test !TimeZones.lt_local(t, local_dt)
+        @test TimeZones.lt_local(t, local_dt + ms)
+    end
+
+    @testset "lt_utc" begin
+        utc_dt = DateTime(1977, 5, 26, 1)
+
+        @test TimeZones.lt_utc(utc_dt - ms, t)
+        @test !TimeZones.lt_utc(utc_dt, t)
+        @test !TimeZones.lt_utc(utc_dt + ms, t)
+
+        @test !TimeZones.lt_utc(t, utc_dt - ms)
+        @test !TimeZones.lt_utc(t, utc_dt)
+        @test TimeZones.lt_utc(t, utc_dt + ms)
+    end
+end
+
+@testset "transition_range" begin
+    # TODO: Redundancy with test from ZonedDateTime
+    @testset "multiple hour transitions" begin
+        # Transitions changes that exceed an hour. Results in having two sequential
+        # non-existent hour and two sequential ambiguous hours.
+        tz = VariableTimeZone("Testing", [
+            Transition(DateTime(1800,1,1), FixedTimeZone("TST",0,0)),
+            Transition(DateTime(1950,4,1), FixedTimeZone("TDT",0,7200)),
+            Transition(DateTime(1950,9,1), FixedTimeZone("TST",0,0)),
+        ])
+
+        ### Local ###
+
+        # Initial transition
+        @test transition_range(DateTime(1799, 12, 31, 23), tz, Local) == 1:0
+        @test transition_range(DateTime(1800, 01, 01, 00), tz, Local) == 1:1
+
+        # A "spring forward" where 2 hours are skipped.
+        @test transition_range(DateTime(1950, 03, 31, 23), tz, Local) == 1:1
+        @test transition_range(DateTime(1950, 04, 01, 00), tz, Local) == 2:1  # 00:00 TST/TDT
+        @test transition_range(DateTime(1950, 04, 01, 01), tz, Local) == 2:1  # 01:00 TST/TDT
+        @test transition_range(DateTime(1950, 04, 01, 02), tz, Local) == 2:2
+
+        # A "fall back" where 2 hours are duplicated. Never appears to occur in reality.
+        @test transition_range(DateTime(1950, 08, 31, 23), tz, Local) == 2:2
+        @test transition_range(DateTime(1950, 09, 01, 00), tz, Local) == 2:3  # 00:00 TDT/TST
+        @test transition_range(DateTime(1950, 09, 01, 01), tz, Local) == 2:3  # 01:00 TDT/TST
+        @test transition_range(DateTime(1950, 09, 01, 02), tz, Local) == 3:3
+
+        ### UTC ###
+
+        # Initial transition
+        @test transition_range(DateTime(1799, 12, 31, 23), tz, UTC) == 1:0
+        @test transition_range(DateTime(1800, 01, 01, 00), tz, UTC) == 1:1
+
+        # A "spring forward" where 2 hours are skipped.
+        @test transition_range(DateTime(1950, 03, 31, 23), tz, UTC) == 1:1  # 23:00 TST
+        @test transition_range(DateTime(1950, 04, 01, 00), tz, UTC) == 2:2  # 02:00 TDT
+
+        # A "fall back" where 2 hours are duplicated. Never appears to occur in reality.
+        @test transition_range(DateTime(1950, 08, 31, 21), tz, UTC) == 2:2
+        @test transition_range(DateTime(1950, 08, 31, 22), tz, UTC) == 2:2  # 00:00 TDT
+        @test transition_range(DateTime(1950, 08, 31, 23), tz, UTC) == 2:2  # 01:00 TDT
+        @test transition_range(DateTime(1950, 09, 01, 00), tz, UTC) == 3:3  # 00:00 TST
+        @test transition_range(DateTime(1950, 09, 02, 00), tz, UTC) == 3:3  # 01:00 TST
+        @test transition_range(DateTime(1950, 09, 03, 00), tz, UTC) == 3:3
+    end
+end
+
 # Contains both positive and negative UTC offsets and observes daylight saving time.
 apia = first(compile("Pacific/Apia", tzdata["australasia"]))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,8 @@ include("helpers.jl")
 
 @testset "TimeZones" begin
     include("utils.jl")
+    include("indexable_generator.jl")
+
     include("class.jl")
     include(joinpath("tzdata", "timeoffset.jl"))
     include(joinpath("tzdata", "archive.jl"))


### PR DESCRIPTION
Fixes #289. While looking into ways to avoid having `interpret` create a vector I realized that improvements to `transition_range` could result in us avoiding having to perform checks later in `interpret`. Doing this made `transition_range` slightly slower but allowed us to use a generator in `interpret` which avoided allocations. I then found myself wanting to index into a generator to avoid having to construct unnecessary `ZonedDateTime`s which resulted in me creating the `IndexableGenerator` (I'll try to make a Base PR for this). Finally, I noticed one more allocation in the `ZonedDateTime(dt::DateTime, tz::VariableTimeZone ; from_utc::Bool)` constructor which I addressed by introducing a function barrier.

The end result brings us down to a single allocation for the `ZonedDateTime` and zero allocation when using the [isbits type PR](#287).

Benchmarks on Julia 1.5.1:

PR:

```julia
julia> using TimeZones, BenchmarkTools

julia> @benchmark TimeZones.transition_range($(DateTime(2015,11,1,1)), $(tz"America/Winnipeg"), $Local)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     22.847 ns (0.00% GC)
  median time:      22.910 ns (0.00% GC)
  mean time:        30.983 ns (0.00% GC)
  maximum time:     1.253 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     996

julia> @benchmark TimeZones.interpret($(DateTime(2015,11,1,1)), $(tz"America/Winnipeg"), $Local)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     24.096 ns (0.00% GC)
  median time:      24.993 ns (0.00% GC)
  mean time:        35.547 ns (0.00% GC)
  maximum time:     1.875 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     995

julia> @benchmark ZonedDateTime($(DateTime(2015,11,1,1)), $(tz"America/Winnipeg"), 2)
BenchmarkTools.Trial:
  memory estimate:  48 bytes
  allocs estimate:  1
  --------------
  minimum time:     38.280 ns (0.00% GC)
  median time:      38.915 ns (0.00% GC)
  mean time:        50.162 ns (2.74% GC)
  maximum time:     2.441 μs (96.29% GC)
  --------------
  samples:          10000
  evals/sample:     992

julia> @benchmark ZonedDateTime($(DateTime(2015,6,1)), $(tz"America/Winnipeg"), from_utc=true)
BenchmarkTools.Trial:
  memory estimate:  48 bytes
  allocs estimate:  1
  --------------
  minimum time:     42.385 ns (0.00% GC)
  median time:      43.016 ns (0.00% GC)
  mean time:        53.853 ns (1.98% GC)
  maximum time:     2.580 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     990
```

Current master (48fe988):

```julia
julia> using TimeZones, BenchmarkTools

julia> @benchmark TimeZones.transition_range($(DateTime(2015,11,1,1)), $(tz"America/Winnipeg"), $Local)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     15.793 ns (0.00% GC)
  median time:      15.833 ns (0.00% GC)
  mean time:        19.110 ns (0.00% GC)
  maximum time:     926.346 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     998

julia> @benchmark TimeZones.interpret($(DateTime(2015,11,1,1)), $(tz"America/Winnipeg"), $Local)
BenchmarkTools.Trial:
  memory estimate:  352 bytes
  allocs estimate:  4
  --------------
  minimum time:     98.732 ns (0.00% GC)
  median time:      101.708 ns (0.00% GC)
  mean time:        134.360 ns (9.06% GC)
  maximum time:     2.939 μs (94.61% GC)
  --------------
  samples:          10000
  evals/sample:     944

julia> @benchmark ZonedDateTime($(DateTime(2015,11,1,1)), $(tz"America/Winnipeg"), 2)
BenchmarkTools.Trial:
  memory estimate:  352 bytes
  allocs estimate:  4
  --------------
  minimum time:     104.684 ns (0.00% GC)
  median time:      107.021 ns (0.00% GC)
  mean time:        139.278 ns (8.58% GC)
  maximum time:     3.300 μs (94.68% GC)
  --------------
  samples:          10000
  evals/sample:     919

julia> @benchmark ZonedDateTime($(DateTime(2015,6,1)), $(tz"America/Winnipeg"), from_utc=true)
BenchmarkTools.Trial:
  memory estimate:  176 bytes
  allocs estimate:  2
  --------------
  minimum time:     55.916 ns (0.00% GC)
  median time:      57.818 ns (0.00% GC)
  mean time:        76.190 ns (5.72% GC)
  maximum time:     2.519 μs (96.18% GC)
  --------------
  samples:          10000
  evals/sample:     983
```