### PR TITLE
Remove active version logic

### DIFF
--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -63,9 +63,5 @@ function build(version::AbstractString=tzdata_version())
     end
 
     version = build(version, REGIONS, TZ_SOURCE_DIR, COMPILED_DIR, verbose=true)
-
-    # Store the version of the compiled tzdata
-    write(ACTIVE_VERSION_FILE, version)
-
     return version
 end

--- a/src/tzdata/version.jl
+++ b/src/tzdata/version.jl
@@ -29,9 +29,6 @@ const TZDATA_NEWS_REGEX = r"""
     \b
 """x
 
-const ACTIVE_VERSION_FILE = joinpath(DEPS_DIR, "active_version")
-
-
 """
     read_news(news, [limit]) -> Vector{AbstractString}
 
@@ -98,17 +95,3 @@ function tzdata_version_archive(archive::AbstractString)
 end
 
 tzdata_version() = get(ENV, "JULIA_TZ_VERSION", DEFAULT_TZDATA_VERSION)
-
-function active_version()
-    if !isfile(ACTIVE_VERSION_FILE)
-        error("No active tzdata version. Try re-building TimeZones")
-    end
-    read(ACTIVE_VERSION_FILE, String)
-end
-
-function active_archive()
-    version = active_version()
-    archive = joinpath(ARCHIVE_DIR, "tzdata$version.tar.gz")
-    !isfile(archive) && error("Missing $version tzdata archive")
-    return archive
-end

--- a/test/tzdata/version.jl
+++ b/test/tzdata/version.jl
@@ -1,8 +1,6 @@
 using LazyArtifacts: @artifact_str
 using TimeZones.TZData: TZDATA_VERSION_REGEX, TZDATA_NEWS_REGEX
 using TimeZones.TZData: read_news, tzdata_version_dir, tzdata_version_archive
-using TimeZones.TZData: active_version, active_archive
-
 
 for year = ("12", "1234"), letter = ("", "z")
     version = year * letter
@@ -51,8 +49,3 @@ mktempdir() do temp_dir
     @test tzdata_version_dir(temp_dir) == TZDATA_VERSION
     @test_throws ErrorException tzdata_version_dir(dirname(@__FILE__))
 end
-
-# Active/built tzdata version
-version = active_version()
-@test version != "latest"  # Could happen if the logic to resolve the version fails
-@test match(TZDATA_VERSION_REGEX, version) !== nothing


### PR DESCRIPTION
Logic was used in a version of TimeZones.jl which didn't use the artifacts system and wasn't removed from the code base. 