### PR TITLE
Use `RelocatableFolders` for cached timezone data.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 EzXML = "0.9.1, 1"
 Mocking = "0.7"
 RecipesBase = "0.7, 0.8, 1"
+RelocatableFolders = "0.1"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+RelocatableFolders = "05181044-ff0b-4ac5-8273-598c1e38db00"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,3 +1,8 @@
+mkpath(joinpath(@__DIR__, "tzarchive"))
+mkpath(joinpath(@__DIR__, "compiled", string(VERSION)))
+touch(joinpath(@__DIR__, "active_version"))
+touch(joinpath(@__DIR__, "latest"))
+
 using TimeZones: build
 
 build()

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,3 +1,5 @@
+# `RelocatableFolders.@path` requires the existance of the referenced root
+# directory/file.  We ensure they exist prior to calling `using TimeZones`.
 mkpath(joinpath(@__DIR__, "tzarchive"))
 mkpath(joinpath(@__DIR__, "compiled", string(VERSION)))
 touch(joinpath(@__DIR__, "active_version"))

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -1,11 +1,11 @@
 module TimeZones
 
-using RelocatableFolders
 
 using Dates
 using Printf
 using Serialization
 using RecipesBase: RecipesBase, @recipe
+using RelocatableFolders: @path
 using Unicode
 
 import Dates: TimeZone, UTC

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -1,5 +1,7 @@
 module TimeZones
 
+using RelocatableFolders
+
 using Dates
 using Printf
 using Serialization
@@ -31,7 +33,7 @@ export TimeZone, @tz_str, istimezone, FixedTimeZone, VariableTimeZone, ZonedDate
     guess
 
 const PKG_DIR = dirname(@__DIR__)
-const DEPS_DIR = joinpath(PKG_DIR, "deps")
+const DEPS_DIR = @path joinpath(PKG_DIR, "deps")
 
 # TimeZone types used to disambiguate the context of a DateTime
 # abstract type UTC <: TimeZone end  # Already defined in the Dates stdlib

--- a/src/tzdata/TZData.jl
+++ b/src/tzdata/TZData.jl
@@ -15,11 +15,11 @@ end
 # the "tzdata" archive or more specifically the "tz source" files within the archive
 # (africa, australasia, ...)
 
-const ARCHIVE_DIR = @path(joinpath(DEPS_DIR, "tzarchive"))
-const TZ_SOURCE_DIR = @path(joinpath(DEPS_DIR, "tzsource"))
-const COMPILED_DIR = @path(joinpath(DEPS_DIR, "compiled", string(VERSION)))
+const ARCHIVE_DIR = @path joinpath(DEPS_DIR, "tzarchive")
+const TZ_SOURCE_DIR = @path joinpath(DEPS_DIR, "tzsource")
+const COMPILED_DIR = @path joinpath(DEPS_DIR, "compiled", string(VERSION))
 
-const ARTIFACT_TOML = @path(joinpath(@__DIR__, "..", "..", "Artifacts.toml"))
+const ARTIFACT_TOML = @path joinpath(@__DIR__, "..", "..", "Artifacts.toml")
 
 export ARCHIVE_DIR, TZ_SOURCE_DIR, COMPILED_DIR, REGIONS, LEGACY_REGIONS
 

--- a/src/tzdata/TZData.jl
+++ b/src/tzdata/TZData.jl
@@ -1,6 +1,7 @@
 module TZData
 
 using Printf
+using RelocatableFolders
 using ...TimeZones: DEPS_DIR
 
 import Pkg
@@ -14,11 +15,11 @@ end
 # the "tzdata" archive or more specifically the "tz source" files within the archive
 # (africa, australasia, ...)
 
-const ARCHIVE_DIR = joinpath(DEPS_DIR, "tzarchive")
-const TZ_SOURCE_DIR = joinpath(DEPS_DIR, "tzsource")
-const COMPILED_DIR = joinpath(DEPS_DIR, "compiled", string(VERSION))
+const ARCHIVE_DIR = @path(joinpath(DEPS_DIR, "tzarchive"))
+const TZ_SOURCE_DIR = @path(joinpath(DEPS_DIR, "tzsource"))
+const COMPILED_DIR = @path(joinpath(DEPS_DIR, "compiled", string(VERSION)))
 
-const ARTIFACT_TOML = joinpath(@__DIR__, "..", "..", "Artifacts.toml")
+const ARTIFACT_TOML = @path(joinpath(@__DIR__, "..", "..", "Artifacts.toml"))
 
 export ARCHIVE_DIR, TZ_SOURCE_DIR, COMPILED_DIR, REGIONS, LEGACY_REGIONS
 

--- a/src/tzdata/download.jl
+++ b/src/tzdata/download.jl
@@ -8,7 +8,7 @@ else
     using Base: download
 end
 
-const LATEST_FILE = @path(joinpath(DEPS_DIR, "latest"))
+const LATEST_FILE = @path joinpath(DEPS_DIR, "latest")
 const LATEST_FORMAT = Dates.DateFormat("yyyy-mm-ddTHH:MM:SS")
 const LATEST_DELAY = Hour(1)  # In 1996 a correction to a release was made an hour later
 

--- a/src/tzdata/download.jl
+++ b/src/tzdata/download.jl
@@ -8,7 +8,7 @@ else
     using Base: download
 end
 
-const LATEST_FILE = joinpath(DEPS_DIR, "latest")
+const LATEST_FILE = @path(joinpath(DEPS_DIR, "latest"))
 const LATEST_FORMAT = Dates.DateFormat("yyyy-mm-ddTHH:MM:SS")
 const LATEST_DELAY = Hour(1)  # In 1996 a correction to a release was made an hour later
 

--- a/src/tzdata/version.jl
+++ b/src/tzdata/version.jl
@@ -29,7 +29,7 @@ const TZDATA_NEWS_REGEX = r"""
     \b
 """x
 
-const ACTIVE_VERSION_FILE = joinpath(DEPS_DIR, "active_version")
+const ACTIVE_VERSION_FILE = @path(joinpath(DEPS_DIR, "active_version"))
 
 
 """

--- a/src/tzdata/version.jl
+++ b/src/tzdata/version.jl
@@ -29,7 +29,7 @@ const TZDATA_NEWS_REGEX = r"""
     \b
 """x
 
-const ACTIVE_VERSION_FILE = @path(joinpath(DEPS_DIR, "active_version"))
+const ACTIVE_VERSION_FILE = @path joinpath(DEPS_DIR, "active_version")
 
 
 """

--- a/src/winzone/WindowsTimeZoneIDs.jl
+++ b/src/winzone/WindowsTimeZoneIDs.jl
@@ -16,8 +16,8 @@ const UNICODE_CLDR_VERSION = "release-37"
 const WINDOWS_ZONE_URL = "https://raw.githubusercontent.com/unicode-org/cldr/$UNICODE_CLDR_VERSION/common/supplemental/windowsZones.xml"
 const WINDOWS_ZONE_FILE = joinpath("cldr-$UNICODE_CLDR_VERSION", "common", "supplemental", "windowsZones.xml")
 
-const WINDOWS_XML_DIR = @path(joinpath(DEPS_DIR, "local"))
-const WINDOWS_XML_FILE = @path(joinpath(WINDOWS_XML_DIR, "windowsZones.xml"))
+const WINDOWS_XML_DIR = @path joinpath(DEPS_DIR, "local")
+const WINDOWS_XML_FILE = @path joinpath(WINDOWS_XML_DIR, "windowsZones.xml")
 
 isdir(WINDOWS_XML_DIR) || mkdir(WINDOWS_XML_DIR)
 

--- a/src/winzone/WindowsTimeZoneIDs.jl
+++ b/src/winzone/WindowsTimeZoneIDs.jl
@@ -2,6 +2,7 @@ module WindowsTimeZoneIDs
 
 using ...TimeZones: DEPS_DIR
 using EzXML
+using RelocatableFolders
 
 if VERSION >= v"1.3"
     using ...TimeZones: @artifact_str
@@ -15,8 +16,8 @@ const UNICODE_CLDR_VERSION = "release-37"
 const WINDOWS_ZONE_URL = "https://raw.githubusercontent.com/unicode-org/cldr/$UNICODE_CLDR_VERSION/common/supplemental/windowsZones.xml"
 const WINDOWS_ZONE_FILE = joinpath("cldr-$UNICODE_CLDR_VERSION", "common", "supplemental", "windowsZones.xml")
 
-const WINDOWS_XML_DIR = joinpath(DEPS_DIR, "local")
-const WINDOWS_XML_FILE = joinpath(WINDOWS_XML_DIR, "windowsZones.xml")
+const WINDOWS_XML_DIR = @path(joinpath(DEPS_DIR, "local"))
+const WINDOWS_XML_FILE = @path(joinpath(WINDOWS_XML_DIR, "windowsZones.xml"))
 
 isdir(WINDOWS_XML_DIR) || mkdir(WINDOWS_XML_DIR)
 


### PR DESCRIPTION
This is an alternative to https://github.com/JuliaTime/TimeZones.jl/pull/347 that abstracts away the scratchspace handling into the ~~soon-to-be-~~ registered https://github.com/JuliaPackaging/RelocatableFolders.jl. ~~Currently it's source is included here just to see if CI actually likes it~~, locally it was fine (including the benchmarks), and PackageCompiler liked it too. ~~Once this is ready the actual package should be used prior to merging.~~