### PR TITLE
Require Scratch 1.1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 InlineStrings = "1"
 Mocking = "0.7"
 RecipesBase = "0.7, 0.8, 1"
-Scratch = "1"
+Scratch = "1.1.1"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
Closes #393 by forcing the version of Scratch.jl used has compatibility with relocating sysimages.