### PR TITLE
Fix support for version `JULIA_TZ_VERSION=latest`

### DIFF
--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -30,10 +30,10 @@ function build(
 )
     if version == "latest"
         version = tzdata_latest_version()
-        tzdata_hash = artifact_hash("tzdata$latest_version", ARTIFACT_TOML)
+        tzdata_hash = artifact_hash("tzdata$version", ARTIFACT_TOML)
 
         if tzdata_hash === nothing
-            error("Latest tzdata is $latest_version which is not present in the Artifacts.toml")
+            error("Latest tzdata is $version which is not present in the Artifacts.toml")
         end
     end
 


### PR DESCRIPTION
Mistake introduced in https://github.com/JuliaTime/TimeZones.jl/pull/363 and results in:
```julia
ERROR: LoadError: UndefVarError: latest_version not defined
Stacktrace:
 [1] build(version::String, regions::Vector{String}, tz_source_dir::String, compiled_dir::String; verbose::Bool)
   @ TimeZones.TZData ~/.julia/dev/TimeZones/src/tzdata/build.jl:33
 [2] build(version::String)
   @ TimeZones.TZData ~/.julia/dev/TimeZones/src/tzdata/build.jl:68
 [3] build(version::String; force::Bool)
   @ TimeZones ~/.julia/dev/TimeZones/src/build.jl:11
 [4] build (repeats 2 times)
   @ ~/.julia/dev/TimeZones/src/build.jl:11 [inlined]
 [5] top-level scope
   @ ~/.julia/dev/TimeZones/deps/build.jl:3
 [6] include(fname::String)
   @ Base.MainInclude ./client.jl:444
 [7] top-level scope
   @ none:5
in expression starting at /Users/omus/.julia/dev/TimeZones/deps/build.jl:3
```
If the user has the env variable `JULIA_TZ_VERSION=latest` set. Change will be backported to 1.5