### PR TITLE
Modify show for FixedTimeZone

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         version:
           - "1.6"  # LTS / Oldest supported version

--- a/src/io.jl
+++ b/src/io.jl
@@ -60,7 +60,7 @@ function Base.show(io::IO, tz::FixedTimeZone)
         std = Dates.value(tz.offset.std)
         dst = Dates.value(tz.offset.dst)
 
-        params = [repr(tz.name), repr(std)]
+        params = [repr(string(tz.name)), repr(std)]
         dst != 0 && push!(params, repr(dst))
         print(io, FixedTimeZone, "(", join(params, ", "), ")")
     end


### PR DESCRIPTION
In https://github.com/JuliaStrings/InlineStrings.jl/pull/52 (InlineStrings@1.3.0) the `repr` method for `InlineString` now shows type information (👍 ). For the `show` method for `FixedTimeZone` this information isn't required as all strings are convered to an `InlineString`. To keep the output of `show` concise we'll just show a simple string instead of including the type information.