### PR TITLE
Fix deprecations for julia 1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,13 @@
 name = "TimeZones"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 authors = ["Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "1.5.4"
+version = "1.5.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
+LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "1.5.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -42,8 +42,11 @@ if v"1.3.1-pre.18" <= VERSION < v"1.3.2"
             Base.invokelatest(do_artifact_str, $(esc(name)), $(artifact_dict), $(artifacts_toml), $__module__)
         end
     end
-elseif VERSION >= v"1.3.0"
+elseif v"1.3.0" <= VERSION < v"1.6.0-beta1.15"
     # Issue does not exist in 1.3.0, and >= 1.4.0. Also, assume that the issue would also be
     # fixed on >= 1.3.2
     using Pkg.Artifacts: @artifact_str
+elseif VERSION >= v"1.6.0-beta1.15"
+    # Using Pkg instead of using LazyArtifacts is deprecated on 1.6.0-beta1.15 and 1.7.0-DEV.302
+    using LazyArtifacts: @artifact_str
 end

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -1,4 +1,5 @@
 using ...TimeZones: Class
+using LazyArtifacts
 
 # The default tz source files we care about. See "ftp://ftp.iana.org/tz/data/Makefile"
 # "PRIMARY_YDATA" for listing of tz source files to include.

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -3,7 +3,7 @@ if VERSION >= v"1.3"
     # Artifacts introduced in Pkg v1.3
     # Using Pkg instead of using LazyArtifacts is deprecated on 1.6.0-beta1.15 and 1.7.0-DEV.302
     # LazyArtifacts.jl available for v1.3 and up
-    using LazyArtifacts: @artifact_str
+    using LazyArtifacts
 end
 
 # The default tz source files we care about. See "ftp://ftp.iana.org/tz/data/Makefile"

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -1,5 +1,10 @@
 using ...TimeZones: Class
-using LazyArtifacts
+if VERSION >= v"1.3"
+    # Artifacts introduced in Pkg v1.3
+    # Using Pkg instead of using LazyArtifacts is deprecated on 1.6.0-beta1.15 and 1.7.0-DEV.302
+    # LazyArtifacts.jl available for v1.3 and up
+    using LazyArtifacts: @artifact_str
+end
 
 # The default tz source files we care about. See "ftp://ftp.iana.org/tz/data/Makefile"
 # "PRIMARY_YDATA" for listing of tz source files to include.

--- a/src/tzdata/download.jl
+++ b/src/tzdata/download.jl
@@ -3,7 +3,7 @@ using TimeZones: DEPS_DIR
 
 if VERSION >= v"1.6.0-DEV.923"
     # Use Downloads.jl once TimeZones.jl drops support for Julia versions < 1.3
-    download(args...) = invokelatest(Base.Downloads().download, args...)
+    download(args...) = Base.invokelatest(Base.Downloads().download, args...)
 else
     using Base: download
 end

--- a/src/tzdata/download.jl
+++ b/src/tzdata/download.jl
@@ -1,6 +1,12 @@
 using Dates
-using Downloads
 using TimeZones: DEPS_DIR
+
+if VERSION >= v"1.6.0-DEV.923"
+    # Use Downloads.jl once TimeZones.jl drops support for Julia versions < 1.3
+    download(args...) = invokelatest(Base.Downloads().download, args...)
+else
+    using Base: download
+end
 
 const LATEST_FILE = joinpath(DEPS_DIR, "latest")
 const LATEST_FORMAT = Dates.DateFormat("yyyy-mm-ddTHH:MM:SS")
@@ -60,7 +66,7 @@ julia> last(tzdata_versions())  # Current latest available tzdata version
 ```
 """
 function tzdata_versions()
-    releases_file = Downloads.download("https://data.iana.org/time-zones/releases/")
+    releases_file = download("https://data.iana.org/time-zones/releases/")
 
     html = try
         read(releases_file, String)
@@ -120,7 +126,7 @@ function tzdata_download(version::AbstractString="latest", dir::AbstractString=t
     end
 
     url = tzdata_url(version)
-    archive = Downloads.download(url, joinpath(dir, basename(url)))  # Overwrites the local file if any
+    archive = download(url, joinpath(dir, basename(url)))  # Overwrites the local file if any
 
     # Note: An "HTTP 404 Not Found" may result in the 404 page being downloaded. Also,
     # catches issues with corrupt archives

--- a/src/tzdata/download.jl
+++ b/src/tzdata/download.jl
@@ -1,4 +1,5 @@
 using Dates
+using Downloads
 using TimeZones: DEPS_DIR
 
 const LATEST_FILE = joinpath(DEPS_DIR, "latest")
@@ -59,7 +60,7 @@ julia> last(tzdata_versions())  # Current latest available tzdata version
 ```
 """
 function tzdata_versions()
-    releases_file = Base.download("https://data.iana.org/time-zones/releases/")
+    releases_file = Downloads.download("https://data.iana.org/time-zones/releases/")
 
     html = try
         read(releases_file, String)
@@ -119,7 +120,7 @@ function tzdata_download(version::AbstractString="latest", dir::AbstractString=t
     end
 
     url = tzdata_url(version)
-    archive = Base.download(url, joinpath(dir, basename(url)))  # Overwrites the local file if any
+    archive = Downloads.download(url, joinpath(dir, basename(url)))  # Overwrites the local file if any
 
     # Note: An "HTTP 404 Not Found" may result in the 404 page being downloaded. Also,
     # catches issues with corrupt archives


### PR DESCRIPTION
When running jobs to find deprecations on our CI on julia 1.6, our jobs are failing with errors like:
```
ERROR: LoadError: LoadError: LoadError: ArgumentError: Unable to find time zone "America/New_York". Try running `TimeZones.build()`.
Stacktrace:
  [1] (::TimeZones.var"#3#4"{String})()
    @ TimeZones ~/.julia/packages/TimeZones/ACKYR/src/types/timezone.jl:56
  [2] get!(default::TimeZones.var"#3#4"{String}, h::Dict{String, Tuple{Dates.TimeZone, TimeZones.Class}}, key::String)
    @ Base ./dict.jl:465
  [3] Dates.TimeZone(str::String, mask::TimeZones.Class) (repeats 2 times)
    @ TimeZones ~/.julia/packages/TimeZones/ACKYR/src/types/timezone.jl:46
  [4] var"@tz_str"(__source__::LineNumberNode, __module__::Module, str::Any)
    @ TimeZones ~/.julia/packages/TimeZones/ACKYR/src/types/timezone.jl:86
  [5] include(mod::Module, _path::String)
    @ Base ./Base.jl:386
  [6] include(x::String)
    @ ElectricityMarkets ~/.julia/packages/ElectricityMarkets/gDt52/src/ElectricityMarkets.jl:1
  [7] top-level scope
    @ ~/.julia/packages/ElectricityMarkets/gDt52/src/ElectricityMarkets.jl:28
  [8] include
    @ ./Base.jl:386 [inlined]
  [9] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt64}}, source::String)
    @ Base ./loading.jl:1213
 [10] top-level scope
    @ none:1
 [11] eval
    @ ./boot.jl:360 [inlined]
 [12] eval(x::Expr)
    @ Base.MainInclude ./client.jl:446
 [13] top-level scope
    @ none:1
 ```
 This error shows up only in our deprecations jobs and started happening directly after we switched the jobs to julia 1.6. When packages are built, TimeZones claims to have built successfully but then fails when used.

This seems to be due to a couple of version dependent deprecations to the locations of `@artifact_str` and `download` causing failures when trying to build TimeZones with `depwarn` set to `error`.

Deprecation failures when run directly:

```julia
     Testing Running tests...
ERROR: LoadError: using Pkg instead of using LazyArtifacts is deprecated
Stacktrace:
  [1] depwarn(msg::String, funcsym::Symbol; force::Bool)
    @ Base ./deprecated.jl:82
  [2] _artifact_str(__module__::Module, artifacts_toml::String, name::SubString{String}, path_tail::String, artifact_dict::Dict{String, Any}, hash::Base.SHA1, platform::Base.BinaryPlatforms.Platform, lazyartifacts::Any)
    @ Artifacts /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Artifacts/src/Artifacts.jl:545
  [3] #invokelatest#2
    @ ./essentials.jl:708 [inlined]
  [4] invokelatest
    @ ./essentials.jl:706 [inlined]
  [5] macro expansion
    @ /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Artifacts/src/Artifacts.jl:689 [inlined]
  [6] build(version::String, regions::Vector{String}, archive_dir::String, tz_source_dir::String, compiled_dir::String; verbose::Bool)
    @ TimeZones.TZData ~/.julia/dev/TimeZones/src/tzdata/build.jl:52
  [7] build (repeats 2 times)
    @ ~/.julia/dev/TimeZones/src/tzdata/build.jl:31 [inlined]
  [8] top-level scope
    @ ~/.julia/dev/TimeZones/test/runtests.jl:28
  [9] include(fname::String)
    @ Base.MainInclude ./client.jl:444
 [10] top-level scope
    @ none:6
in expression starting at /Users/sam/.julia/dev/TimeZones/test/runtests.jl:28
ERROR: Package TimeZones errored during testing
```
```julia
     Testing Running tests...
  Downloaded artifact: tzdata2016j
[ Info: Installing 2016j tzdata region data
TimeZones: Error During Test at /Users/sam/.julia/dev/TimeZones/test/runtests.jl:43
  Got exception outside of a @test
  LoadError: Base.download is deprecated; use Downloads.download instead
  Stacktrace:
    [1] depwarn(msg::String, funcsym::Symbol; force::Bool)
      @ Base ./deprecated.jl:82
    [2] depwarn
      @ ./deprecated.jl:80 [inlined]
    [3] do_download
      @ ./download.jl:32 [inlined]
    [4] download
      @ ./download.jl:28 [inlined]
    [5] tzdata_download(version::String, dir::String)
      @ TimeZones.TZData ~/.julia/dev/TimeZones/src/tzdata/download.jl:122
    [6] top-level scope
      @ ~/.julia/dev/TimeZones/test/tzdata/archive.jl:11
    [7] include(fname::String)
      @ Base.MainInclude ./client.jl:444
    [8] macro expansion
      @ ~/.julia/dev/TimeZones/test/runtests.jl:49 [inlined]
    [9] macro expansion
      @ /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
   [10] top-level scope
      @ ~/.julia/dev/TimeZones/test/runtests.jl:44
   [11] include(fname::String)
      @ Base.MainInclude ./client.jl:444
   [12] top-level scope
      @ none:6
   [13] eval
      @ ./boot.jl:360 [inlined]
   [14] exec_options(opts::Base.JLOptions)
      @ Base ./client.jl:261
   [15] _start()
      @ Base ./client.jl:485
  in expression starting at /Users/sam/.julia/dev/TimeZones/test/tzdata/archive.jl:3
```

Unfortunately Downloads.jl only works on julia v1.3 or greater. I'm not sure how to get packages to resolve on 1.0.