### PR TITLE
Fix thread-local cache management for Julia 1.9.0

### DIFF
--- a/src/types/timezone.jl
+++ b/src/types/timezone.jl
@@ -19,9 +19,16 @@ const THREAD_TZ_CACHES = Vector{Dict{String,Tuple{TimeZone,Class}}}()
 end
 @noinline _tz_cache_length_assert() = @assert false "0 < tid <= length(THREAD_TZ_CACHES)"
 
+@static if VERSION >= v"1.9.0"
+function _reset_tz_cache()
+    # ensures that we didn't save a bad object
+    resize!(empty!(THREAD_TZ_CACHES), Threads.maxthreadid())
+end
+else # prior to 1.9.0
 function _reset_tz_cache()
     # ensures that we didn't save a bad object
     resize!(empty!(THREAD_TZ_CACHES), Threads.nthreads())
+end
 end
 
 """


### PR DESCRIPTION
Here's an alternative (to https://github.com/JuliaTime/TimeZones.jl/pull/382) way to fix the thread-local caches. It's a bit clunky. And also I think Julia would generally prefer that nobody did thread-local stuff. And it remains racy against concurrent use of the caches (though that's probably not a major concern). But here it is anyway.

Closes #430 
Closes #429 