### PR TITLE
Build at package initialization time (if required)

### DIFF
--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -44,11 +44,16 @@ const _COMPILED_DIR = Ref{String}()
 abstract type Local <: TimeZone end
 
 function __init__()
-    # Write out our compiled tzdata representations into a scratchspace
-    _COMPILED_DIR[] = _compiled_dir(tzdata_version())
-
     # Initialize the thread-local TimeZone cache (issue #342)
     _reset_tz_cache()
+
+    # Write out our compiled tzdata representations into a scratchspace
+    version = tzdata_version()
+    _COMPILED_DIR[] = _compiled_dir(version)
+
+    # Build the time zone data if required. Should only occur when `JULIA_TZ_VERSION` is
+    # specified we to a version not previously built.
+    isdir(_COMPILED_DIR[]) || build(version)
 
     # Base extension needs to happen everytime the module is loaded (issue #24)
     Dates.CONVERSION_SPECIFIERS['z'] = TimeZone


### PR DESCRIPTION
See https://github.com/JuliaTime/TimeZones.jl/pull/389#discussion_r917343619 for details. PR causes `TimeZones.build` to automatically be called if the desired tzdata version has not previously been built. This should:

- Result in end-users not having to ever run `TimeZones.build()` themselves
- Avoid having automated environments fail in scenarios where `deps/build.jl` was not triggered

The main concerns with this change is that it may not play nicely with PackageCompiler.jl and users may not like that artifact retrieval and some processing could occur at package initialization time.