### PR TITLE
disable fail-fast on GHA CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         version:
           - "1.0"  # LTS


### PR DESCRIPTION
Fail-fast on GHA doesn't work great.
The benchmark job erroring shouldn't prevent the actual testing jobs from running.
Since the benchmarking job can error if you change how any types are defined https://github.com/JuliaTime/TimeZones.jl/pull/327#issuecomment-818623379