### PR TITLE
Use `Scratch` for cached timezone data.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -83,7 +83,7 @@ jobs:
       - run: |
           git fetch origin +:refs/remotes/origin/HEAD
           julia --project=benchmark/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
-          julia --project=benchmark/ -e 'using PkgBenchmark, TimeZones; export_markdown(stdout, judge(TimeZones, "origin/HEAD", verbose=false))'
+          julia --project=benchmark/ -e 'using PkgBenchmark, TimeZones; TimeZones.build(); export_markdown(stdout, judge(TimeZones, "origin/HEAD", verbose=false))'
 
   doctest:
     name: Documentation - Julia ${{ matrix.version }}

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 

--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 EzXML = "0.9.1, 1"
 Mocking = "0.7"
 RecipesBase = "0.7, 0.8, 1"
+Scratch = "1.1"
 julia = "1"
 
 [extras]

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,1 +1,3 @@
-using TimeZones
+using TimeZones: build
+
+build()

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,3 +1,1 @@
-using TimeZones: build
-
-build()
+using TimeZones

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -50,7 +50,7 @@ const PKG_VERSION = VersionNumber(TOML.parsefile(joinpath(dirname(@__DIR__), "Pr
 const DEPS_DIR = Ref{String}()
 
 function __init__()
-    DEPS_DIR[] = @get_scratch!("timezones-$PKG_VERSION")
+    DEPS_DIR[] = @get_scratch!("timezones-$VERSION-$PKG_VERSION-$(TZData.tzdata_version())")
     isdir(DEPS_DIR[]) || mkpath(DEPS_DIR[])
     TZData._init()
     @static Sys.iswindows() && WindowsTimeZoneIDs._init()

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -54,12 +54,6 @@ function __init__()
     TZData._init()
     @static Sys.iswindows() && WindowsTimeZoneIDs._init()
     if !isdir(joinpath(DEPS_DIR, "compiled", string(VERSION)))
-        cd(DEPS_DIR) do
-            for (path, contents) in DEPS_CONTENTS
-                mkpath(dirname(path))
-                write(path, contents)
-            end
-        end
         build()
     end
 

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -47,13 +47,14 @@ end
 abstract type Local <: TimeZone end
 
 const PKG_VERSION = VersionNumber(TOML.parsefile(joinpath(dirname(@__DIR__), "Project.toml"))["version"])
+const DEPS_DIR = Ref{String}()
 
 function __init__()
-    global DEPS_DIR = @get_scratch!("timezones-$PKG_VERSION")
-    isdir(DEPS_DIR) || mkpath(DEPS_DIR)
+    DEPS_DIR[] = @get_scratch!("timezones-$PKG_VERSION")
+    isdir(DEPS_DIR[]) || mkpath(DEPS_DIR[])
     TZData._init()
     @static Sys.iswindows() && WindowsTimeZoneIDs._init()
-    if !isdir(joinpath(DEPS_DIR, "compiled", string(VERSION)))
+    if !isdir(joinpath(DEPS_DIR[], "compiled", string(VERSION)))
         build()
     end
 

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -49,10 +49,11 @@ abstract type Local <: TimeZone end
 const PKG_VERSION = VersionNumber(TOML.parsefile(joinpath(dirname(@__DIR__), "Project.toml"))["version"])
 
 function __init__()
-    global DEPS_DIR = @get_scratch!("timezones-$VERSION-$PKG_VERSION")
+    global DEPS_DIR = @get_scratch!("timezones-$PKG_VERSION")
+    isdir(DEPS_DIR) || mkpath(DEPS_DIR)
     TZData._init()
-    Sys.iswindows() && WindowsTimeZoneIDs._init()
-    if isempty(readdir(DEPS_DIR))
+    @static Sys.iswindows() && WindowsTimeZoneIDs._init()
+    if !isdir(joinpath(DEPS_DIR, "compiled", string(VERSION)))
         cd(DEPS_DIR) do
             for (path, contents) in DEPS_CONTENTS
                 mkpath(dirname(path))

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -46,10 +46,10 @@ end
 # abstract type UTC <: TimeZone end  # Already defined in the Dates stdlib
 abstract type Local <: TimeZone end
 
-const pkg_version = VersionNumber(TOML.parsefile(joinpath(dirname(@__DIR__), "Project.toml"))["version"])
+const PKG_VERSION = VersionNumber(TOML.parsefile(joinpath(dirname(@__DIR__), "Project.toml"))["version"])
 
 function __init__()
-    global DEPS_DIR = @get_scratch!("timezones-$VERSION-$pkg_version")
+    global DEPS_DIR = @get_scratch!("timezones-$VERSION-$PKG_VERSION")
     TZData._init()
     Sys.iswindows() && WindowsTimeZoneIDs._init()
     if isempty(readdir(DEPS_DIR))

--- a/src/build.jl
+++ b/src/build.jl
@@ -8,6 +8,12 @@ Builds the TimeZones package with the specified tzdata `version` and `regions`. 
 (e.g. "$DEFAULT_TZDATA_VERSION"). The `force` flag is used to re-download tzdata archives.
 """
 function build(version::AbstractString=tzdata_version(); force::Bool=false)
+    cd(DEPS_DIR) do
+        for (path, contents) in DEPS_CONTENTS
+            mkpath(dirname(path))
+            write(path, contents)
+        end
+    end
     TimeZones.TZData.build(version)
 
     if Sys.iswindows()

--- a/src/build.jl
+++ b/src/build.jl
@@ -8,7 +8,7 @@ Builds the TimeZones package with the specified tzdata `version` and `regions`. 
 (e.g. "$DEFAULT_TZDATA_VERSION"). The `force` flag is used to re-download tzdata archives.
 """
 function build(version::AbstractString=tzdata_version(); force::Bool=false)
-    cd(DEPS_DIR) do
+    cd(DEPS_DIR[]) do
         for (path, contents) in DEPS_CONTENTS
             mkpath(dirname(path))
             write(path, contents)

--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -7,7 +7,7 @@ Returns a sorted list of all of the pre-computed time zone names.
 """
 function timezone_names()
     names = String[]
-    check = Tuple{String,String}[(TZData.COMPILED_DIR, "")]
+    check = Tuple{String,String}[(TZData.COMPILED_DIR[], "")]
 
     for (dir, partial) in check
         for filename in readdir(dir)

--- a/src/local.jl
+++ b/src/local.jl
@@ -144,8 +144,8 @@ function localzone()
         # - Read the Windows registry
         win_name = @mock read(`tzutil /g`, String)
 
-        if haskey(WINDOWS_TRANSLATION, win_name)
-            return TimeZone(WINDOWS_TRANSLATION[win_name], mask)
+        if haskey(WINDOWS_TRANSLATION[], win_name)
+            return TimeZone(WINDOWS_TRANSLATION[][win_name], mask)
         else
             error("unable to translate to POSIX time zone name from: \"$win_name\"")
         end

--- a/src/types/timezone.jl
+++ b/src/types/timezone.jl
@@ -44,13 +44,13 @@ function TimeZone(str::AbstractString, mask::Class=Class(:DEFAULT))
     # Note: If the class `mask` does not match the time zone we'll still load the
     # information into the cache to ensure the result is consistent.
     tz, class = get!(TIME_ZONE_CACHE, str) do
-        tz_path = joinpath(TZData.COMPILED_DIR, split(str, "/")...)
+        tz_path = joinpath(TZData.COMPILED_DIR[], split(str, "/")...)
 
         if isfile(tz_path)
             open(deserialize, tz_path, "r")
         elseif occursin(FIXED_TIME_ZONE_REGEX, str)
             FixedTimeZone(str), Class(:FIXED)
-        elseif !isdir(TZData.COMPILED_DIR) || isempty(readdir(TZData.COMPILED_DIR))
+        elseif !isdir(TZData.COMPILED_DIR[]) || isempty(readdir(TZData.COMPILED_DIR[]))
             # Note: Julia 1.0 supresses the build logs which can hide issues in time zone
             # compliation which result in no tzdata time zones being available.
             throw(ArgumentError(
@@ -99,7 +99,7 @@ function istimezone(str::AbstractString, mask::Class=Class(:DEFAULT))
 
     # Perform more expensive checks against pre-compiled time zones
     tz, class = get(TIME_ZONE_CACHE, str) do
-        tz_path = joinpath(TZData.COMPILED_DIR, split(str, "/")...)
+        tz_path = joinpath(TZData.COMPILED_DIR[], split(str, "/")...)
 
         if isfile(tz_path)
             # Cache the data since we're already performing the deserialization

--- a/src/tzdata/TZData.jl
+++ b/src/tzdata/TZData.jl
@@ -1,7 +1,7 @@
 module TZData
 
 using Printf
-using ...TimeZones: DEPS_DIR
+import ...TimeZones
 
 import Pkg
 
@@ -14,11 +14,17 @@ end
 # the "tzdata" archive or more specifically the "tz source" files within the archive
 # (africa, australasia, ...)
 
-const ARCHIVE_DIR = joinpath(DEPS_DIR, "tzarchive")
-const TZ_SOURCE_DIR = joinpath(DEPS_DIR, "tzsource")
-const COMPILED_DIR = joinpath(DEPS_DIR, "compiled", string(VERSION))
+function _init()
+    global ARCHIVE_DIR = joinpath(TimeZones.DEPS_DIR, "tzarchive")
+    global TZ_SOURCE_DIR = joinpath(TimeZones.DEPS_DIR, "tzsource")
+    global COMPILED_DIR = joinpath(TimeZones.DEPS_DIR, "compiled", string(VERSION))
+    global ACTIVE_VERSION_FILE = joinpath(TimeZones.DEPS_DIR, "active_version")
+    global LATEST_FILE = joinpath(TimeZones.DEPS_DIR, "latest")
 
-const ARTIFACT_TOML = joinpath(@__DIR__, "..", "..", "Artifacts.toml")
+    global LATEST = let T = Tuple{AbstractString, DateTime}
+        isfile(LATEST_FILE) ? Ref{T}(read_latest(LATEST_FILE)) : Ref{T}()
+    end
+end
 
 export ARCHIVE_DIR, TZ_SOURCE_DIR, COMPILED_DIR, REGIONS, LEGACY_REGIONS
 

--- a/src/tzdata/TZData.jl
+++ b/src/tzdata/TZData.jl
@@ -1,6 +1,7 @@
 module TZData
 
 using Printf
+import Dates
 import ...TimeZones
 
 import Pkg
@@ -14,15 +15,22 @@ end
 # the "tzdata" archive or more specifically the "tz source" files within the archive
 # (africa, australasia, ...)
 
-function _init()
-    global ARCHIVE_DIR = joinpath(TimeZones.DEPS_DIR, "tzarchive")
-    global TZ_SOURCE_DIR = joinpath(TimeZones.DEPS_DIR, "tzsource")
-    global COMPILED_DIR = joinpath(TimeZones.DEPS_DIR, "compiled", string(VERSION))
-    global ACTIVE_VERSION_FILE = joinpath(TimeZones.DEPS_DIR, "active_version")
-    global LATEST_FILE = joinpath(TimeZones.DEPS_DIR, "latest")
+const ARCHIVE_DIR = Ref{String}()
+const TZ_SOURCE_DIR = Ref{String}()
+const COMPILED_DIR = Ref{String}()
+const ACTIVE_VERSION_FILE = Ref{String}()
+const LATEST_FILE = Ref{String}()
+const LATEST = Ref{Tuple{String, Dates.DateTime}}()
 
-    global LATEST = let T = Tuple{AbstractString, DateTime}
-        isfile(LATEST_FILE) ? Ref{T}(read_latest(LATEST_FILE)) : Ref{T}()
+function _init()
+    ARCHIVE_DIR[] = joinpath(TimeZones.DEPS_DIR[], "tzarchive")
+    TZ_SOURCE_DIR[] = joinpath(TimeZones.DEPS_DIR[], "tzsource")
+    COMPILED_DIR[] = joinpath(TimeZones.DEPS_DIR[], "compiled", string(VERSION))
+    ACTIVE_VERSION_FILE[] = joinpath(TimeZones.DEPS_DIR[], "active_version")
+    LATEST_FILE[] = joinpath(TimeZones.DEPS_DIR[], "latest")
+
+    if isfile(LATEST_FILE[])
+        LATEST[] = read_latest(LATEST_FILE[])
     end
 end
 

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -104,22 +104,22 @@ function build(
 end
 
 function build(version::AbstractString=tzdata_version())
-    isdir(ARCHIVE_DIR) || mkpath(ARCHIVE_DIR)
-    isdir(TZ_SOURCE_DIR) || mkpath(TZ_SOURCE_DIR)
-    isdir(COMPILED_DIR) || mkpath(COMPILED_DIR)
+    isdir(ARCHIVE_DIR[]) || mkpath(ARCHIVE_DIR[])
+    isdir(TZ_SOURCE_DIR[]) || mkpath(TZ_SOURCE_DIR[])
+    isdir(COMPILED_DIR[]) || mkpath(COMPILED_DIR[])
 
     # Empty the compile directory in case to handle different versions not overriding all
     # files.
-    for file in readdir(COMPILED_DIR)
-        rm(joinpath(COMPILED_DIR, file), recursive=true)
+    for file in readdir(COMPILED_DIR[])
+        rm(joinpath(COMPILED_DIR[], file), recursive=true)
     end
 
     version = build(
-        version, REGIONS, ARCHIVE_DIR, TZ_SOURCE_DIR, COMPILED_DIR, verbose=true,
+        version, REGIONS, ARCHIVE_DIR[], TZ_SOURCE_DIR[], COMPILED_DIR[], verbose=true,
     )
 
     # Store the version of the compiled tzdata
-    write(ACTIVE_VERSION_FILE, version)
+    write(ACTIVE_VERSION_FILE[], version)
 
     return version
 end

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -43,11 +43,7 @@ function build(
             # Retrieve the current latest version the cached latest has expired
             if latest_version === nothing
                 latest_version = last(tzdata_versions())
-                tzdata_hash = artifact_hash("tzdata$latest_version", ARTIFACT_TOML)
-
-                if tzdata_hash === nothing
-                    error("Latest tzdata is $latest_version which is not present in the Artifacts.toml")
-                end
+                @artifact_str "tzdata$latest_version"
 
                 set_latest_cached(latest_version)
             end

--- a/src/tzdata/compile.jl
+++ b/src/tzdata/compile.jl
@@ -712,7 +712,7 @@ function compile(tz_source::TZSource, dest_dir::AbstractString; kwargs...)
 end
 
 # TODO: Deprecate?
-function compile(tz_source_dir::AbstractString=TZ_SOURCE_DIR, dest_dir::AbstractString=COMPILED_DIR; kwargs...)
+function compile(tz_source_dir::AbstractString=TZ_SOURCE_DIR[], dest_dir::AbstractString=COMPILED_DIR[]; kwargs...)
     tz_source_paths = joinpath.(tz_source_dir, readdir(tz_source_dir))
     compile(TZSource(tz_source_paths), dest_dir; kwargs...)
 end

--- a/src/tzdata/download.jl
+++ b/src/tzdata/download.jl
@@ -1,5 +1,4 @@
 using Dates
-using TimeZones: DEPS_DIR
 
 if VERSION >= v"1.6.0-DEV.923"
     # Use Downloads.jl once TimeZones.jl drops support for Julia versions < 1.3
@@ -8,7 +7,6 @@ else
     using Base: download
 end
 
-const LATEST_FILE = joinpath(DEPS_DIR, "latest")
 const LATEST_FORMAT = Dates.DateFormat("yyyy-mm-ddTHH:MM:SS")
 const LATEST_DELAY = Hour(1)  # In 1996 a correction to a release was made an hour later
 
@@ -28,10 +26,6 @@ function write_latest(io::IO, version::AbstractString, retrieved_utc::DateTime=n
     write(io, version)
     write(io, "\n")
     write(io, Dates.format(retrieved_utc, LATEST_FORMAT))
-end
-
-const LATEST = let T = Tuple{AbstractString, DateTime}
-    isfile(LATEST_FILE) ? Ref{T}(read_latest(LATEST_FILE)) : Ref{T}()
 end
 
 function set_latest_cached(version::AbstractString, retrieved_utc::DateTime=now(Dates.UTC))

--- a/src/tzdata/download.jl
+++ b/src/tzdata/download.jl
@@ -30,7 +30,7 @@ end
 
 function set_latest_cached(version::AbstractString, retrieved_utc::DateTime=now(Dates.UTC))
     LATEST[] = version, retrieved_utc
-    open(LATEST_FILE, "w") do io
+    open(LATEST_FILE[], "w") do io
         write_latest(io, version, retrieved_utc)
     end
 end

--- a/src/tzdata/version.jl
+++ b/src/tzdata/version.jl
@@ -29,8 +29,6 @@ const TZDATA_NEWS_REGEX = r"""
     \b
 """x
 
-const ACTIVE_VERSION_FILE = joinpath(DEPS_DIR, "active_version")
-
 
 """
     read_news(news, [limit]) -> Vector{AbstractString}

--- a/src/tzdata/version.jl
+++ b/src/tzdata/version.jl
@@ -98,15 +98,15 @@ end
 tzdata_version() = get(ENV, "JULIA_TZ_VERSION", DEFAULT_TZDATA_VERSION)
 
 function active_version()
-    if !isfile(ACTIVE_VERSION_FILE)
+    if !isfile(ACTIVE_VERSION_FILE[])
         error("No active tzdata version. Try re-building TimeZones")
     end
-    read(ACTIVE_VERSION_FILE, String)
+    read(ACTIVE_VERSION_FILE[], String)
 end
 
 function active_archive()
     version = active_version()
-    archive = joinpath(ARCHIVE_DIR, "tzdata$version.tar.gz")
+    archive = joinpath(ARCHIVE_DIR[], "tzdata$version.tar.gz")
     !isfile(archive) && error("Missing $version tzdata archive")
     return archive
 end

--- a/src/winzone/WindowsTimeZoneIDs.jl
+++ b/src/winzone/WindowsTimeZoneIDs.jl
@@ -1,6 +1,6 @@
 module WindowsTimeZoneIDs
 
-using ...TimeZones: DEPS_DIR
+import ...TimeZones
 using EzXML
 
 if VERSION >= v"1.3"
@@ -15,10 +15,17 @@ const UNICODE_CLDR_VERSION = "release-37"
 const WINDOWS_ZONE_URL = "https://raw.githubusercontent.com/unicode-org/cldr/$UNICODE_CLDR_VERSION/common/supplemental/windowsZones.xml"
 const WINDOWS_ZONE_FILE = joinpath("cldr-$UNICODE_CLDR_VERSION", "common", "supplemental", "windowsZones.xml")
 
-const WINDOWS_XML_DIR = joinpath(DEPS_DIR, "local")
-const WINDOWS_XML_FILE = joinpath(WINDOWS_XML_DIR, "windowsZones.xml")
+function _init()
+    global WINDOWS_XML_DIR = joinpath(TimeZones.DEPS_DIR, "local")
+    global WINDOWS_XML_FILE = joinpath(WINDOWS_XML_DIR, "windowsZones.xml")
+    isdir(WINDOWS_XML_DIR) || mkdir(WINDOWS_XML_DIR)
 
-isdir(WINDOWS_XML_DIR) || mkdir(WINDOWS_XML_DIR)
+    global WINDOWS_TRANSLATION = if isfile(WINDOWS_XML_FILE)
+        compile(WINDOWS_XML_FILE)
+    else
+        Dict{AbstractString, AbstractString}()
+    end
+end
 
 function compile(xml_file::AbstractString)
     # Get the timezone conversions from the file
@@ -38,12 +45,6 @@ function compile(xml_file::AbstractString)
     end
 
     return translation
-end
-
-const WINDOWS_TRANSLATION = if isfile(WINDOWS_XML_FILE)
-    compile(WINDOWS_XML_FILE)
-else
-    Dict{AbstractString, AbstractString}()
 end
 
 function build(xml_file::AbstractString=WINDOWS_XML_FILE; force::Bool=false)

--- a/src/winzone/WindowsTimeZoneIDs.jl
+++ b/src/winzone/WindowsTimeZoneIDs.jl
@@ -15,15 +15,19 @@ const UNICODE_CLDR_VERSION = "release-37"
 const WINDOWS_ZONE_URL = "https://raw.githubusercontent.com/unicode-org/cldr/$UNICODE_CLDR_VERSION/common/supplemental/windowsZones.xml"
 const WINDOWS_ZONE_FILE = joinpath("cldr-$UNICODE_CLDR_VERSION", "common", "supplemental", "windowsZones.xml")
 
-function _init()
-    global WINDOWS_XML_DIR = joinpath(TimeZones.DEPS_DIR, "local")
-    global WINDOWS_XML_FILE = joinpath(WINDOWS_XML_DIR, "windowsZones.xml")
-    isdir(WINDOWS_XML_DIR) || mkdir(WINDOWS_XML_DIR)
+const WINDOWS_XML_DIR = Ref{String}()
+const WINDOWS_XML_FILE = Ref{String}()
+const WINDOWS_TRANSLATION = Ref{Dict{String,String}}()
 
-    global WINDOWS_TRANSLATION = if isfile(WINDOWS_XML_FILE)
-        compile(WINDOWS_XML_FILE)
+function _init()
+    WINDOWS_XML_DIR[] = joinpath(TimeZones.DEPS_DIR[], "local")
+    WINDOWS_XML_FILE[] = joinpath(WINDOWS_XML_DIR[], "windowsZones.xml")
+    isdir(WINDOWS_XML_DIR[]) || mkdir(WINDOWS_XML_DIR[])
+
+    WINDOWS_TRANSLATION[] = if isfile(WINDOWS_XML_FILE[])
+        compile(WINDOWS_XML_FILE[])
     else
-        Dict{AbstractString, AbstractString}()
+        Dict{String, String}()
     end
 end
 
@@ -47,8 +51,8 @@ function compile(xml_file::AbstractString)
     return translation
 end
 
-function build(xml_file::AbstractString=WINDOWS_XML_FILE; force::Bool=false)
-    fallback_xml_file = joinpath(WINDOWS_XML_DIR, "windowsZones2017a.xml")
+function build(xml_file::AbstractString=WINDOWS_XML_FILE[]; force::Bool=false)
+    fallback_xml_file = joinpath(WINDOWS_XML_DIR[], "windowsZones2017a.xml")
 
     if !isfile(xml_file)
         if isfile(fallback_xml_file) && !force
@@ -68,9 +72,9 @@ function build(xml_file::AbstractString=WINDOWS_XML_FILE; force::Bool=false)
     translation = compile(xml_file)
 
     # Copy contents into translation constant
-    empty!(WINDOWS_TRANSLATION)
+    empty!(WINDOWS_TRANSLATION[])
     for (k, v) in translation
-        WINDOWS_TRANSLATION[k] = v
+        WINDOWS_TRANSLATION[][k] = v
     end
 end
 

--- a/test/ci.jl
+++ b/test/ci.jl
@@ -5,21 +5,21 @@ using TimeZones: TZData
 
 @testset "build process" begin
     # Clean out deps directories for a clean re-build
-    rm(TZData.COMPILED_DIR, recursive=true)
-    for file in readdir(TZData.TZ_SOURCE_DIR)
+    rm(TZData.COMPILED_DIR[], recursive=true)
+    for file in readdir(TZData.TZ_SOURCE_DIR[])
         file == "utc" && continue
-        rm(joinpath(TZData.TZ_SOURCE_DIR, file))
+        rm(joinpath(TZData.TZ_SOURCE_DIR[], file))
     end
 
-    @test !isdir(TZData.COMPILED_DIR)
-    @test length(readdir(TZData.TZ_SOURCE_DIR)) == 1
+    @test !isdir(TZData.COMPILED_DIR[])
+    @test length(readdir(TZData.TZ_SOURCE_DIR[])) == 1
 
     # Using a version we already have avoids triggering a download
     TimeZones.build(TZDATA_VERSION)
 
-    @test isdir(TZData.COMPILED_DIR)
-    @test length(readdir(TZData.COMPILED_DIR)) > 0
-    @test readdir(TZData.TZ_SOURCE_DIR) == sort(TZData.REGIONS)
+    @test isdir(TZData.COMPILED_DIR[])
+    @test length(readdir(TZData.COMPILED_DIR[])) > 0
+    @test readdir(TZData.TZ_SOURCE_DIR[]) == sort(TZData.REGIONS)
 
     # Compile tz source files with an extended max_year. An example from the FAQ.
     warsaw = TimeZone("Europe/Warsaw")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,6 @@ using Mocking
 using RecipesBase
 using Test
 using TimeZones
-using TimeZones: PKG_DIR
 using TimeZones.TZData: ARCHIVE_DIR, TZSource, compile, build
 using Unicode
 
@@ -11,8 +10,8 @@ Mocking.activate()
 
 
 const TZDATA_VERSION = "2016j"
-const TZ_SOURCE_DIR = get(ENV, "TZ_SOURCE_DIR", joinpath(PKG_DIR, "test", "tzsource"))
-const TZFILE_DIR = joinpath(PKG_DIR, "test", "tzfile")
+const TZ_SOURCE_DIR = get(ENV, "TZ_SOURCE_DIR", joinpath(@__DIR__, "tzsource"))
+const TZFILE_DIR = joinpath(@__DIR__, "tzfile")
 const TEST_REGIONS = ["asia", "australasia", "europe", "northamerica"]
 
 # https://github.com/JuliaLang/julia/pull/27900

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,12 +19,12 @@ if VERSION < v"1.2.0-DEV.642"
     const ProcessFailedException = ErrorException
 end
 
-isdir(ARCHIVE_DIR) || mkdir(ARCHIVE_DIR)
+isdir(ARCHIVE_DIR[]) || mkdir(ARCHIVE_DIR[])
 isdir(TZ_SOURCE_DIR) || mkdir(TZ_SOURCE_DIR)
 
 # By default use a specific version of the tz database so we just testing for TimeZones.jl
 # changes and not changes to the tzdata.
-build(TZDATA_VERSION, TEST_REGIONS, ARCHIVE_DIR, TZ_SOURCE_DIR)
+build(TZDATA_VERSION, TEST_REGIONS, ARCHIVE_DIR[], TZ_SOURCE_DIR)
 
 # For testing we'll reparse the tzdata every time to instead of using the serialized data.
 # This should make the development/testing cycle simplier since you won't be forced to

--- a/test/tzdata/archive.jl
+++ b/test/tzdata/archive.jl
@@ -2,13 +2,13 @@ using TimeZones.TZData: ARCHIVE_DIR, isarchive, readarchive, extract, tzdata_dow
 
 const ARCHIVE_PATH = let
     if VERSION < v"1.3"
-        archives = filter(file -> endswith(file, "tar.gz"), readdir(ARCHIVE_DIR))
+        archives = filter(file -> endswith(file, "tar.gz"), readdir(ARCHIVE_DIR[]))
         isempty(archives) && error("Unable to run archive tests without first running Pkg.build(\"TimeZones\")")
-        joinpath(ARCHIVE_DIR, first(archives))
+        joinpath(ARCHIVE_DIR[], first(archives))
     else
         # For Julia versions that use artifacts we'll need to retrieve an archive only for
         # testing purposes.
-        tzdata_download(TZDATA_VERSION, ARCHIVE_DIR)
+        tzdata_download(TZDATA_VERSION, ARCHIVE_DIR[])
     end
 end
 

--- a/test/tzdata/download.jl
+++ b/test/tzdata/download.jl
@@ -29,8 +29,8 @@ mktempdir() do temp_dir
 
     # Validate the contents of the LATEST_FILE which will be automatically created when
     # downloading the latest data.
-    @test isfile(LATEST_FILE)
-    version, retrieved = read_latest(LATEST_FILE)
+    @test isfile(LATEST_FILE[])
+    version, retrieved = read_latest(LATEST_FILE[])
     @test occursin(r"\A(?:\d{2}){1,2}[a-z]?\z", version)
     @test isa(retrieved, DateTime)
 end

--- a/test/tzdata/version.jl
+++ b/test/tzdata/version.jl
@@ -38,7 +38,7 @@ end
 @static if use_artifacts
     artifact_dir = @artifact_str "tzdata$TZDATA_VERSION"
 else
-    archive = joinpath(ARCHIVE_DIR, "tzdata$TZDATA_VERSION.tar.gz")
+    archive = joinpath(ARCHIVE_DIR[], "tzdata$TZDATA_VERSION.tar.gz")
 end
 
 mktempdir() do temp_dir
@@ -79,6 +79,6 @@ version = active_version()
 if !use_artifacts
     archive = active_archive()
     @test isfile(archive)
-    @test dirname(archive) == ARCHIVE_DIR
+    @test dirname(archive) == ARCHIVE_DIR[]
     @test basename(archive) == "tzdata$version.tar.gz"
 end

--- a/test/winzone/WindowsTimeZoneIDs.jl
+++ b/test/winzone/WindowsTimeZoneIDs.jl
@@ -1,6 +1,6 @@
 using TimeZones.WindowsTimeZoneIDs
 
-xml_file = TimeZones.WindowsTimeZoneIDs.WINDOWS_XML_FILE
+xml_file = TimeZones.WindowsTimeZoneIDs.WINDOWS_XML_FILE[]
 !isfile(xml_file) && error("Missing required XML file. Run Pkg.build(\"TimeZones\").")
 
 trans = TimeZones.WindowsTimeZoneIDs.compile(xml_file)

--- a/test/winzone/WindowsTimeZoneIDs.jl
+++ b/test/winzone/WindowsTimeZoneIDs.jl
@@ -10,11 +10,11 @@ mktempdir() do temp_dir
     xml_file = joinpath(temp_dir, "windowZones.xml")
     @test !isfile(xml_file)
 
-    empty!(TimeZones.WindowsTimeZoneIDs.WINDOWS_TRANSLATION)
-    @test isempty(TimeZones.WindowsTimeZoneIDs.WINDOWS_TRANSLATION)
+    empty!(TimeZones.WindowsTimeZoneIDs.WINDOWS_TRANSLATION[])
+    @test isempty(TimeZones.WindowsTimeZoneIDs.WINDOWS_TRANSLATION[])
 
     # Does not perform download
     TimeZones.WindowsTimeZoneIDs.build(xml_file)
     @test isfile(xml_file)
-    @test !isempty(TimeZones.WindowsTimeZoneIDs.WINDOWS_TRANSLATION)
+    @test !isempty(TimeZones.WindowsTimeZoneIDs.WINDOWS_TRANSLATION[])
 end


### PR DESCRIPTION
Fixes #338, based on https://github.com/JuliaTime/TimeZones.jl/issues/343#issuecomment-848823981 by KristofferC.

At module init runs the current `build` to generate
the cached data, and stores it in a scratchspace instead of the
deps folder. Associated globals that were defined at top-level are
now set in `__init__` (and `_init` for submodules) to allow for
`PackageCompiler` support. Scratchspace is linked to the Julia and
package version so should rebuild when those change for users.

The `deps/build.jl` now just imports the package which triggers
a build of the cache if needed so this shouldn't really impact
`using TimeZones` much as far as I could tell.

A required PR for `Scratch` to expand it's version support is at
https://github.com/JuliaPackaging/Scratch.jl/pull/24. I've enabled
support going back to 1.0 for that package to match what `TimeZones`
says it supports, but it turns out `EzXML` is bounded at `1.3` so
I couldn't test down to 1.0-1.2.