### PR TITLE
Benchmark failures should not cancel other jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,7 +75,7 @@ jobs:
     name: Benchmarks
     runs-on: ubuntu-latest
     strategy:
-      fast-fail: false
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,6 +74,7 @@ jobs:
   benchmarks:
     name: Benchmarks
     runs-on: ubuntu-latest
+    fast-fail: false
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,19 +74,20 @@ jobs:
   benchmarks:
     name: Benchmarks
     runs-on: ubuntu-latest
-    fast-fail: false
-    steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: "1"
-      - uses: julia-actions/julia-buildpkg@latest
-      - run: |
-          git fetch origin +:refs/remotes/origin/HEAD
-          julia --project=benchmark/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
-          julia --project=benchmark/ -e 'using PkgBenchmark, TimeZones; export_markdown(stdout, judge(TimeZones, "origin/HEAD", verbose=false))'
-        env:
-          TZDATA_VERSION: 2016j  # Matches tzdata version used in tests
+    strategy:
+      fast-fail: false
+      steps:
+        - uses: actions/checkout@v2
+        - uses: julia-actions/setup-julia@v1
+          with:
+            version: "1"
+        - uses: julia-actions/julia-buildpkg@latest
+        - run: |
+            git fetch origin +:refs/remotes/origin/HEAD
+            julia --project=benchmark/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
+            julia --project=benchmark/ -e 'using PkgBenchmark, TimeZones; export_markdown(stdout, judge(TimeZones, "origin/HEAD", verbose=false))'
+          env:
+            TZDATA_VERSION: 2016j  # Matches tzdata version used in tests
 
   doctest:
     name: Documentation - Julia ${{ matrix.version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,18 +76,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fast-fail: false
-      steps:
-        - uses: actions/checkout@v2
-        - uses: julia-actions/setup-julia@v1
-          with:
-            version: "1"
-        - uses: julia-actions/julia-buildpkg@latest
-        - run: |
-            git fetch origin +:refs/remotes/origin/HEAD
-            julia --project=benchmark/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
-            julia --project=benchmark/ -e 'using PkgBenchmark, TimeZones; export_markdown(stdout, judge(TimeZones, "origin/HEAD", verbose=false))'
-          env:
-            TZDATA_VERSION: 2016j  # Matches tzdata version used in tests
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: "1"
+      - uses: julia-actions/julia-buildpkg@latest
+      - run: |
+          git fetch origin +:refs/remotes/origin/HEAD
+          julia --project=benchmark/ -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
+          julia --project=benchmark/ -e 'using PkgBenchmark, TimeZones; export_markdown(stdout, judge(TimeZones, "origin/HEAD", verbose=false))'
+        env:
+          TZDATA_VERSION: 2016j  # Matches tzdata version used in tests
 
   doctest:
     name: Documentation - Julia ${{ matrix.version }}


### PR DESCRIPTION
Replaces: https://github.com/JuliaTime/TimeZones.jl/pull/328

> When set to `true`, GitHub cancels all in-progress jobs if any `matrix` job fails. Default: `true`

https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast

By setting `fail-fast: false` on the benchmark job then a failure there does not cancel the other in-progress jobs but other jobs with `fail-fast: true` can cause the benchmark to be cancelled.