### PR TITLE
Include the tzdata version in our scratch directory structure

### DIFF
--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -31,15 +31,22 @@ export TimeZone, @tz_str, istimezone, FixedTimeZone, VariableTimeZone, ZonedDate
     # ranges.jl
     guess
 
-# When we write out things like serialized tzdata representations,
-# do it into a scratchspace.
-scratch_dir(args...) = mkpath(joinpath(@get_scratch!(args[1]), args[2:end]...))
+_scratch_dir() = @get_scratch!("build")
+_tz_source_dir(version::AbstractString) = joinpath(_scratch_dir(), "tzsource", version)
+function _compiled_dir(version::AbstractString)
+    joinpath(_scratch_dir(), "compiled", "tzjf", "v$(TZJFile.DEFAULT_VERSION)", version)
+end
+
+const COMPILED_DIR = Ref{String}()
 
 # TimeZone types used to disambiguate the context of a DateTime
 # abstract type UTC <: TimeZone end  # Already defined in the Dates stdlib
 abstract type Local <: TimeZone end
 
 function __init__()
+    # Write out our compiled tzdata representations into a scratchspace
+    COMPILED_DIR[] = _compiled_dir(tzdata_version())
+
     # Initialize the thread-local TimeZone cache (issue #342)
     _reset_tz_cache()
 

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -37,7 +37,7 @@ function _compiled_dir(version::AbstractString)
     joinpath(_scratch_dir(), "compiled", "tzjf", "v$(TZJFile.DEFAULT_VERSION)", version)
 end
 
-const COMPILED_DIR = Ref{String}()
+const _COMPILED_DIR = Ref{String}()
 
 # TimeZone types used to disambiguate the context of a DateTime
 # abstract type UTC <: TimeZone end  # Already defined in the Dates stdlib
@@ -45,7 +45,7 @@ abstract type Local <: TimeZone end
 
 function __init__()
     # Write out our compiled tzdata representations into a scratchspace
-    COMPILED_DIR[] = _compiled_dir(tzdata_version())
+    _COMPILED_DIR[] = _compiled_dir(tzdata_version())
 
     # Initialize the thread-local TimeZone cache (issue #342)
     _reset_tz_cache()

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -44,16 +44,11 @@ const _COMPILED_DIR = Ref{String}()
 abstract type Local <: TimeZone end
 
 function __init__()
+    # Write out our compiled tzdata representations into a scratchspace
+    _COMPILED_DIR[] = _compiled_dir(tzdata_version())
+
     # Initialize the thread-local TimeZone cache (issue #342)
     _reset_tz_cache()
-
-    # Write out our compiled tzdata representations into a scratchspace
-    version = tzdata_version()
-    _COMPILED_DIR[] = _compiled_dir(version)
-
-    # Build the time zone data if required. Should only occur when `JULIA_TZ_VERSION` is
-    # specified we to a version not previously built.
-    isdir(_COMPILED_DIR[]) || build(version)
 
     # Base extension needs to happen everytime the module is loaded (issue #24)
     Dates.CONVERSION_SPECIFIERS['z'] = TimeZone

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -44,11 +44,16 @@ const _COMPILED_DIR = Ref{String}()
 abstract type Local <: TimeZone end
 
 function __init__()
-    # Write out our compiled tzdata representations into a scratchspace
-    _COMPILED_DIR[] = _compiled_dir(tzdata_version())
-
     # Initialize the thread-local TimeZone cache (issue #342)
     _reset_tz_cache()
+
+    # Write out our compiled tzdata representations into a scratchspace
+    version = tzdata_version()
+    _COMPILED_DIR[] = _compiled_dir(version)
+
+    # Build the time zone data if required. Should only occur when `JULIA_TZ_VERSION` is
+    # specified we to a version not previously built.
+    isdir(_COMPILED_DIR[]) || build(version)
 
     # Base extension needs to happen everytime the module is loaded (issue #24)
     Dates.CONVERSION_SPECIFIERS['z'] = TimeZone

--- a/src/build.jl
+++ b/src/build.jl
@@ -8,11 +8,22 @@ Builds the TimeZones package with the specified tzdata `version` and `regions`. 
 (e.g. "$DEFAULT_TZDATA_VERSION"). The `force` flag is used to re-download tzdata archives.
 """
 function build(version::AbstractString=tzdata_version(); force::Bool=false)
-    TimeZones.TZData.build(version)
+    tz_source_dir = _tz_source_dir(version)
+    compiled_dir = _compiled_dir(version)
+
+    isdir(tz_source_dir) && rm(tz_source_dir, recursive=true)
+    isdir(compiled_dir) && rm(compiled_dir, recursive=true)
+    mkpath(tz_source_dir)
+    mkpath(compiled_dir)
+
+    TimeZones.TZData.build(version, TZData.REGIONS, tz_source_dir, compiled_dir)
 
     if Sys.iswindows()
         TimeZones.WindowsTimeZoneIDs.build(force=force)
     end
+
+    # Set the compiled directory to the new location
+    COMPILED_DIR[] = compiled_dir
 
     # Reset cached information
     _reset_tz_cache()

--- a/src/build.jl
+++ b/src/build.jl
@@ -23,7 +23,7 @@ function build(version::AbstractString=tzdata_version(); force::Bool=false)
     end
 
     # Set the compiled directory to the new location
-    COMPILED_DIR[] = compiled_dir
+    _COMPILED_DIR[] = compiled_dir
 
     # Reset cached information
     _reset_tz_cache()

--- a/src/build.jl
+++ b/src/build.jl
@@ -8,22 +8,14 @@ Builds the TimeZones package with the specified tzdata `version` and `regions`. 
 (e.g. "$DEFAULT_TZDATA_VERSION"). The `force` flag is used to re-download tzdata archives.
 """
 function build(version::AbstractString=tzdata_version(); force::Bool=false)
-    tz_source_dir = _tz_source_dir(version)
-    compiled_dir = _compiled_dir(version)
-
-    isdir(tz_source_dir) && rm(tz_source_dir, recursive=true)
-    isdir(compiled_dir) && rm(compiled_dir, recursive=true)
-    mkpath(tz_source_dir)
-    mkpath(compiled_dir)
-
-    TimeZones.TZData.build(version, TZData.REGIONS, tz_source_dir, compiled_dir)
+    built = TimeZones.TZData.build(version, returned=:namedtuple)
 
     if Sys.iswindows()
         TimeZones.WindowsTimeZoneIDs.build(force=force)
     end
 
     # Set the compiled directory to the new location
-    _COMPILED_DIR[] = compiled_dir
+    _COMPILED_DIR[] = built.compiled_dir
 
     # Reset cached information
     _reset_tz_cache()

--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -7,7 +7,7 @@ Returns a sorted list of all of the pre-computed time zone names.
 """
 function timezone_names()
     names = String[]
-    check = Tuple{String,String}[(TZData.compiled_dir(), "")]
+    check = Tuple{String,String}[(COMPILED_DIR[], "")]
 
     for (dir, partial) in check
         for filename in readdir(dir)

--- a/src/discovery.jl
+++ b/src/discovery.jl
@@ -7,7 +7,7 @@ Returns a sorted list of all of the pre-computed time zone names.
 """
 function timezone_names()
     names = String[]
-    check = Tuple{String,String}[(COMPILED_DIR[], "")]
+    check = Tuple{String,String}[(_COMPILED_DIR[], "")]
 
     for (dir, partial) in check
         for filename in readdir(dir)

--- a/src/types/timezone.jl
+++ b/src/types/timezone.jl
@@ -68,14 +68,13 @@ function TimeZone(str::AbstractString, mask::Class=Class(:DEFAULT))
     # Note: If the class `mask` does not match the time zone we'll still load the
     # information into the cache to ensure the result is consistent.
     tz, class = get!(_tz_cache(), str) do
-        compiled_dir = TZData.compiled_dir()
-        tz_path = joinpath(compiled_dir, split(str, "/")...)
+        tz_path = joinpath(COMPILED_DIR[], split(str, "/")...)
 
         if isfile(tz_path)
             open(TZJFile.read, tz_path, "r")(str)
         elseif occursin(FIXED_TIME_ZONE_REGEX, str)
             FixedTimeZone(str), Class(:FIXED)
-        elseif !isdir(compiled_dir) || isempty(readdir(compiled_dir))
+        elseif !isdir(COMPILED_DIR[]) || isempty(readdir(COMPILED_DIR[]))
             # Note: Julia 1.0 supresses the build logs which can hide issues in time zone
             # compliation which result in no tzdata time zones being available.
             throw(ArgumentError(
@@ -124,7 +123,7 @@ function istimezone(str::AbstractString, mask::Class=Class(:DEFAULT))
 
     # Perform more expensive checks against pre-compiled time zones
     tz, class = get(_tz_cache(), str) do
-        tz_path = joinpath(TZData.compiled_dir(), split(str, "/")...)
+        tz_path = joinpath(COMPILED_DIR[], split(str, "/")...)
 
         if isfile(tz_path)
             # Cache the data since we're already performing the deserialization

--- a/src/types/timezone.jl
+++ b/src/types/timezone.jl
@@ -68,13 +68,13 @@ function TimeZone(str::AbstractString, mask::Class=Class(:DEFAULT))
     # Note: If the class `mask` does not match the time zone we'll still load the
     # information into the cache to ensure the result is consistent.
     tz, class = get!(_tz_cache(), str) do
-        tz_path = joinpath(COMPILED_DIR[], split(str, "/")...)
+        tz_path = joinpath(_COMPILED_DIR[], split(str, "/")...)
 
         if isfile(tz_path)
             open(TZJFile.read, tz_path, "r")(str)
         elseif occursin(FIXED_TIME_ZONE_REGEX, str)
             FixedTimeZone(str), Class(:FIXED)
-        elseif !isdir(COMPILED_DIR[]) || isempty(readdir(COMPILED_DIR[]))
+        elseif !isdir(_COMPILED_DIR[]) || isempty(readdir(_COMPILED_DIR[]))
             # Note: Julia 1.0 supresses the build logs which can hide issues in time zone
             # compliation which result in no tzdata time zones being available.
             throw(ArgumentError(
@@ -123,7 +123,7 @@ function istimezone(str::AbstractString, mask::Class=Class(:DEFAULT))
 
     # Perform more expensive checks against pre-compiled time zones
     tz, class = get(_tz_cache(), str) do
-        tz_path = joinpath(COMPILED_DIR[], split(str, "/")...)
+        tz_path = joinpath(_COMPILED_DIR[], split(str, "/")...)
 
         if isfile(tz_path)
             # Cache the data since we're already performing the deserialization

--- a/src/tzdata/TZData.jl
+++ b/src/tzdata/TZData.jl
@@ -1,23 +1,26 @@
 module TZData
 
+using Dates: Dates, DateTime
 using LazyArtifacts
 using Printf
-using ...TimeZones: TZJFile, scratch_dir
+using ...TimeZones: TZJFile, _scratch_dir
 
 # Note: The tz database is made up of two parts: code and data. TimeZones.jl only requires
 # the "tzdata" archive or more specifically the "tz source" files within the archive
 # (africa, australasia, ...)
 
-tz_source_dir() = scratch_dir("tzsource")
-
-# By including the default tzjfile version in the directory structure we can support having
-# multiple tzjfile file versions co-existing. Ideally the version specified here would be
-# tied in someway to the version produced by `compile` in a more explicit manner.
-compiled_dir() = scratch_dir("compiled", "tzjf", "v$(TZJFile.DEFAULT_VERSION)")
-
 const ARTIFACT_TOML = joinpath(@__DIR__, "..", "..", "Artifacts.toml")
+const LATEST_FILE_PATH = Ref{String}()
+const LATEST = Ref{Tuple{AbstractString, DateTime}}()
 
 export REGIONS, LEGACY_REGIONS
+
+function __init__()
+    LATEST_FILE_PATH[] = joinpath(_scratch_dir(), "latest")
+    if isfile(LATEST_FILE_PATH[])
+        LATEST[] = read_latest(LATEST_FILE_PATH[])
+    end
+end
 
 include("timeoffset.jl")
 include("version.jl")

--- a/src/tzdata/TZData.jl
+++ b/src/tzdata/TZData.jl
@@ -10,15 +10,16 @@ using ...TimeZones: TZJFile, _scratch_dir
 # (africa, australasia, ...)
 
 const ARTIFACT_TOML = joinpath(@__DIR__, "..", "..", "Artifacts.toml")
-const LATEST_FILE_PATH = Ref{String}()
-const LATEST = Ref{Tuple{AbstractString, DateTime}}()
+
+const _LATEST_FILE_PATH = Ref{String}()
+const _LATEST = Ref{Tuple{AbstractString, DateTime}}()
 
 export REGIONS, LEGACY_REGIONS
 
 function __init__()
-    LATEST_FILE_PATH[] = joinpath(_scratch_dir(), "latest")
-    if isfile(LATEST_FILE_PATH[])
-        LATEST[] = read_latest(LATEST_FILE_PATH[])
+    _LATEST_FILE_PATH[] = joinpath(_scratch_dir(), "latest")
+    if isfile(_LATEST_FILE_PATH[])
+        _LATEST[] = read_latest(_LATEST_FILE_PATH[])
     end
 end
 

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -25,13 +25,10 @@ function build(
     tz_source_dir::AbstractString="",
     compiled_dir::AbstractString="",
 )
-    if version == "latest"
-        version = tzdata_latest_version()
-        tzdata_hash = artifact_hash("tzdata$version", ARTIFACT_TOML)
-
-        if tzdata_hash === nothing
-            error("Latest tzdata is $version which is not present in the Artifacts.toml")
-        end
+    # Validate that the version specified is in the Artifact.toml
+    tzdata_hash = artifact_hash("tzdata$version", ARTIFACT_TOML)
+    if tzdata_hash === nothing
+        error("tzdata$version is not present in the Artifacts.toml")
     end
 
     artifact_dir = @artifact_str "tzdata$version"

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -67,8 +67,7 @@ function build(
     return version
 end
 
-# TODO: Deprecate this function
-function build(version::AbstractString=tzdata_version())
+function build(version::AbstractString=tzdata_version(); returned::Symbol=:version)
     tz_source_dir = _tz_source_dir(version)
     compiled_dir = _compiled_dir(version)
 
@@ -79,5 +78,12 @@ function build(version::AbstractString=tzdata_version())
     mkpath(compiled_dir)
 
     version = build(version, REGIONS, tz_source_dir, compiled_dir)
-    return version
+
+    if returned === :version
+        return version
+    elseif returned === :namedtuple
+        return (; version, tz_source_dir, compiled_dir)
+    else
+        throw(ArgumentError("Unhandled return option: $returned"))
+    end
 end

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -67,12 +67,17 @@ function build(
     return version
 end
 
+# TODO: Deprecate this function
 function build(version::AbstractString=tzdata_version())
-    # Empty the compile directory so each build starts fresh.  Note that `serialized_cache_dir()`
-    # creates the directory if it doesn't exist, so the `build()` call lower down will recreate
-    # the directory after we delete it here.
-    rm(compiled_dir(), recursive=true)
+    tz_source_dir = _tz_source_dir(version)
+    compiled_dir = _compiled_dir(version)
 
-    version = build(version, REGIONS, tz_source_dir(), compiled_dir())
+    # Empty directories to avoid having left over files from previous builds.
+    isdir(tz_source_dir) && rm(tz_source_dir, recursive=true)
+    isdir(compiled_dir) && rm(compiled_dir, recursive=true)
+    mkpath(tz_source_dir)
+    mkpath(compiled_dir)
+
+    version = build(version, REGIONS, tz_source_dir, compiled_dir)
     return version
 end

--- a/src/tzdata/compile.jl
+++ b/src/tzdata/compile.jl
@@ -1,7 +1,7 @@
 using Dates
 using Dates: parse_components
 
-using ...TimeZones: _tz_cache
+using ...TimeZones: _tz_cache, _tz_source_dir, _compiled_dir
 using ...TimeZones: TimeZones, TimeZone, FixedTimeZone, VariableTimeZone, Transition, Class
 using ...TimeZones: rename
 using ..TZData: TimeOffset, ZERO, MIN_GMT_OFFSET, MAX_GMT_OFFSET, MIN_SAVE, MAX_SAVE,
@@ -718,6 +718,10 @@ function compile(tz_source::TZSource, dest_dir::AbstractString; kwargs...)
 end
 
 # TODO: Deprecate?
-function compile(tz_source_dir::AbstractString=tz_source_dir(), dest_dir::AbstractString=compiled_dir(); kwargs...)
+function compile(
+    tz_source_dir::AbstractString=_tz_source_dir(tzdata_version()),
+    dest_dir::AbstractString=_compiled_dir(tzdata_version());
+    kwargs...
+)
     compile(TZSource(readdir(tz_source_dir; join=true)), dest_dir; kwargs...)
 end

--- a/src/tzdata/download.jl
+++ b/src/tzdata/download.jl
@@ -1,8 +1,5 @@
-using Dates
 using Downloads: download
-using TimeZones: scratch_dir
 
-latest_file_path() = joinpath(scratch_dir("downloads"), "latest")
 const LATEST_FORMAT = Dates.DateFormat("yyyy-mm-ddTHH:MM:SS")
 const LATEST_DELAY = Hour(1)  # In 1996 a correction to a release was made an hour later
 
@@ -24,14 +21,9 @@ function write_latest(io::IO, version::AbstractString, retrieved_utc::DateTime=n
     write(io, Dates.format(retrieved_utc, LATEST_FORMAT))
 end
 
-const LATEST = let T = Tuple{AbstractString, DateTime}
-    path = latest_file_path()
-    isfile(path) ? Ref{T}(read_latest(path)) : Ref{T}()
-end
-
 function set_latest_cached(version::AbstractString, retrieved_utc::DateTime=now(Dates.UTC))
     LATEST[] = version, retrieved_utc
-    open(latest_file_path(), "w") do io
+    open(LATEST_FILE_PATH[], "w") do io
         write_latest(io, version, retrieved_utc)
     end
 end

--- a/src/tzdata/download.jl
+++ b/src/tzdata/download.jl
@@ -22,15 +22,15 @@ function write_latest(io::IO, version::AbstractString, retrieved_utc::DateTime=n
 end
 
 function set_latest_cached(version::AbstractString, retrieved_utc::DateTime=now(Dates.UTC))
-    LATEST[] = version, retrieved_utc
-    open(LATEST_FILE_PATH[], "w") do io
+    _LATEST[] = version, retrieved_utc
+    open(_LATEST_FILE_PATH[], "w") do io
         write_latest(io, version, retrieved_utc)
     end
 end
 
 function latest_cached(now_utc::DateTime=now(Dates.UTC))
-    if isassigned(LATEST)
-        latest_version, latest_retrieved_utc = LATEST[]
+    if isassigned(_LATEST)
+        latest_version, latest_retrieved_utc = _LATEST[]
 
         if now_utc - latest_retrieved_utc < LATEST_DELAY
             return latest_version

--- a/src/tzdata/version.jl
+++ b/src/tzdata/version.jl
@@ -94,4 +94,7 @@ function tzdata_version_archive(archive::AbstractString)
     end
 end
 
-tzdata_version() = get(ENV, "JULIA_TZ_VERSION", DEFAULT_TZDATA_VERSION)
+function tzdata_version()
+    version = get(ENV, "JULIA_TZ_VERSION", DEFAULT_TZDATA_VERSION)
+    return version == "latest" ? tzdata_latest_version() : version
+end

--- a/src/winzone/WindowsTimeZoneIDs.jl
+++ b/src/winzone/WindowsTimeZoneIDs.jl
@@ -40,7 +40,7 @@ function compile(xml_file::AbstractString)
     return translation
 end
 
-function build(xml_file::AbstractString=_WINDOWS_XML_FILE_PATH[]; force::Bool=false)
+function build(xml_file::AbstractString; force::Bool=false)
     if !isfile(xml_file) || force
         @info "Downloading Windows to POSIX timezone ID XML version: $UNICODE_CLDR_VERSION"
         artifact_dir = @artifact_str "unicode-cldr-$UNICODE_CLDR_VERSION"
@@ -49,6 +49,14 @@ function build(xml_file::AbstractString=_WINDOWS_XML_FILE_PATH[]; force::Bool=fa
 
     @info "Compiling Windows time zone name translation"
     copy!(WINDOWS_TRANSLATION, compile(xml_file))
+end
+
+function build(; kwargs...)
+    # Note: Directory creation during package initialization can cause failures when using
+    # PackageCompiler.jl: https://github.com/JuliaTime/TimeZones.jl/issues/371
+    windows_xml_dir = dirname(_WINDOWS_XML_FILE_PATH[])
+    isdir(windows_xml_dir) || mkdir(windows_xml_dir)
+    return build(_WINDOWS_XML_FILE_PATH[]; kwargs...)
 end
 
 end

--- a/src/winzone/WindowsTimeZoneIDs.jl
+++ b/src/winzone/WindowsTimeZoneIDs.jl
@@ -9,14 +9,14 @@ const UNICODE_CLDR_VERSION = "release-40"
 # Details on the contents of this file can be found at:
 # http://cldr.unicode.org/development/development-process/design-proposals/extended-windows-olson-zid-mapping
 const WINDOWS_ZONE_FILE = joinpath("cldr-$UNICODE_CLDR_VERSION", "common", "supplemental", "windowsZones.xml")
-const WINDOWS_XML_FILE_PATH = Ref{String}()
+const _WINDOWS_XML_FILE_PATH = Ref{String}()
 
 const WINDOWS_TRANSLATION = Dict{String, String}()
 
 function __init__()
-    WINDOWS_XML_FILE_PATH[] = joinpath(_scratch_dir(), "local", "windowsZones.xml")
-    if isfile(WINDOWS_XML_FILE_PATH[])
-        copy!(WINDOWS_TRANSLATION, compile(WINDOWS_XML_FILE_PATH[]))
+    _WINDOWS_XML_FILE_PATH[] = joinpath(_scratch_dir(), "local", "windowsZones.xml")
+    if isfile(_WINDOWS_XML_FILE_PATH[])
+        copy!(WINDOWS_TRANSLATION, compile(_WINDOWS_XML_FILE_PATH[]))
     end
 end
 
@@ -40,7 +40,7 @@ function compile(xml_file::AbstractString)
     return translation
 end
 
-function build(xml_file::AbstractString=WINDOWS_XML_FILE_PATH[]; force::Bool=false)
+function build(xml_file::AbstractString=_WINDOWS_XML_FILE_PATH[]; force::Bool=false)
     if !isfile(xml_file) || force
         @info "Downloading Windows to POSIX timezone ID XML version: $UNICODE_CLDR_VERSION"
         artifact_dir = @artifact_str "unicode-cldr-$UNICODE_CLDR_VERSION"

--- a/src/winzone/WindowsTimeZoneIDs.jl
+++ b/src/winzone/WindowsTimeZoneIDs.jl
@@ -1,7 +1,7 @@
 module WindowsTimeZoneIDs
 
 using LazyArtifacts
-using ...TimeZones: scratch_dir
+using ...TimeZones: _scratch_dir
 
 const UNICODE_CLDR_VERSION = "release-40"
 
@@ -9,14 +9,14 @@ const UNICODE_CLDR_VERSION = "release-40"
 # Details on the contents of this file can be found at:
 # http://cldr.unicode.org/development/development-process/design-proposals/extended-windows-olson-zid-mapping
 const WINDOWS_ZONE_FILE = joinpath("cldr-$UNICODE_CLDR_VERSION", "common", "supplemental", "windowsZones.xml")
-windows_xml_file_path() = joinpath(scratch_dir("local"), "windowsZones.xml")
+const WINDOWS_XML_FILE_PATH = Ref{String}()
 
 const WINDOWS_TRANSLATION = Dict{String, String}()
 
 function __init__()
-    xml_file_path = windows_xml_file_path()
-    if isfile(xml_file_path)
-        copy!(WINDOWS_TRANSLATION, compile(xml_file_path))
+    WINDOWS_XML_FILE_PATH[] = joinpath(_scratch_dir(), "local", "windowsZones.xml")
+    if isfile(WINDOWS_XML_FILE_PATH[])
+        copy!(WINDOWS_TRANSLATION, compile(WINDOWS_XML_FILE_PATH[]))
     end
 end
 
@@ -40,7 +40,7 @@ function compile(xml_file::AbstractString)
     return translation
 end
 
-function build(xml_file::AbstractString=windows_xml_file_path(); force::Bool=false)
+function build(xml_file::AbstractString=WINDOWS_XML_FILE_PATH[]; force::Bool=false)
     if !isfile(xml_file) || force
         @info "Downloading Windows to POSIX timezone ID XML version: $UNICODE_CLDR_VERSION"
         artifact_dir = @artifact_str "unicode-cldr-$UNICODE_CLDR_VERSION"

--- a/test/ci.jl
+++ b/test/ci.jl
@@ -5,8 +5,8 @@ using TimeZones: TZData
 
 @testset "build process" begin
     # Clean out deps directories for a clean re-build
-    compiled_dir = TZData.compiled_dir()
-    tz_source_dir = TZData.tz_source_dir()
+    compiled_dir = TZData._compiled_dir(TZDATA_VERSION)
+    tz_source_dir = TZData._tz_source_dir(TZDATA_VERSION)
 
     rm(compiled_dir, recursive=true)
     for file in readdir(tz_source_dir)

--- a/test/tzdata/download.jl
+++ b/test/tzdata/download.jl
@@ -1,4 +1,4 @@
-using TimeZones.TZData: latest_file_path, read_latest
+using TimeZones.TZData: LATEST_FILE_PATH, read_latest
 using TimeZones.TZData: tzdata_latest_version, tzdata_versions
 
 @testset "tzdata_versions" begin
@@ -12,8 +12,8 @@ end
 
     # Validate the contents of the latest file which will be automatically created when
     # downloading the latest data.
-    @test isfile(latest_file_path())
-    version, retrieved = read_latest(latest_file_path())
+    @test isfile(LATEST_FILE_PATH[])
+    version, retrieved = read_latest(LATEST_FILE_PATH[])
     @test occursin(r"\A(?:\d{2}){1,2}[a-z]?\z", version)
     @test isa(retrieved, DateTime)
 end

--- a/test/tzdata/download.jl
+++ b/test/tzdata/download.jl
@@ -1,4 +1,4 @@
-using TimeZones.TZData: LATEST_FILE_PATH, read_latest
+using TimeZones.TZData: _LATEST_FILE_PATH, read_latest
 using TimeZones.TZData: tzdata_latest_version, tzdata_versions
 
 @testset "tzdata_versions" begin
@@ -12,8 +12,8 @@ end
 
     # Validate the contents of the latest file which will be automatically created when
     # downloading the latest data.
-    @test isfile(LATEST_FILE_PATH[])
-    version, retrieved = read_latest(LATEST_FILE_PATH[])
+    @test isfile(_LATEST_FILE_PATH[])
+    version, retrieved = read_latest(_LATEST_FILE_PATH[])
     @test occursin(r"\A(?:\d{2}){1,2}[a-z]?\z", version)
     @test isa(retrieved, DateTime)
 end

--- a/test/tzdata/version.jl
+++ b/test/tzdata/version.jl
@@ -1,6 +1,7 @@
 using LazyArtifacts: @artifact_str
 using TimeZones.TZData: TZDATA_VERSION_REGEX, TZDATA_NEWS_REGEX
-using TimeZones.TZData: read_news, tzdata_version_dir, tzdata_version_archive
+using TimeZones.TZData: read_news, tzdata_version_dir, tzdata_version_archive,
+    tzdata_version
 
 for year = ("12", "1234"), letter = ("", "z")
     version = year * letter
@@ -48,4 +49,22 @@ mktempdir() do temp_dir
     # Determine tzdata version from a directory
     @test tzdata_version_dir(temp_dir) == TZDATA_VERSION
     @test_throws ErrorException tzdata_version_dir(dirname(@__FILE__))
+end
+
+@testset "tzdata_version" begin
+    withenv("JULIA_TZ_VERSION" => nothing) do
+        version = tzdata_version()
+        @test version != "latest"
+        @test version == TimeZones.TZData.DEFAULT_TZDATA_VERSION
+    end
+
+    withenv("JULIA_TZ_VERSION" => TZDATA_VERSION) do
+        @test tzdata_version() == TZDATA_VERSION
+    end
+
+    withenv("JULIA_TZ_VERSION" => "latest") do
+        version = tzdata_version()
+        @test version != "latest"
+        @test occursin(TZDATA_VERSION_REGEX, version)
+    end
 end

--- a/test/winzone/WindowsTimeZoneIDs.jl
+++ b/test/winzone/WindowsTimeZoneIDs.jl
@@ -1,6 +1,6 @@
 using TimeZones.WindowsTimeZoneIDs
 
-xml_file = TimeZones.WindowsTimeZoneIDs.windows_xml_file_path()
+xml_file = TimeZones.WindowsTimeZoneIDs._WINDOWS_XML_FILE_PATH[]
 !isfile(xml_file) && error("Missing required XML file. Run Pkg.build(\"TimeZones\").")
 
 trans = TimeZones.WindowsTimeZoneIDs.compile(xml_file)


### PR DESCRIPTION
Follow up to #384. Since we're using a scratch directory multiple TimeZones.jl packages using different versions may concurrently be using the scratch directory. If these packages use different tzdata versions we could accidentally use a different tzdata version that what is typically used by that package. To solve this I've included the tzdata version in the scratch directory structure as well as included the tzjfile version. To make this work properly I ended up using `Ref`s to some of the directories so it's possible to update the tzdata version being used.