### PR TITLE
make FixedTimeZones be isbits by using ShortStrings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,12 +11,14 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+ShortStrings = "63221d1c-8677-4ff0-9126-0ff0817b4975"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 EzXML = "0.9.1, 1"
 Mocking = "0.7"
 RecipesBase = "0.7, 0.8, 1"
+ShortStrings = "0.3.6"
 julia = "1"
 
 [extras]

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -4,6 +4,7 @@ using Dates
 using Printf
 using Serialization
 using RecipesBase: RecipesBase, @recipe
+using ShortStrings: ShortString15
 using Unicode
 
 import Dates: TimeZone, UTC

--- a/src/types/fixedtimezone.jl
+++ b/src/types/fixedtimezone.jl
@@ -1,3 +1,7 @@
+# Ideally would always use ShortString15, but it's `hash` is broken on 32-bit systems.
+# https://github.com/JuliaString/MurmurHash3.jl/issues/12
+const FixedTimeZoneName = Int === Int64 ? ShortString15 : String
+
 const FIXED_TIME_ZONE_REGEX = r"""
     ^(?|
         Z
@@ -30,7 +34,7 @@ const FIXED_TIME_ZONE_REGEX = r"""
 A `TimeZone` with a constant offset for all of time.
 """
 struct FixedTimeZone <: TimeZone
-    name::String
+    name::FixedTimeZoneName
     offset::UTCOffset
 end
 
@@ -72,7 +76,7 @@ UTC+15:45:21
 function FixedTimeZone(s::AbstractString)
     s == "Z" && return UTC_ZERO
 
-    m = match(FIXED_TIME_ZONE_REGEX, s)
+    m = match(FIXED_TIME_ZONE_REGEX, String(s))
     m === nothing && throw(ArgumentError("Unrecognized time zone: $s"))
 
     coefficient = m[:sign] == "-" ? -1 : 1

--- a/test/types/fixedtimezone.jl
+++ b/test/types/fixedtimezone.jl
@@ -41,4 +41,14 @@
         fixed_tz = FixedTimeZone("UTC")
         @test size(fixed_tz .== fixed_tz) == ()
     end
+
+    @testset "isbits" begin
+        # We are not using ShortStrings on 32 bit due to hash being broken on it.
+        # see https://github.com/JuliaString/MurmurHash3.jl/issues/12
+        if Int === Int64
+            @test isbits FixedTimeZone("0123")
+        else
+            @test_broken isbits FixedTimeZone("0123")
+        end
+    end
 end


### PR DESCRIPTION
Contributes towards #271 ,
following up on just this part of https://github.com/JuliaTime/TimeZones.jl/pull/324#discussion_r610994546

requires https://github.com/JuliaString/ShortStrings.jl/pull/46

Is  less extreme than https://github.com/JuliaTime/TimeZones.jl/issues/326