### PR TITLE
Bump version number from "1.5.1" to "1.5.2"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeZones"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 authors = ["Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "1.5.1"
+version = "1.5.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
I forgot to bump the version number in #312 

This PR bumps the version number from `1.5.1` to `1.5.2`. After this PR is merged, we can make a new release.