### PR TITLE
Thread-safe time zone cache via ReentrantLock

### DIFF
--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -52,6 +52,7 @@ end
 include("compat.jl")
 include("utils.jl")
 include("indexable_generator.jl")
+include("readers_writer_lock.jl")
 
 include("class.jl")
 include("utcoffset.jl")

--- a/src/readers_writer_lock.jl
+++ b/src/readers_writer_lock.jl
@@ -1,0 +1,61 @@
+using Base.Threads: AbstractLock, Atomic
+
+struct StateLock{L} <: AbstractLock
+    state::Atomic{UInt8}
+end
+
+const ReadersLock = StateLock{:Readers}
+const WriterLock = StateLock{:Writer}
+
+function Base.lock(r::ReadersLock)
+    while true
+        x = r.state[]
+        if x != 0xff
+            y = x + 0x01
+            if Threads.atomic_cas!(r.state, x, y) == x
+                break
+            end
+        end
+    end
+end
+
+function Base.unlock(r::ReadersLock)
+    Threads.atomic_sub!(r.state, 0x01)
+end
+
+function Base.lock(w::WriterLock)
+    while true
+        x = w.state[]
+        if x == 0x00
+            if Threads.atomic_cas!(w.state, x, 0xff) == x
+                break
+            end
+        end
+    end
+end
+
+function Base.unlock(w::WriterLock)
+    Threads.atomic_xchg!(w.state, 0x00)
+end
+
+# https://en.wikipedia.org/wiki/Readers–writer_lock
+# https://yizhang82.dev/lock-free-rw-lock
+
+"""
+    ReadersWriterLock
+
+Allow for concurrent read-only operations, while providing exclusive access for write
+operations.
+"""
+struct ReadersWriterLock
+    readers::ReadersLock
+    writer::WriterLock
+
+    function ReadersWriterLock()
+        state = Threads.Atomic{UInt8}(0)
+        readers = ReadersLock(state)
+        writer = WriterLock(state)
+
+        return new(readers, writer)
+    end
+end

--- a/src/types/timezone.jl
+++ b/src/types/timezone.jl
@@ -1,4 +1,5 @@
 const TIME_ZONE_CACHE = Dict{String,Tuple{TimeZone,Class}}()
+const TZ_CACHE_LOCK = ReentrantLock()
 
 """
     TimeZone(str::AbstractString) -> TimeZone
@@ -43,21 +44,31 @@ TimeZone(::AbstractString, ::Class)
 function TimeZone(str::AbstractString, mask::Class=Class(:DEFAULT))
     # Note: If the class `mask` does not match the time zone we'll still load the
     # information into the cache to ensure the result is consistent.
-    tz, class = get!(TIME_ZONE_CACHE, str) do
-        tz_path = joinpath(TZData.COMPILED_DIR, split(str, "/")...)
+    tz, class = get(TIME_ZONE_CACHE, str) do
+        lock(TZ_CACHE_LOCK)
 
-        if isfile(tz_path)
-            open(deserialize, tz_path, "r")
-        elseif occursin(FIXED_TIME_ZONE_REGEX, str)
-            FixedTimeZone(str), Class(:FIXED)
-        elseif !isdir(TZData.COMPILED_DIR) || isempty(readdir(TZData.COMPILED_DIR))
-            # Note: Julia 1.0 supresses the build logs which can hide issues in time zone
-            # compliation which result in no tzdata time zones being available.
-            throw(ArgumentError(
-                "Unable to find time zone \"$str\". Try running `TimeZones.build()`."
-            ))
-        else
-            throw(ArgumentError("Unknown time zone \"$str\""))
+        try
+            # The first thread to acquire the lock will update the cache. Other threads
+            # waiting for the lock will just read from the cache.
+            get!(TIME_ZONE_CACHE, str) do
+                tz_path = joinpath(TZData.COMPILED_DIR, split(str, "/")...)
+
+                if isfile(tz_path)
+                    open(deserialize, tz_path, "r")
+                elseif occursin(FIXED_TIME_ZONE_REGEX, str)
+                    FixedTimeZone(str), Class(:FIXED)
+                elseif !isdir(TZData.COMPILED_DIR) || isempty(readdir(TZData.COMPILED_DIR))
+                    # Note: Julia 1.0 supresses the build logs which can hide issues in time zone
+                    # compliation which result in no tzdata time zones being available.
+                    throw(ArgumentError(
+                        "Unable to find time zone \"$str\". Try running `TimeZones.build()`."
+                    ))
+                else
+                    throw(ArgumentError("Unknown time zone \"$str\""))
+                end
+            end
+        finally
+            unlock(TZ_CACHE_LOCK)
         end
     end
 


### PR DESCRIPTION
Experimenting with an alternative approach to #344. Part of the reason for having the time zone cache is to avoid having to read from disk. The approach in #344 results in each thread having to load data from disk which I think is slower than this approach (performance tests to come).

Fixes #342