### PR TITLE
Broadcast arithmetic with `StepRange{ZonedDateTime}` returns a `StepRange`

### DIFF
--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -42,7 +42,7 @@ function broadcasted(::typeof(+), r::StepRange{ZonedDateTime}, p::DatePeriod)
 end
 
 function broadcasted(::typeof(+), r::StepRange{ZonedDateTime}, p::TimePeriod)
-    StepRange(r.start + p, r.step, r.stop + p)
+    return StepRange(r.start + p, r.step, r.stop + p)
 end
 
 broadcasted(::typeof(+), p::Period, r::StepRange{ZonedDateTime}) = broadcasted(+, r, p)

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -41,4 +41,10 @@ function broadcasted(::typeof(+), r::StepRange{ZonedDateTime}, p::DatePeriod)
     return StepRange(start, step, stop)
 end
 
-broadcasted(::typeof(-), r::StepRange{ZonedDateTime}, p::DatePeriod) = broadcast(+, r, -p)
+function broadcasted(::typeof(+), r::StepRange{ZonedDateTime}, p::TimePeriod)
+    StepRange(r.start + p, r.step, r.stop + p)
+end
+
+broadcasted(::typeof(+), p::Period, r::StepRange{ZonedDateTime}) = broadcasted(+, r, p)
+broadcasted(::typeof(-), r::StepRange{ZonedDateTime}, p::Period) = broadcasted(+, r, -p)
+broadcasted(::typeof(-), p::Period, r::StepRange{ZonedDateTime}) = broadcasted(-, r, p)


### PR DESCRIPTION

In re-evaluating the performance of [this old benchmark](https://github.com/JuliaTime/TimeZones.jl/issues/182#issuecomment-459380018) I noticed the performance has actually gotten worse with the recent changes even though there are less allocations:

```julia
julia> using Dates, TimeZones, BenchmarkTools

julia> @btime (DateTime(2019):Day(1):DateTime(2020)) .+ Minute(1);
  309.455 ns (1 allocation: 3.00 KiB)

julia> @btime (ZonedDateTime(2019,tz"UTC"):Day(1):ZonedDateTime(2020,tz"UTC")) .+ Minute(1);
  7.023 μs (1 allocation: 14.44 KiB)
```

Upon investigating I was surprized that a `Vector` was returned instead of a `StepRange`:
```julia
julia> @btime (ZonedDateTime(2019,tz"UTC"):Day(1):ZonedDateTime(2020,tz"UTC")) .+ Minute(1)
  7.061 μs (1 allocation: 14.44 KiB)
366-element Array{ZonedDateTime,1}:
 2019-01-01T00:01:00+00:00
 2019-01-02T00:01:00+00:00
 2019-01-03T00:01:00+00:00
 ⋮
 2019-12-30T00:01:00+00:00
 2019-12-31T00:01:00+00:00
 2020-01-01T00:01:00+00:00
 ```

This PR changes arithmetic for `StepRange{ZonedDateTime}` to return a `StepRange` instead of a `Vector`:
```julia
julia> @btime (ZonedDateTime(2019,tz"UTC"):Day(1):ZonedDateTime(2020,tz"UTC")) .+ Minute(1)
  130.477 ns (0 allocations: 0 bytes)
ZonedDateTime(2019, 1, 1, 0, 1, tz"UTC"):Day(1):ZonedDateTime(2020, 1, 1, 0, 1, tz"UTC")
```

I'm also attempting to get this changed for `TimeType`s in general: https://github.com/JuliaLang/julia/pull/37759