### PR TITLE
Address `argerror` deprecation

### DIFF
--- a/src/types/zoneddatetime.jl
+++ b/src/types/zoneddatetime.jl
@@ -1,4 +1,4 @@
-using Dates: AbstractDateTime, argerror, validargs
+using Dates: AbstractDateTime, validargs
 
 # """
 #     ZonedDateTime
@@ -188,6 +188,6 @@ Base.typemax(::Type{ZonedDateTime}) = ZonedDateTime(typemax(DateTime), utc_tz; f
 function Dates.validargs(::Type{ZonedDateTime}, y::Int64, m::Union{Int64, Int32}, d::Int64, h::Int64, mi::Int64, s::Int64, ms::Int64, tz::AbstractString)
     err = validargs(DateTime, y, Int64(m), d, h, mi, s, ms)
     err === nothing || return err
-    istimezone(tz) || return argerror("TimeZone: \"$tz\" is not a recognized time zone")
-    return argerror()
+    istimezone(tz) || return ArgumentError("TimeZone: \"$tz\" is not a recognized time zone")
+    return nothing
 end


### PR DESCRIPTION
Fixes these deprecations introduced in https://github.com/JuliaLang/julia/pull/46031:
```
 ┌ Warning: `argerror()` is deprecated, use `nothing` instead.
│   caller = validargs(#unused#::Type{ZonedDateTime}, y::Int64, m::Int64, d::Int64, h::Int64, mi::Int64, s::Int64, ms::Int64, tz::SubString{String}) at zoneddatetime.jl:192
└ @ TimeZones ~/work/TimeZones.jl/TimeZones.jl/src/types/zoneddatetime.jl:192
┌ Warning: `argerror(msg::String)` is deprecated, use `ArgumentError(msg)` instead.
│   caller = validargs(#unused#::Type{ZonedDateTime}, y::Int64, m::Int64, d::Int64, h::Int64, mi::Int64, s::Int64, ms::Int64, tz::String) at zoneddatetime.jl:191
└ @ TimeZones ~/work/TimeZones.jl/TimeZones.jl/src/types/zoneddatetime.jl:191
```
As I was interested to see if the behaviour of `argerror` had differed in the past I found that this function used `Nullable` way back in Julia before `0.7.0-DEV.3017`. So as TimeZones requires Julia 1.6+ now we're safe to follow the deprecation.