### PR TITLE
TimeZones.build(): request static thread scheduler.

### DIFF
--- a/src/tzdata/compile.jl
+++ b/src/tzdata/compile.jl
@@ -698,7 +698,7 @@ function compile(tz_source::TZSource, dest_dir::AbstractString; kwargs...)
     # TimeZone objects, so that newly constructed objects pick up the newly compiled rules.
     # Since we use thread-local caches, we spawn a task on _each thread_ to clear that
     # thread's local cache.
-    Threads.@threads for i in 1:Threads.nthreads()
+    Threads.@threads :static for i in 1:Threads.nthreads()
         @assert Threads.threadid() === i "TimeZones.TZData.compile() must be called from the main, top-level Task."
         empty!(_tz_cache())
     end


### PR DESCRIPTION
Fixes build errors on Julia >= 1.8 where the default scheduler has changed from `:static` to `:dynamic`. `:static` is supported since Julia 1.5.