### PR TITLE
Default to using 2022b tzdata

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1816,6 +1816,7 @@ lazy = true
 
 [tzdata2022a]
 git-tree-sha1 = "0a6b08679140a459a92cd574727bb18755249c48"
+lazy = true
 
     [[tzdata2022a.download]]
     sha256 = "ef7fffd9f4f50f4f58328b35022a32a5a056b245c5cb3d6791dddb342f871664"
@@ -1823,7 +1824,6 @@ git-tree-sha1 = "0a6b08679140a459a92cd574727bb18755249c48"
 
 [tzdata2022b]
 git-tree-sha1 = "18d4de12617f98663540d55ea4ba10bd1fe69f53"
-lazy = true
 
     [[tzdata2022b.download]]
     sha256 = "f590eaf04a395245426c2be4fae71c143aea5cebc11088b7a0a5704461df397d"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1821,6 +1821,14 @@ git-tree-sha1 = "0a6b08679140a459a92cd574727bb18755249c48"
     sha256 = "ef7fffd9f4f50f4f58328b35022a32a5a056b245c5cb3d6791dddb342f871664"
     url = "https://data.iana.org/time-zones/releases/tzdata2022a.tar.gz"
 
+[tzdata2022b]
+git-tree-sha1 = "18d4de12617f98663540d55ea4ba10bd1fe69f53"
+lazy = true
+
+    [[tzdata2022b.download]]
+    sha256 = "f590eaf04a395245426c2be4fae71c143aea5cebc11088b7a0a5704461df397d"
+    url = "https://data.iana.org/time-zones/releases/tzdata2022b.tar.gz"
+
 [tzdata93g]
 git-tree-sha1 = "e7ddeb4a45080afa6dbdd7c38df81bcf8b9d8f1a"
 lazy = true
@@ -2060,3 +2068,11 @@ lazy = true
     [[unicode-cldr-release-40.download]]
     sha256 = "580cbe09e2bb97369d63a5b641e8f4bef76a585efdf7ccddc65130b0ffb579e2"
     url = "https://github.com/unicode-org/cldr/archive/release-40.tar.gz"
+
+[unicode-cldr-release-41]
+git-tree-sha1 = "2d3c24083305ba06fe44e09f7c269eb02b61bee6"
+lazy = true
+
+    [[unicode-cldr-release-41.download]]
+    sha256 = "9f8ac41a609bcd9bdae6674146472ee3f0fa2cf6ce73a27c9b1ab3fc75fc18ce"
+    url = "https://github.com/unicode-org/cldr/archive/release-41.tar.gz"

--- a/dev/Manifest.toml
+++ b/dev/Manifest.toml
@@ -15,6 +15,10 @@ git-tree-sha1 = "9be8be1d8a6f44b96482c8af52238ea7987da3e3"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
 version = "3.45.0"
 
+[[CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -54,9 +58,9 @@ version = "0.5.1"
 
 [[InlineStrings]]
 deps = ["Parsers"]
-git-tree-sha1 = "61feba885fac3a407465726d0c330b3055df897f"
+git-tree-sha1 = "d19f9edd8c34760dca2de2b503f969d8700ed288"
 uuid = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
-version = "1.1.2"
+version = "1.1.4"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
@@ -92,7 +96,7 @@ uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[LinearAlgebra]]
-deps = ["Libdl"]
+deps = ["Libdl", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[Logging]]
@@ -103,10 +107,10 @@ deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[MbedTLS]]
-deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
-git-tree-sha1 = "1c38e51c3d08ef2278062ebceade0e46cefc96fe"
+deps = ["Dates", "MbedTLS_jll", "MozillaCACerts_jll", "Random", "Sockets"]
+git-tree-sha1 = "d9ab10da9de748859a7780338e1d6566993d1f25"
 uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-version = "1.0.3"
+version = "1.1.3"
 
 [[MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -127,6 +131,10 @@ uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 [[NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 
+[[OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+
 [[Parsers]]
 deps = ["Dates"]
 git-tree-sha1 = "0044b23da09b5608b4ecacb4e5e6c6332f833a7e"
@@ -146,7 +154,7 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
-deps = ["Serialization"]
+deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[RecipesBase]]
@@ -156,6 +164,12 @@ version = "1.2.1"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Scratch]]
+deps = ["Dates"]
+git-tree-sha1 = "f94f779c94e58bf9ea243e77a37e16d9de9126bd"
+uuid = "6c6a2e73-6563-6170-7368-637461726353"
+version = "1.1.1"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -188,10 +202,10 @@ deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[TimeZones]]
-deps = ["Dates", "Downloads", "InlineStrings", "LazyArtifacts", "Mocking", "Printf", "RecipesBase", "Unicode"]
+deps = ["Dates", "Downloads", "InlineStrings", "LazyArtifacts", "Mocking", "Printf", "RecipesBase", "Scratch", "Unicode"]
 path = ".."
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
-version = "1.7.3"
+version = "1.9.0"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
@@ -203,6 +217,10 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [[Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
 
 [[nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/src/tzdata/version.jl
+++ b/src/tzdata/version.jl
@@ -2,7 +2,7 @@
 # We want to use a specific version here to ensure that specific revisions of the
 # TimeZones.jl package always use the same revision of tzdata. Doing so ensure that we can
 # always use older revisions of this package and always reproduce the same results.
-const DEFAULT_TZDATA_VERSION = "2022a"  # Do not use floating revision "latest" here
+const DEFAULT_TZDATA_VERSION = "2022b"  # Do not use floating revision "latest" here
 
 
 # Note: A tz code or data version consists of a year and letter while a release consists of

--- a/test/ci.jl
+++ b/test/ci.jl
@@ -29,13 +29,17 @@ using TimeZones: TZData
     @test warsaw.cutoff == DateTime(2038, 3, 28, 1)
     @test_throws TimeZones.UnhandledTimeError ZonedDateTime(DateTime(2039), warsaw)
 
-    TZData.compile(max_year=2200)
+    # Note: Using `TZData.compile(max_year=2200)` will end up updating the compiled data for
+    # `tzdata_version()` instead of what we last built using `TZDATA_VERSION`.
+    tz_source = TZData.TZSource(joinpath.(tz_source_dir, ["europe", "africa"]))
+    TZData.compile(tz_source, compiled_dir, max_year=2200)
+
     new_warsaw = TimeZone("Europe/Warsaw")
 
     @test warsaw !== new_warsaw
     @test last(new_warsaw.transitions).utc_datetime == DateTime(2200, 10, 26, 1)
     @test new_warsaw.cutoff == DateTime(2201, 3, 29, 1)
-    ZonedDateTime(2100, new_warsaw)  # Test this doesn't throw an exception
+    @test year(ZonedDateTime(2100, new_warsaw)) == 2100  # Test this doesn't throw an exception
 
     @test_throws TimeZones.UnhandledTimeError ZonedDateTime(2100, warsaw)
 

--- a/test/ci.jl
+++ b/test/ci.jl
@@ -9,8 +9,8 @@ using TimeZones: TZData
     compiled_dir = TZData._compiled_dir(TZDATA_VERSION)
     tz_source_dir = TZData._tz_source_dir(TZDATA_VERSION)
 
-    rm(compiled_dir, recursive=true)
-    rm(tz_source_dir, recursive=true)
+    isdir(compiled_dir) && rm(compiled_dir, recursive=true)
+    isdir(tz_source_dir) && rm(tz_source_dir, recursive=true)
 
     @test !isdir(compiled_dir)
     @test !isdir(tz_source_dir)


### PR DESCRIPTION
Release notes:

- 2022b: http://mm.icann.org/pipermail/tz-announce/2022-August/000071.html