### PR TITLE
Replace `DateTime(zdt, Local)` with `DateTime(zdt)`

### DIFF
--- a/docs/src/api-public.md
+++ b/docs/src/api-public.md
@@ -34,9 +34,12 @@ ZonedDateTime(::DateTime, ::VariableTimeZone, ::Integer)
 ZonedDateTime(::DateTime, ::VariableTimeZone, ::Bool)
 astimezone
 TimeZones.timezone(::ZonedDateTime)
-DateTime(::ZonedDateTime, ::Union{Type{Local}, Type{UTC}})
-Date(::ZonedDateTime, ::Union{Type{Local}, Type{UTC}})
-Time(::ZonedDateTime, ::Union{Type{Local}, Type{UTC}})
+DateTime(::ZonedDateTime)
+DateTime(::ZonedDateTime, ::Type{UTC})
+Date(::ZonedDateTime)
+Date(::ZonedDateTime, ::Type{UTC})
+Time(::ZonedDateTime)
+Time(::ZonedDateTime, ::Type{UTC})
 ```
 
 ## Current Time

--- a/docs/src/conversions.md
+++ b/docs/src/conversions.md
@@ -9,14 +9,14 @@ end
 ## Converting Date/Time without time zone information
 
 To convert from a `ZonedDateTime` into a vanilla `DateTime`, one can use the `DateTime` constructor.
-Passing either `Local` to directly drop the time zone,  or `UTC` to extract the time as UTC instead.
-The canonical way to represent datetimes is generally in `UTC`, as this is a requirement to correctly compute the [Unix Timestamp](https://en.wikipedia.org/wiki/Unix_time).
+Just passing in the `ZonedDateTime` will directly drop the time zone, and passing in `UTC` as the second argument will extract the time as UTC instead.
+Note: The canonical way to represent datetimes is generally in `UTC`, as this is a requirement to correctly compute the [Unix Timestamp](https://en.wikipedia.org/wiki/Unix_time).
 
 ```jldoctest
 julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
 2014-05-30T21:00:00-04:00
 
-julia> DateTime(zdt, Local)
+julia> DateTime(zdt)
 2014-05-30T21:00:00
 
 julia> DateTime(zdt, UTC)
@@ -29,14 +29,15 @@ Similar can be done for `Date` and `Time`:
 julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
 2014-05-30T21:00:00-04:00
 
-julia> Date(zdt, Local)
+julia> Date(zdt)
 2014-05-30
 
 julia> Date(zdt, UTC)
 2014-05-31
 
-julia> Time(zdt, Local)
+julia> Time(zdt)
 21:00:00
+
 julia> Time(zdt, UTC)
 01:00:00
 ```

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -7,12 +7,12 @@ Returns the `TimeZone` used by the `ZonedDateTime`.
 """
 timezone(zdt::ZonedDateTime) = zdt.timezone
 
-Dates.days(zdt::ZonedDateTime) = days(DateTime(zdt, Local))
+Dates.days(zdt::ZonedDateTime) = days(DateTime(zdt))
 
 for period in (:Hour, :Minute, :Second, :Millisecond)
     accessor = Symbol(lowercase(string(period)))
     @eval begin
-        Dates.$accessor(zdt::ZonedDateTime) = $accessor(DateTime(zdt, Local))
+        Dates.$accessor(zdt::ZonedDateTime) = $accessor(DateTime(zdt))
         Dates.$period(zdt::ZonedDateTime) = $period($accessor(zdt))
     end
 end

--- a/src/adjusters.jl
+++ b/src/adjusters.jl
@@ -6,10 +6,10 @@ using Dates: DatePeriod, TimePeriod, firstdayofweek, lastdayofweek,
 # Truncation
 # TODO: Just utilize floor code for truncation?
 function Base.trunc(zdt::ZonedDateTime, ::Type{P}) where P <: DatePeriod
-    ZonedDateTime(trunc(DateTime(zdt, Local), P), timezone(zdt))
+    ZonedDateTime(trunc(DateTime(zdt), P), timezone(zdt))
 end
 function Base.trunc(zdt::ZonedDateTime, ::Type{P}) where P <: TimePeriod
-    local_dt = trunc(DateTime(zdt, Local), P)
+    local_dt = trunc(DateTime(zdt), P)
     utc_dt = local_dt - zdt.zone.offset
     ZonedDateTime(utc_dt, timezone(zdt); from_utc=true)
 end
@@ -19,6 +19,6 @@ Base.trunc(zdt::ZonedDateTime, ::Type{Millisecond}) = zdt
 for prefix in ("firstdayof", "lastdayof"), suffix in ("week", "month", "year", "quarter")
     func = Symbol(prefix * suffix)
     @eval function Dates.$func(zdt::ZonedDateTime)
-        ZonedDateTime($func(DateTime(zdt, Local)), zdt.timezone)
+        ZonedDateTime($func(DateTime(zdt)), zdt.timezone)
     end
 end

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -5,13 +5,13 @@ Base.:(+)(x::ZonedDateTime) = x
 Base.:(-)(x::ZonedDateTime, y::ZonedDateTime) = x.utc_datetime - y.utc_datetime
 
 function Base.:(+)(zdt::ZonedDateTime, p::DatePeriod)
-    return ZonedDateTime(DateTime(zdt, Local) + p, timezone(zdt))
+    return ZonedDateTime(DateTime(zdt) + p, timezone(zdt))
 end
 function Base.:(+)(zdt::ZonedDateTime, p::TimePeriod)
     return ZonedDateTime(DateTime(zdt, UTC) + p, timezone(zdt); from_utc=true)
 end
 function Base.:(-)(zdt::ZonedDateTime, p::DatePeriod)
-    return ZonedDateTime(DateTime(zdt, Local) - p, timezone(zdt))
+    return ZonedDateTime(DateTime(zdt) - p, timezone(zdt))
 end
 function Base.:(-)(zdt::ZonedDateTime, p::TimePeriod)
     return ZonedDateTime(DateTime(zdt, UTC) - p, timezone(zdt); from_utc=true)
@@ -26,14 +26,14 @@ function broadcasted(::typeof(+), r::StepRange{ZonedDateTime}, p::DatePeriod)
 
     tz = timezone(start)
     if isa(tz, VariableTimeZone)
-        start = first_valid(DateTime(start, Local) + p, tz, step)
+        start = first_valid(DateTime(start) + p, tz, step)
     else
         start = start + p
     end
 
     tz = timezone(stop)
     if isa(tz, VariableTimeZone)
-        stop = last_valid(DateTime(stop, Local) + p, tz, step)
+        stop = last_valid(DateTime(stop) + p, tz, step)
     else
         stop = stop + p
     end

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -143,7 +143,7 @@ julia> today(tz"Pacific/Midway"), today(tz"Pacific/Apia")
 (2017-11-09, 2017-11-10)
 ```
 """
-Dates.today(tz::TimeZone) = Date(now(tz), Local)
+Dates.today(tz::TimeZone) = Date(now(tz))
 
 """
     todayat(tod::Time, tz::TimeZone, [amb]) -> ZonedDateTime
@@ -182,7 +182,7 @@ function astimezone(zdt::ZonedDateTime, tz::VariableTimeZone)
     )
 
     if i == 0
-        throw(NonExistentTimeError(DateTime(zdt, Local), tz))
+        throw(NonExistentTimeError(DateTime(zdt), tz))
     end
 
     zone = tz.transitions[i].zone

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -4,12 +4,12 @@ using Mocking: Mocking, @mock
 # UTC is an abstract type defined in Dates, for some reason
 const utc_tz = FixedTimeZone("UTC")
 
-"""
-    DateTime(zdt::ZonedDateTime, ::Union{Type{Local}, Type{UTC}}) -> DateTime
 
-Create a `DateTime` which is implicitly associated with a time zone. The result can be
-specified to either be in `UTC` or `Local` (relative to the provided `ZonedDateTime` and not
-user's system time zone).
+"""
+    DateTime(zdt::ZonedDateTime) -> DateTime
+
+Create a `DateTime` by dropping the associated time zone. Effectively, this new `DateTime`
+is implicitly associated with `timezone(zdt)`.
 
 # Example
 
@@ -17,25 +17,35 @@ user's system time zone).
 julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
 2014-05-30T21:00:00-04:00
 
-julia> DateTime(zdt, Local)
+julia> DateTime(zdt)
 2014-05-30T21:00:00
+```
+"""
+Dates.DateTime(zdt::ZonedDateTime) = zdt.utc_datetime + zdt.zone.offset
+
+"""
+    DateTime(zdt::ZonedDateTime, ::Type{UTC}) -> DateTime
+
+Create a `DateTime` which is implicitly associated with UTC.
+
+# Example
+
+```jldoctest
+julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
+2014-05-30T21:00:00-04:00
 
 julia> DateTime(zdt, UTC)
 2014-05-31T01:00:00
 ```
 """
-DateTime(::ZonedDateTime, ::Union{Type{Local}, Type{UTC}})
-
-Dates.DateTime(zdt::ZonedDateTime, ::Type{Local}) = zdt.utc_datetime + zdt.zone.offset
 Dates.DateTime(zdt::ZonedDateTime, ::Type{UTC}) = zdt.utc_datetime
 
 
 """
-    Date(zdt::ZonedDateTime, ::Union{Type{Local}, Type{UTC}}) -> Date
+    Date(zdt::ZonedDateTime) -> Date
 
-Create a `Date` which is implicitly associated with a time zone. The result can be
-specified to either be in `UTC` or `Local` (relative to the provided `ZonedDateTime` and not
-user's system time zone).
+Create a `Date` by dropping the associated time zone. Effectively, this new `Date`
+is implicitly associated with `timezone(zdt)`.
 
 # Example
 
@@ -43,25 +53,36 @@ user's system time zone).
 julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
 2014-05-30T21:00:00-04:00
 
-julia> Date(zdt, Local)
+julia> Date(zdt)
 2014-05-30
+```
+"""
+Dates.Date(zdt::ZonedDateTime) = Date(DateTime(zdt))
+
+
+"""
+    Date(zdt::ZonedDateTime, ::Type{UTC}) -> Date
+
+Create a `Date` which is implicitly associated with UTC.
+
+# Example
+
+```jldoctest
+julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
+2014-05-30T21:00:00-04:00
 
 julia> Date(zdt, UTC)
 2014-05-31
 ```
 """
-Date(::ZonedDateTime, ::Union{Type{Local}, Type{UTC}})
-
-Dates.Date(zdt::ZonedDateTime, ::Type{Local}) = Date(DateTime(zdt, Local))
 Dates.Date(zdt::ZonedDateTime, ::Type{UTC}) = Date(DateTime(zdt, UTC))
 
 
 """
-    Time(zdt::ZonedDateTime, ::Union{Type{Local}, Type{UTC}}) -> Time
+    Time(zdt::ZonedDateTime) -> Time
 
-Create a `Time` which is implicitly associated with a time zone. The result can be
-specified to either be in `UTC` or `Local` (relative to the provided `ZonedDateTime` and not
-user's system time zone).
+Create a `Time` by dropping the associated time zone. Effectively, this new `Time`
+is implicitly associated with `timezone(zdt)`.
 
 # Example
 
@@ -69,16 +90,28 @@ user's system time zone).
 julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
 2014-05-30T21:00:00-04:00
 
-julia> Time(zdt, Local)
+julia> Time(zdt)
 21:00:00
+```
+"""
+Dates.Time(zdt::ZonedDateTime) = Time(DateTime(zdt))
+
+
+"""
+    Time(zdt::ZonedDateTime, ::Type{UTC}) -> Date
+
+Create a `Time` which is implicitly associated with UTC.
+
+# Example
+
+```jldoctest
+julia> zdt = ZonedDateTime(2014, 5, 30, 21, tz"UTC-4")
+2014-05-30T21:00:00-04:00
 
 julia> Time(zdt, UTC)
 01:00:00
 ```
 """
-Time(::ZonedDateTime, ::Union{Type{Local}, Type{UTC}})
-
-Dates.Time(zdt::ZonedDateTime, ::Type{Local}) = Time(DateTime(zdt, Local))
 Dates.Time(zdt::ZonedDateTime, ::Type{UTC}) = Time(DateTime(zdt, UTC))
 
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -2,8 +2,8 @@ using Base: @deprecate
 
 # BEGIN TimeZones 1.0 deprecations
 
-@deprecate Dates.DateTime(zdt::ZonedDateTime, ::Type{Local}) DateTime(zdt)
-@deprecate Dates.Date(zdt::ZonedDateTime, ::Type{Local}) Date(zdt)
-@deprecate Dates.Time(zdt::ZonedDateTime, ::Type{Local}) Time(zdt)
+@deprecate DateTime(zdt::ZonedDateTime, ::Type{Local}) DateTime(zdt)
+@deprecate Date(zdt::ZonedDateTime, ::Type{Local}) Date(zdt)
+@deprecate Time(zdt::ZonedDateTime, ::Type{Local}) Time(zdt)
 
 # END TimeZones 1.0 deprecations

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,4 +1,9 @@
 using Base: @deprecate
 
 # BEGIN TimeZones 1.0 deprecations
+
+@deprecate Dates.DateTime(zdt::ZonedDateTime, ::Type{Local}) DateTime(zdt)
+@deprecate Dates.Date(zdt::ZonedDateTime, ::Type{Local}) Date(zdt)
+@deprecate Dates.Time(zdt::ZonedDateTime, ::Type{Local}) Time(zdt)
+
 # END TimeZones 1.0 deprecations

--- a/src/io.jl
+++ b/src/io.jl
@@ -50,7 +50,7 @@ function Base.print(io::IO, t::Transition)
     !isempty(t.zone.name) && print(io, " (", t.zone.name, ")")
 end
 
-Base.print(io::IO, zdt::ZonedDateTime) = print(io, DateTime(zdt, Local), zdt.zone.offset)
+Base.print(io::IO, zdt::ZonedDateTime) = print(io, DateTime(zdt), zdt.zone.offset)
 
 
 function Base.show(io::IO, tz::FixedTimeZone)

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -10,7 +10,7 @@ for details on the options and their tradeoffs.
 @recipe function f(xs::AbstractVector{<:ZonedDateTime}, ys)
     if !isempty(xs)
         tz = timezone(first(xs))  # convert all to same timezone as first one
-        new_xs = DateTime.(astimezone.(xs, tz), Local)
+        new_xs = DateTime.(astimezone.(xs, tz))
 
         # xguide is the proper name for xlabel
         label = get(plotattributes, :xguide, "")

--- a/src/rounding.jl
+++ b/src/rounding.jl
@@ -1,18 +1,18 @@
 using Dates: Period, DatePeriod, TimePeriod
 
 function Base.floor(zdt::ZonedDateTime, p::DatePeriod)
-    return ZonedDateTime(floor(DateTime(zdt, Local), p), timezone(zdt))
+    return ZonedDateTime(floor(DateTime(zdt), p), timezone(zdt))
 end
 
 function Base.floor(zdt::ZonedDateTime, p::TimePeriod)
     # Rounding is done using the current fixed offset to avoid transitional ambiguities.
-    dt = floor(DateTime(zdt, Local), p)
+    dt = floor(DateTime(zdt), p)
     utc_dt = dt - zdt.zone.offset
     return ZonedDateTime(utc_dt, timezone(zdt); from_utc=true)
 end
 
 function Base.ceil(zdt::ZonedDateTime, p::DatePeriod)
-    return ZonedDateTime(ceil(DateTime(zdt, Local), p), timezone(zdt))
+    return ZonedDateTime(ceil(DateTime(zdt), p), timezone(zdt))
 end
 
 #function Dates.floorceil(zdt::ZonedDateTime, p::Dates.DatePeriod)

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -10,7 +10,7 @@ midway = first(compile("Pacific/Midway", tzdata["australasia"]))
     # Constructing a ZonedDateTime from a DateTime and the reverse
     dt = DateTime(2019, 4, 11, 0)
     zdt = ZonedDateTime(dt, warsaw)
-    @test DateTime(zdt, Local) == DateTime(2019, 4, 11, 0)
+    @test DateTime(zdt) == DateTime(2019, 4, 11, 0)
     @test DateTime(zdt, UTC) == DateTime(2019, 4, 10, 22)
 
     # Converting between ZonedDateTime and DateTime isn't possible as it isn't lossless.
@@ -21,7 +21,7 @@ end
 @testset "Construct Date / ZonedDateTime" begin
     date = Date(2018, 6, 14)
     zdt = ZonedDateTime(date, warsaw)
-    @test Date(zdt, Local) == Date(2018, 6, 14)
+    @test Date(zdt) == Date(2018, 6, 14)
     @test Date(zdt, UTC) == Date(2018, 6, 13)
 
     # Converting between ZonedDateTime and Date isn't possible as it isn't lossless.
@@ -31,7 +31,7 @@ end
 
 @testset "Construct Time" begin
     zdt = ZonedDateTime(2017, 8, 21, 0, 12, warsaw)
-    @test Time(zdt, Local) == Time(0, 12)
+    @test Time(zdt) == Time(0, 12)
     @test Time(zdt, UTC) == Time(22, 12)
 
     # Converting between ZonedDateTime and Time isn't possible as it isn't lossless.
@@ -53,7 +53,7 @@ end
 @testset "todayat" begin
     @testset "current time" begin
         local zdt = now(warsaw)
-        now_time = Time(zdt, Local)
+        now_time = Time(zdt)
         @test todayat(now_time, warsaw) == zdt
     end
 

--- a/test/plotting.jl
+++ b/test/plotting.jl
@@ -8,7 +8,7 @@
     zoned_dates = start_zdt:Hour(1):end_zdt
 
     # what the point should be after recipe is applied
-    expected_dates = DateTime.(zoned_dates, Local)
+    expected_dates = DateTime.(zoned_dates)
 
     @testset "No label (should now say the Timezone)" begin
         # The below use of `apply_recipe` is equivelent to:


### PR DESCRIPTION
It was brought up that there is some confusion around `Local` (meaning local to the time zone provided) and `localzone()` (meaning the user's system time zone). When we originally [switched from using `localtime`/`utc`](https://github.com/JuliaTime/TimeZones.jl/pull/231) it appears the intent was to be explicit. As it seems that most people want to drop the time zone info we'll change things such that `DateTime(zdt)` means drop the time zone and `DateTime(zdt, UTC)` provides the `DateTime` implicitly in `UTC`.