### PR TITLE
Update ZonedDateTime constructor to clarify behaviour when from_utc=false

### DIFF
--- a/src/types/zoneddatetime.jl
+++ b/src/types/zoneddatetime.jl
@@ -28,9 +28,10 @@ end
     ZonedDateTime(dt::DateTime, tz::TimeZone; from_utc=false) -> ZonedDateTime
 
 Construct a `ZonedDateTime` by applying a `TimeZone` to a `DateTime`. When the `from_utc`
-keyword is true the given `DateTime` is assumed to be in UTC instead of in local time and is
-converted to the specified `TimeZone`.  Note that when `from_utc` is true the given
-`DateTime` will always exists and is never ambiguous.
+keyword is true the given `DateTime` is assumed to be in UTC and is converted to the specified
+`TimeZone`.  When `from_utc` is false the given `DateTime` is assumed to already be in the
+specified `TimeZone`. Note that when `from_utc` is true the given `DateTime` will always exist
+and is never ambiguous.
 """
 function ZonedDateTime(dt::DateTime, tz::VariableTimeZone; from_utc::Bool=false)
     # Note: Using a function barrier which reduces allocations


### PR DESCRIPTION
I got caught by this and almost assumed something incorrect about the downstream CloudWatchLogs.jl library. The "instead of in local time" clause implied to me that when `from_utc=false` the `DateTime` would be _converted_ from `localzone()` into the specified `TimeZone`, but that is not the case. 