### PR TITLE
Rebuild TZData before benchmarks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,6 +84,8 @@ jobs:
           git fetch origin +:refs/remotes/origin/HEAD
           julia --project=benchmark/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
           julia --project=benchmark/ -e 'using PkgBenchmark, TimeZones; export_markdown(stdout, judge(TimeZones, "origin/HEAD", verbose=false))'
+        env:
+          TZDATA_VERSION: 2016j  # Matches tzdata version used in tests
 
   doctest:
     name: Documentation - Julia ${{ matrix.version }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeZones"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 authors = ["Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "1.5.7"
+version = "1.5.8"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,7 +1,7 @@
 using BenchmarkTools
 using Dates: Period, Day, Hour, DateFormat, @dateformat_str
 using TimeZones
-using TimeZones.TZData: parse_components
+using TimeZones.TZData: parse_components, build
 using Test: GenericString
 
 const SUITE = BenchmarkGroup()
@@ -10,6 +10,10 @@ function gen_range(num_units::Period, tz::TimeZone)
     zdt = ZonedDateTime(2000, tz)
     return StepRange(zdt, oneunit(num_units), zdt + num_units)
 end
+
+# Ensure that when comparing benchmarks 
+# That the compiled TZData is compatible with this version
+build("2016j") # version consistent with tests
 
 include("tzdata.jl")
 include("interpret.jl")


### PR DESCRIPTION
This recompiles TZData before running benchmarks to ensure benchmarks still run when the serialized TZdata is changed