### PR TITLE
WIP: Compile time zone information during package

### DIFF
--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -38,6 +38,8 @@ const DEPS_DIR = joinpath(PKG_DIR, "deps")
 abstract type Local <: TimeZone end
 
 function __init__()
+    copy!(TIME_ZONE_CACHE, TZData.compile())
+
     # Base extension needs to happen everytime the module is loaded (issue #24)
     Dates.CONVERSION_SPECIFIERS['z'] = TimeZone
     Dates.CONVERSION_SPECIFIERS['Z'] = TimeZone

--- a/src/types/timezone.jl
+++ b/src/types/timezone.jl
@@ -44,18 +44,8 @@ function TimeZone(str::AbstractString, mask::Class=Class(:DEFAULT))
     # Note: If the class `mask` does not match the time zone we'll still load the
     # information into the cache to ensure the result is consistent.
     tz, class = get!(TIME_ZONE_CACHE, str) do
-        tz_path = joinpath(TZData.COMPILED_DIR, split(str, "/")...)
-
-        if isfile(tz_path)
-            open(deserialize, tz_path, "r")
-        elseif occursin(FIXED_TIME_ZONE_REGEX, str)
+        if occursin(FIXED_TIME_ZONE_REGEX, str)
             FixedTimeZone(str), Class(:FIXED)
-        elseif !isdir(TZData.COMPILED_DIR) || isempty(readdir(TZData.COMPILED_DIR))
-            # Note: Julia 1.0 supresses the build logs which can hide issues in time zone
-            # compliation which result in no tzdata time zones being available.
-            throw(ArgumentError(
-                "Unable to find time zone \"$str\". Try running `TimeZones.build()`."
-            ))
         else
             throw(ArgumentError("Unknown time zone \"$str\""))
         end

--- a/src/tzdata/compile.jl
+++ b/src/tzdata/compile.jl
@@ -711,8 +711,13 @@ function compile(tz_source::TZSource, dest_dir::AbstractString; kwargs...)
     return results
 end
 
-# TODO: Deprecate?
-function compile(tz_source_dir::AbstractString=TZ_SOURCE_DIR, dest_dir::AbstractString=COMPILED_DIR; kwargs...)
-    tz_source_paths = joinpath.(tz_source_dir, readdir(tz_source_dir))
-    compile(TZSource(tz_source_paths), dest_dir; kwargs...)
+function compile(; kwargs...)
+    results = Dict{String,Tuple{TimeZone,Class}}()
+    tz_source = TZSource(joinpath.(TZ_SOURCE_DIR, REGIONS))
+
+    for (tz, class) in compile(tz_source; kwargs...)
+        results[TimeZones.name(tz)] = (tz, class)
+    end
+
+    return results
 end


### PR DESCRIPTION
Fixes #288. Originally TimeZones.jl serialized the compiled time zone information to reduce the time it took to load the package. Julia has had many improvements since then and now it seems feasible to compile the time zone information during package initialization 