### PR TITLE
Update ZonedDateTime range benchmarks

### DIFF
--- a/benchmark/arithmetic.jl
+++ b/benchmark/arithmetic.jl
@@ -8,3 +8,19 @@ SUITE["arithmetic"]["TimePeriod"] = begin
     zdt = ZonedDateTime(2000, 1, 2, tz"America/Winnipeg")
     @benchmarkable $zdt + $(Hour(1))
 end
+
+
+SUITE["arithmetic"]["broadcast"] = BenchmarkGroup()
+
+SUITE["arithmetic"]["broadcast"]["VariableTimeZone/TimePeriod"] = begin
+    @benchmarkable $(gen_range(Hour(100), tz"America/Winnipeg")) .+ Hour(1)
+end
+SUITE["arithmetic"]["broadcast"]["VariableTimeZone/DatePeriod"] = begin
+    @benchmarkable $(gen_range(Day(100), tz"America/Winnipeg")) .+ Day(1)
+end
+SUITE["arithmetic"]["broadcast"]["FixedTimeZone/TimePeriod"] = begin
+    @benchmarkable $(gen_range(Hour(100), tz"UTC")) .+ Hour(1)
+end
+SUITE["arithmetic"]["broadcast"]["FixedTimeZone/DatePeriod"] = begin
+    @benchmarkable $(gen_range(Day(100), tz"UTC")) .+ Day(1)
+end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,10 +1,15 @@
 using BenchmarkTools
-using Dates: Day, Hour, DateFormat, @dateformat_str
+using Dates: Period, Day, Hour, DateFormat, @dateformat_str
 using TimeZones
 using TimeZones.TZData: parse_components
 using Test: GenericString
 
 const SUITE = BenchmarkGroup()
+
+function gen_range(num_units::Period, tz::TimeZone)
+    zdt = ZonedDateTime(2000, tz)
+    return StepRange(zdt, oneunit(num_units), zdt + num_units)
+end
 
 include("tzdata.jl")
 include("interpret.jl")

--- a/benchmark/zoneddatetime.jl
+++ b/benchmark/zoneddatetime.jl
@@ -12,11 +12,20 @@ SUITE["ZonedDateTime"]["utc"] = begin
     @benchmarkable ZonedDateTime($(DateTime(2015,1,1)), $(tz"America/Winnipeg"), from_utc=true)
 end
 
-SUITE["ZonedDateTime"]["time-period-range"] = begin
-    @benchmarkable collect($(ZonedDateTime(2020, tz"America/Winnipeg"):Hour(1):ZonedDateTime(2021, tz"America/Winnipeg")))
+
+SUITE["ZonedDateTime"]["range"] = BenchmarkGroup()
+
+SUITE["ZonedDateTime"]["range"]["VariableTimeZone/TimePeriod"] = begin
+    @benchmarkable collect($(gen_range(Hour(100), tz"America/Winnipeg")))
 end
-SUITE["ZonedDateTime"]["date-period-range"] = begin
-    @benchmarkable collect($(ZonedDateTime(2020, tz"America/Winnipeg"):Day(1):ZonedDateTime(2021, tz"America/Winnipeg")))
+SUITE["ZonedDateTime"]["range"]["VariableTimeZone/DatePeriod"] = begin
+    @benchmarkable collect($(gen_range(Day(100), tz"America/Winnipeg")))
+end
+SUITE["ZonedDateTime"]["range"]["FixedTimeZone/TimePeriod"] = begin
+    @benchmarkable collect($(gen_range(Hour(100), tz"UTC")))
+end
+SUITE["ZonedDateTime"]["range"]["FixedTimeZone/DatePeriod"] = begin
+    @benchmarkable collect($(gen_range(Day(100), tz"UTC")))
 end
 
 # https://github.com/JuliaTime/TimeZones.jl/pull/287#issuecomment-687358202


### PR DESCRIPTION
Making the number of Date/Time periods in the ranges consistent so that they can be compared. New benchmarks are useful for testing #296