### PR TITLE
Default to using 2022a tzdata

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1814,6 +1814,14 @@ lazy = true
     sha256 = "07ec42b737d0d3c6be9c337f8abb5f00554a0f9cc4fcf01a703d69403b6bb2b1"
     url = "https://data.iana.org/time-zones/releases/tzdata2021e.tar.gz"
 
+[tzdata2022a]
+git-tree-sha1 = "0a6b08679140a459a92cd574727bb18755249c48"
+lazy = true
+
+    [[tzdata2022a.download]]
+    sha256 = "ef7fffd9f4f50f4f58328b35022a32a5a056b245c5cb3d6791dddb342f871664"
+    url = "https://data.iana.org/time-zones/releases/tzdata2022a.tar.gz"
+
 [tzdata93g]
 git-tree-sha1 = "e7ddeb4a45080afa6dbdd7c38df81bcf8b9d8f1a"
 lazy = true

--- a/dev/Manifest.toml
+++ b/dev/Manifest.toml
@@ -42,6 +42,11 @@ git-tree-sha1 = "c7ec02c4c6a039a98a15f955462cd7aea5df4508"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 version = "0.8.19"
 
+[[Inflate]]
+git-tree-sha1 = "f5fc07d4e706b84f72d54eedcc1c13d92fb0871c"
+uuid = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
+version = "0.1.2"
+
 [[IniFile]]
 deps = ["Test"]
 git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
@@ -184,10 +189,10 @@ deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[TimeZones]]
-deps = ["Dates", "Downloads", "InlineStrings", "LazyArtifacts", "Mocking", "Pkg", "Printf", "RecipesBase", "Serialization", "Unicode"]
+deps = ["Dates", "Downloads", "InlineStrings", "LazyArtifacts", "Mocking", "Printf", "RecipesBase", "Serialization", "Unicode"]
 path = ".."
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
-version = "1.6.1"
+version = "1.7.2"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]

--- a/dev/Project.toml
+++ b/dev/Project.toml
@@ -1,9 +1,15 @@
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+Inflate = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
 HTTP = "0.8.1"
+Inflate = "0.1.2"
 JSON = "0.20.1, 0.21"
+Tar = "1"
 julia = "1.3"

--- a/src/tzdata/version.jl
+++ b/src/tzdata/version.jl
@@ -2,7 +2,7 @@
 # We want to use a specific version here to ensure that specific revisions of the
 # TimeZones.jl package always use the same revision of tzdata. Doing so ensure that we can
 # always use older revisions of this package and always reproduce the same results.
-const DEFAULT_TZDATA_VERSION = "2021e"  # Do not use floating revision "latest" here
+const DEFAULT_TZDATA_VERSION = "2022a"  # Do not use floating revision "latest" here
 
 
 # Note: A tz code or data version consists of a year and letter while a release consists of


### PR DESCRIPTION
Release notes:

- 2022a: http://mm.icann.org/pipermail/tz-announce/2022-March/000070.html