### PR TITLE
Show `FixedTimeZone` name as a regular string

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -60,7 +60,8 @@ function Base.show(io::IO, tz::FixedTimeZone)
         std = Dates.value(tz.offset.std)
         dst = Dates.value(tz.offset.dst)
 
-        params = [repr(string(tz.name)), repr(std)]
+        # Always show `tz.name` as a regular `String`.
+        params = [repr(String(tz.name)), repr(std)]
         dst != 0 && push!(params, repr(dst))
         print(io, FixedTimeZone, "(", join(params, ", "), ")")
     end


### PR DESCRIPTION
The change from https://github.com/JuliaStrings/InlineStrings.jl/pull/52 changed how `show` works for `InlineStrings.String15` which broke the tests here. I've updated how we show `FixedTimeZone` so that the name always prints as a regular `String`. This works fine for constructing a `FixedTimeZone` and is more terse this seems like a reasonable change.