### PR TITLE
Ensure CUSTOM_REGIONS get compiled

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeZones"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 authors = ["Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "1.5.0"
+version = "1.5.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -53,7 +53,7 @@ function build(
 
         if !isempty(tz_source_dir)
             @info "Installing $version tzdata region data"
-            regions = intersect(regions, readdir(artifact_dir))
+            regions = union!(intersect(regions, readdir(artifact_dir)), CUSTOM_REGIONS)
             for region in setdiff(regions, CUSTOM_REGIONS)
                 cp(joinpath(artifact_dir, region), joinpath(tz_source_dir, region), force=true)
             end
@@ -87,7 +87,7 @@ function build(
 
         if !isempty(tz_source_dir)
             @info "Extracting $version tzdata archive"
-            regions = intersect(regions, readarchive(archive))
+            regions = union!(intersect(regions, readdir(artifact_dir)), CUSTOM_REGIONS)
             extract(archive, tz_source_dir, setdiff(regions, CUSTOM_REGIONS), verbose=verbose)
         end
     end

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -87,7 +87,7 @@ function build(
 
         if !isempty(tz_source_dir)
             @info "Extracting $version tzdata archive"
-            regions = union!(intersect(regions, readdir(artifact_dir)), CUSTOM_REGIONS)
+            regions = union!(intersect(regions, readarchive(archive)), CUSTOM_REGIONS)
             extract(archive, tz_source_dir, setdiff(regions, CUSTOM_REGIONS), verbose=verbose)
         end
     end


### PR DESCRIPTION
Fix #305 

Issue was introduced by https://github.com/JuliaTime/TimeZones.jl/commit/07e3c9e8db4c239817653a9758e1fd2a3fb9bb89

`regions` was being redefined without the `utc` custom region, which cause the later code compiling the time zones to ignore `utc` as well. 

I did a `union!` rather than concatenating to avoid compiling anything twice.