### PR TITLE
replace EzXML dependency by regex parsing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "1.5.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -14,7 +13,6 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
-EzXML = "0.9.1, 1"
 Mocking = "0.7"
 RecipesBase = "0.7, 0.8, 1"
 julia = "1"

--- a/src/winzone/WindowsTimeZoneIDs.jl
+++ b/src/winzone/WindowsTimeZoneIDs.jl
@@ -32,8 +32,8 @@ function compile(xml_file::AbstractString)
     for line in readlines(xml_file)
         # Territory "001" is the global default
         occursin("territory=\"001\"", line) || continue
-        win_name = match(r"other=\"(.+?)\"",line)[1]
-        posix_name = match(r"type=\"(.+?)\"",line)[1]
+        win_name = match(r"other=\"(.*?)\"", line)[1]
+        posix_name = match(r"type=\"(.*?)\"", line)[1]
         translation[win_name] = posix_name
     end
 

--- a/src/winzone/WindowsTimeZoneIDs.jl
+++ b/src/winzone/WindowsTimeZoneIDs.jl
@@ -31,6 +31,7 @@ function compile(xml_file::AbstractString)
         posix_name = match(r"type=\"(.+?)\"",line)[1]
         translation[win_name] = posix_name
     end
+
     return translation
 end
 

--- a/src/winzone/WindowsTimeZoneIDs.jl
+++ b/src/winzone/WindowsTimeZoneIDs.jl
@@ -24,6 +24,11 @@ function compile(xml_file::AbstractString)
     translation = Dict{String,String}()
 
     # Get the timezone conversions from the file
+    #
+    # Note: Since the XML file is simplistic enough that we can parse what we need via a
+    # regex we can avoid having an XML package dependency. Additionally, since this XML file
+    # is included as part of the this package we can correct any parsing issues before a
+    # TimeZones.jl release occurs.
     for line in readlines(xml_file)
         # Territory "001" is the global default
         occursin("territory=\"001\"", line) || continue

--- a/src/winzone/WindowsTimeZoneIDs.jl
+++ b/src/winzone/WindowsTimeZoneIDs.jl
@@ -1,7 +1,6 @@
 module WindowsTimeZoneIDs
 
 using ...TimeZones: DEPS_DIR
-using EzXML
 
 if VERSION >= v"1.3"
     using ...TimeZones: @artifact_str
@@ -21,22 +20,16 @@ const WINDOWS_XML_FILE = joinpath(WINDOWS_XML_DIR, "windowsZones.xml")
 isdir(WINDOWS_XML_DIR) || mkdir(WINDOWS_XML_DIR)
 
 function compile(xml_file::AbstractString)
-    # Get the timezone conversions from the file
-    doc = readxml(xml_file)
 
-    # Territory "001" is the global default
-    map_zones = findall("//mapZone[@territory='001']", doc)
-
-    # TODO: Eliminate the Etc/* POSIX names here? See Windows section of `localzone`
-
-    # Dictionary to store the windows to time zone conversions
     translation = Dict{String,String}()
-    for map_zone in map_zones
-        win_name = map_zone["other"]
-        posix_name = map_zone["type"]
+
+    # Get the timezone conversions from the file
+    for line in readlines(xml_file)
+        occursin("001",line) || continue
+        win_name = match(r"other=\"(.+?)\"",line)[1]
+        posix_name = match(r"type=\"(.+?)\"",line)[1]
         translation[win_name] = posix_name
     end
-
     return translation
 end
 

--- a/src/winzone/WindowsTimeZoneIDs.jl
+++ b/src/winzone/WindowsTimeZoneIDs.jl
@@ -25,7 +25,8 @@ function compile(xml_file::AbstractString)
 
     # Get the timezone conversions from the file
     for line in readlines(xml_file)
-        occursin("001",line) || continue
+        # Territory "001" is the global default
+        occursin("territory=\"001\"", line) || continue
         win_name = match(r"other=\"(.+?)\"",line)[1]
         posix_name = match(r"type=\"(.+?)\"",line)[1]
         translation[win_name] = posix_name


### PR DESCRIPTION
This PR replaces the XML parsing by using a simple regex leading to the removal of EzXML as a dependency. I understand that that usually regex parsing of XML files is a nogo, but in this case the sources files seem stable enough. 
Based on data from JuliaHub, TimeZones.jl is an indirect dependency of 315 packages, and getting rid of EzXML might be benefitial for those packages.