### PR TITLE
Use backzone file as 'standard' regions

### DIFF
--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -5,7 +5,7 @@ using Printf
 using Scratch
 using RecipesBase: RecipesBase, @recipe
 using Unicode
-using InlineStrings: InlineString15
+using InlineStrings: InlineString31
 
 import Dates: TimeZone, UTC
 

--- a/src/types/fixedtimezone.jl
+++ b/src/types/fixedtimezone.jl
@@ -30,7 +30,7 @@ const FIXED_TIME_ZONE_REGEX = r"""
 A `TimeZone` with a constant offset for all of time.
 """
 struct FixedTimeZone <: TimeZone
-    name::InlineString15
+    name::InlineString31
     offset::UTCOffset
 end
 

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -1,7 +1,7 @@
 # The default tz source files we care about. See "ftp://ftp.iana.org/tz/data/Makefile"
 # "PRIMARY_YDATA" for listing of tz source files to include.
 const STANDARD_REGIONS = [
-    "africa", "antarctica", "asia", "australasia",
+    "africa", "antarctica", "asia", "australasia", "backzone",
     "europe", "northamerica", "southamerica", "utc",
 ]
 


### PR DESCRIPTION
Pertaining to https://github.com/JuliaTime/TimeZones.jl/issues/419

Needs discussion!

I had to increase the length of the FixedTimeZone name, as there was at least one name in `backzone` of length 18 characters.