### PR TITLE
Use non-lazy platform specific artifacts for unicode-cldr

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,8 +36,6 @@ jobs:
           # Test 32-bit only on Linux
           - os: macOS-latest
             arch: x86
-          - os: windows-latest
-            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,6 +36,8 @@ jobs:
           # Test 32-bit only on Linux
           - os: macOS-latest
             arch: x86
+          - os: windows-latest
+            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2101,57 +2101,139 @@ lazy = true
     sha256 = "02f8321a3236105338a2a071f9f9ef98dadeb8f939cbe3dc2dd53e1931015604"
     url = "https://data.iana.org/time-zones/releases/tzdata96k.tar.gz"
 
-[unicode-cldr-release-37]
+[[unicode-cldr-release-37]]
 git-tree-sha1 = "614e10267d8173c9d75167149cae0f5da9f6b68e"
 lazy = true
+arch = "i686"
+os = "windows"
 
     [[unicode-cldr-release-37.download]]
     sha256 = "28e1617f70f18cd96162972b1deeb3f2bacc5b9fe02a1494b6dbfcff79ea0f7a"
     url = "https://github.com/unicode-org/cldr/archive/release-37.tar.gz"
 
-[unicode-cldr-release-38-1]
+[[unicode-cldr-release-37]]
+git-tree-sha1 = "614e10267d8173c9d75167149cae0f5da9f6b68e"
+lazy = true
+arch = "x86_64"
+os = "windows"
+
+    [[unicode-cldr-release-37.download]]
+    sha256 = "28e1617f70f18cd96162972b1deeb3f2bacc5b9fe02a1494b6dbfcff79ea0f7a"
+    url = "https://github.com/unicode-org/cldr/archive/release-37.tar.gz"
+
+[[unicode-cldr-release-38-1]]
 git-tree-sha1 = "e3650bb0f45e427653d800ef75558003e7ab4fc0"
 lazy = true
+arch = "i686"
+os = "windows"
 
     [[unicode-cldr-release-38-1.download]]
     sha256 = "923126ef0d459fc4a642514e982d1181472b7a191b82e69929a038a8a469ea7e"
     url = "https://github.com/unicode-org/cldr/archive/release-38-1.tar.gz"
 
-[unicode-cldr-release-39]
+[[unicode-cldr-release-38-1]]
+git-tree-sha1 = "e3650bb0f45e427653d800ef75558003e7ab4fc0"
+lazy = true
+arch = "x86_64"
+os = "windows"
+
+    [[unicode-cldr-release-38-1.download]]
+    sha256 = "923126ef0d459fc4a642514e982d1181472b7a191b82e69929a038a8a469ea7e"
+    url = "https://github.com/unicode-org/cldr/archive/release-38-1.tar.gz"
+
+[[unicode-cldr-release-39]]
 git-tree-sha1 = "de1d78c75cc7ad8f66b8b8be271d05d04d81e305"
 lazy = true
+arch = "i686"
+os = "windows"
 
     [[unicode-cldr-release-39.download]]
     sha256 = "baca3b9d6103a05c823d331e884626926a508d874e0d7ea0ff08d6eaf3534628"
     url = "https://github.com/unicode-org/cldr/archive/release-39.tar.gz"
 
-[unicode-cldr-release-40]
+[[unicode-cldr-release-39]]
+git-tree-sha1 = "de1d78c75cc7ad8f66b8b8be271d05d04d81e305"
+lazy = true
+arch = "x86_64"
+os = "windows"
+
+    [[unicode-cldr-release-39.download]]
+    sha256 = "baca3b9d6103a05c823d331e884626926a508d874e0d7ea0ff08d6eaf3534628"
+    url = "https://github.com/unicode-org/cldr/archive/release-39.tar.gz"
+
+[[unicode-cldr-release-40]]
 git-tree-sha1 = "8d7201f06ff8061c1b5bff0f661b5297ec1d3158"
 lazy = true
+arch = "i686"
+os = "windows"
 
     [[unicode-cldr-release-40.download]]
     sha256 = "580cbe09e2bb97369d63a5b641e8f4bef76a585efdf7ccddc65130b0ffb579e2"
     url = "https://github.com/unicode-org/cldr/archive/release-40.tar.gz"
 
-[unicode-cldr-release-41]
+[[unicode-cldr-release-40]]
+git-tree-sha1 = "8d7201f06ff8061c1b5bff0f661b5297ec1d3158"
+lazy = true
+arch = "x86_64"
+os = "windows"
+
+    [[unicode-cldr-release-40.download]]
+    sha256 = "580cbe09e2bb97369d63a5b641e8f4bef76a585efdf7ccddc65130b0ffb579e2"
+    url = "https://github.com/unicode-org/cldr/archive/release-40.tar.gz"
+
+[[unicode-cldr-release-41]]
 git-tree-sha1 = "2d3c24083305ba06fe44e09f7c269eb02b61bee6"
 lazy = true
+arch = "i686"
+os = "windows"
 
     [[unicode-cldr-release-41.download]]
     sha256 = "9f8ac41a609bcd9bdae6674146472ee3f0fa2cf6ce73a27c9b1ab3fc75fc18ce"
     url = "https://github.com/unicode-org/cldr/archive/release-41.tar.gz"
 
-[unicode-cldr-release-42]
+[[unicode-cldr-release-41]]
+git-tree-sha1 = "2d3c24083305ba06fe44e09f7c269eb02b61bee6"
+lazy = true
+arch = "x86_64"
+os = "windows"
+
+    [[unicode-cldr-release-41.download]]
+    sha256 = "9f8ac41a609bcd9bdae6674146472ee3f0fa2cf6ce73a27c9b1ab3fc75fc18ce"
+    url = "https://github.com/unicode-org/cldr/archive/release-41.tar.gz"
+
+[[unicode-cldr-release-42]]
 git-tree-sha1 = "6a7df65d09c15538ee7f5f0fafcd6a16a3a017a0"
 lazy = true
+arch = "i686"
+os = "windows"
 
     [[unicode-cldr-release-42.download]]
     sha256 = "a65de26e4595be980142590dbd33f3768e78f8c52cc0b15b45c03f20043d5ea7"
     url = "https://github.com/unicode-org/cldr/archive/release-42.tar.gz"
 
-[unicode-cldr-release-43]
-git-tree-sha1 = "768b8b82edd878449348f31bf989867bb13e42a9"
+[[unicode-cldr-release-42]]
+git-tree-sha1 = "6a7df65d09c15538ee7f5f0fafcd6a16a3a017a0"
 lazy = true
+arch = "x86_64"
+os = "windows"
+
+    [[unicode-cldr-release-42.download]]
+    sha256 = "a65de26e4595be980142590dbd33f3768e78f8c52cc0b15b45c03f20043d5ea7"
+    url = "https://github.com/unicode-org/cldr/archive/release-42.tar.gz"
+
+[[unicode-cldr-release-43]]
+git-tree-sha1 = "768b8b82edd878449348f31bf989867bb13e42a9"
+arch = "i686"
+os = "windows"
+
+    [[unicode-cldr-release-43.download]]
+    sha256 = "f76345dc07b31cda3e63aed9feee74f40ebb7b7af764fabdd70ff1cc3f897679"
+    url = "https://github.com/unicode-org/cldr/archive/release-43.tar.gz"
+
+[[unicode-cldr-release-43]]
+git-tree-sha1 = "768b8b82edd878449348f31bf989867bb13e42a9"
+arch = "x86_64"
+os = "windows"
 
     [[unicode-cldr-release-43.download]]
     sha256 = "f76345dc07b31cda3e63aed9feee74f40ebb7b7af764fabdd70ff1cc3f897679"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -2101,140 +2101,19 @@ lazy = true
     sha256 = "02f8321a3236105338a2a071f9f9ef98dadeb8f939cbe3dc2dd53e1931015604"
     url = "https://data.iana.org/time-zones/releases/tzdata96k.tar.gz"
 
-[[unicode-cldr-release-37]]
-git-tree-sha1 = "614e10267d8173c9d75167149cae0f5da9f6b68e"
-lazy = true
-arch = "i686"
-os = "windows"
-
-    [[unicode-cldr-release-37.download]]
-    sha256 = "28e1617f70f18cd96162972b1deeb3f2bacc5b9fe02a1494b6dbfcff79ea0f7a"
-    url = "https://github.com/unicode-org/cldr/archive/release-37.tar.gz"
-
-[[unicode-cldr-release-37]]
-git-tree-sha1 = "614e10267d8173c9d75167149cae0f5da9f6b68e"
-lazy = true
+[[unicode-cldr-release-43-1]]
 arch = "x86_64"
+git-tree-sha1 = "40b35727ea0aff9a9f28b7454004b68849caf67b"
 os = "windows"
 
-    [[unicode-cldr-release-37.download]]
-    sha256 = "28e1617f70f18cd96162972b1deeb3f2bacc5b9fe02a1494b6dbfcff79ea0f7a"
-    url = "https://github.com/unicode-org/cldr/archive/release-37.tar.gz"
-
-[[unicode-cldr-release-38-1]]
-git-tree-sha1 = "e3650bb0f45e427653d800ef75558003e7ab4fc0"
-lazy = true
+    [[unicode-cldr-release-43-1.download]]
+    sha256 = "0b063164ec434c150ff5f41699081ab0e4d9bf85c15a74f81f4b972b67d26bdb"
+    url = "https://github.com/unicode-org/cldr/archive/release-43-1.tar.gz"
+[[unicode-cldr-release-43-1]]
 arch = "i686"
+git-tree-sha1 = "40b35727ea0aff9a9f28b7454004b68849caf67b"
 os = "windows"
 
-    [[unicode-cldr-release-38-1.download]]
-    sha256 = "923126ef0d459fc4a642514e982d1181472b7a191b82e69929a038a8a469ea7e"
-    url = "https://github.com/unicode-org/cldr/archive/release-38-1.tar.gz"
-
-[[unicode-cldr-release-38-1]]
-git-tree-sha1 = "e3650bb0f45e427653d800ef75558003e7ab4fc0"
-lazy = true
-arch = "x86_64"
-os = "windows"
-
-    [[unicode-cldr-release-38-1.download]]
-    sha256 = "923126ef0d459fc4a642514e982d1181472b7a191b82e69929a038a8a469ea7e"
-    url = "https://github.com/unicode-org/cldr/archive/release-38-1.tar.gz"
-
-[[unicode-cldr-release-39]]
-git-tree-sha1 = "de1d78c75cc7ad8f66b8b8be271d05d04d81e305"
-lazy = true
-arch = "i686"
-os = "windows"
-
-    [[unicode-cldr-release-39.download]]
-    sha256 = "baca3b9d6103a05c823d331e884626926a508d874e0d7ea0ff08d6eaf3534628"
-    url = "https://github.com/unicode-org/cldr/archive/release-39.tar.gz"
-
-[[unicode-cldr-release-39]]
-git-tree-sha1 = "de1d78c75cc7ad8f66b8b8be271d05d04d81e305"
-lazy = true
-arch = "x86_64"
-os = "windows"
-
-    [[unicode-cldr-release-39.download]]
-    sha256 = "baca3b9d6103a05c823d331e884626926a508d874e0d7ea0ff08d6eaf3534628"
-    url = "https://github.com/unicode-org/cldr/archive/release-39.tar.gz"
-
-[[unicode-cldr-release-40]]
-git-tree-sha1 = "8d7201f06ff8061c1b5bff0f661b5297ec1d3158"
-lazy = true
-arch = "i686"
-os = "windows"
-
-    [[unicode-cldr-release-40.download]]
-    sha256 = "580cbe09e2bb97369d63a5b641e8f4bef76a585efdf7ccddc65130b0ffb579e2"
-    url = "https://github.com/unicode-org/cldr/archive/release-40.tar.gz"
-
-[[unicode-cldr-release-40]]
-git-tree-sha1 = "8d7201f06ff8061c1b5bff0f661b5297ec1d3158"
-lazy = true
-arch = "x86_64"
-os = "windows"
-
-    [[unicode-cldr-release-40.download]]
-    sha256 = "580cbe09e2bb97369d63a5b641e8f4bef76a585efdf7ccddc65130b0ffb579e2"
-    url = "https://github.com/unicode-org/cldr/archive/release-40.tar.gz"
-
-[[unicode-cldr-release-41]]
-git-tree-sha1 = "2d3c24083305ba06fe44e09f7c269eb02b61bee6"
-lazy = true
-arch = "i686"
-os = "windows"
-
-    [[unicode-cldr-release-41.download]]
-    sha256 = "9f8ac41a609bcd9bdae6674146472ee3f0fa2cf6ce73a27c9b1ab3fc75fc18ce"
-    url = "https://github.com/unicode-org/cldr/archive/release-41.tar.gz"
-
-[[unicode-cldr-release-41]]
-git-tree-sha1 = "2d3c24083305ba06fe44e09f7c269eb02b61bee6"
-lazy = true
-arch = "x86_64"
-os = "windows"
-
-    [[unicode-cldr-release-41.download]]
-    sha256 = "9f8ac41a609bcd9bdae6674146472ee3f0fa2cf6ce73a27c9b1ab3fc75fc18ce"
-    url = "https://github.com/unicode-org/cldr/archive/release-41.tar.gz"
-
-[[unicode-cldr-release-42]]
-git-tree-sha1 = "6a7df65d09c15538ee7f5f0fafcd6a16a3a017a0"
-lazy = true
-arch = "i686"
-os = "windows"
-
-    [[unicode-cldr-release-42.download]]
-    sha256 = "a65de26e4595be980142590dbd33f3768e78f8c52cc0b15b45c03f20043d5ea7"
-    url = "https://github.com/unicode-org/cldr/archive/release-42.tar.gz"
-
-[[unicode-cldr-release-42]]
-git-tree-sha1 = "6a7df65d09c15538ee7f5f0fafcd6a16a3a017a0"
-lazy = true
-arch = "x86_64"
-os = "windows"
-
-    [[unicode-cldr-release-42.download]]
-    sha256 = "a65de26e4595be980142590dbd33f3768e78f8c52cc0b15b45c03f20043d5ea7"
-    url = "https://github.com/unicode-org/cldr/archive/release-42.tar.gz"
-
-[[unicode-cldr-release-43]]
-git-tree-sha1 = "768b8b82edd878449348f31bf989867bb13e42a9"
-arch = "i686"
-os = "windows"
-
-    [[unicode-cldr-release-43.download]]
-    sha256 = "f76345dc07b31cda3e63aed9feee74f40ebb7b7af764fabdd70ff1cc3f897679"
-    url = "https://github.com/unicode-org/cldr/archive/release-43.tar.gz"
-
-[[unicode-cldr-release-43]]
-git-tree-sha1 = "768b8b82edd878449348f31bf989867bb13e42a9"
-arch = "x86_64"
-os = "windows"
-
-    [[unicode-cldr-release-43.download]]
-    sha256 = "f76345dc07b31cda3e63aed9feee74f40ebb7b7af764fabdd70ff1cc3f897679"
-    url = "https://github.com/unicode-org/cldr/archive/release-43.tar.gz"
+    [[unicode-cldr-release-43-1.download]]
+    sha256 = "0b063164ec434c150ff5f41699081ab0e4d9bf85c15a74f81f4b972b67d26bdb"
+    url = "https://github.com/unicode-org/cldr/archive/release-43-1.tar.gz"

--- a/dev/Manifest.toml
+++ b/dev/Manifest.toml
@@ -1,6 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
+julia_version = "1.9.1"
 manifest_format = "2.0"
+project_hash = "b01971d38151b463d98e1f373278d7dad753ef71"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -19,26 +21,28 @@ version = "0.1.7"
 
 [[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
-git-tree-sha1 = "9c209fb7536406834aa938fb149964b985de6c83"
+git-tree-sha1 = "02aa26a4cf76381be7f66e020a3eddeb27b0a092"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-version = "0.7.1"
+version = "0.7.2"
 
 [[deps.Compat]]
-deps = ["Dates", "LinearAlgebra", "UUIDs"]
-git-tree-sha1 = "7a60c856b9fa189eb34f5f8a6f6b5529b7942957"
+deps = ["UUIDs"]
+git-tree-sha1 = "5ce999a19f4ca23ea484e92a1774a61b8ca4cf8e"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.6.1"
+version = "4.8.0"
 
-[[deps.CompilerSupportLibraries_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.0.1+0"
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
+
+    [deps.Compat.weakdeps]
+    Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.ConcurrentUtilities]]
 deps = ["Serialization", "Sockets"]
-git-tree-sha1 = "b306df2650947e9eb100ec125ff8c65ca2053d30"
+git-tree-sha1 = "5372dbbf8f0bdb8c700db5367132925c0771ef7e"
 uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
-version = "2.1.1"
+version = "2.2.1"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -49,6 +53,12 @@ deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 version = "1.6.0"
 
+[[deps.ExceptionUnwrapping]]
+deps = ["Test"]
+git-tree-sha1 = "e90caa41f5a86296e014e148ee061bd6c3edec96"
+uuid = "460bff9d-24e4-43bc-9d9f-a8973cb893f4"
+version = "0.1.9"
+
 [[deps.ExprTools]]
 git-tree-sha1 = "c1d06d129da9f55715c6c212866f5b1bddc5fa00"
 uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
@@ -58,15 +68,10 @@ version = "0.1.9"
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[deps.HTTP]]
-deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
-git-tree-sha1 = "69182f9a2d6add3736b7a06ab6416aafdeec2196"
+deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
+git-tree-sha1 = "cb56ccdd481c0dd7f975ad2b3b62d9eda088f7e2"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "1.8.0"
-
-[[deps.Inflate]]
-git-tree-sha1 = "5cd07aab533df5170988219191dfad0519391428"
-uuid = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
-version = "0.1.3"
+version = "1.9.14"
 
 [[deps.InlineStrings]]
 deps = ["Parsers"]
@@ -85,10 +90,10 @@ uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.4.1"
 
 [[deps.JSON3]]
-deps = ["Dates", "Mmap", "Parsers", "SnoopPrecompile", "StructTypes", "UUIDs"]
-git-tree-sha1 = "84b10656a41ef564c39d2d477d7236966d2b5683"
+deps = ["Dates", "Mmap", "Parsers", "PrecompileTools", "StructTypes", "UUIDs"]
+git-tree-sha1 = "5b62d93f2582b09e469b3099d839c2d2ebf5066d"
 uuid = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-version = "1.12.0"
+version = "1.13.1"
 
 [[deps.LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
@@ -116,10 +121,6 @@ version = "1.10.2+0"
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
-[[deps.LinearAlgebra]]
-deps = ["Libdl", "libblastrampoline_jll"]
-uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
@@ -142,64 +143,59 @@ version = "1.1.7"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.0+0"
+version = "2.28.2+0"
 
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[deps.Mocking]]
 deps = ["Compat", "ExprTools"]
-git-tree-sha1 = "782e258e80d68a73d8c916e55f8ced1de00c2cea"
+git-tree-sha1 = "4cc0c5a83933648b615c36c2b956d94fda70641e"
 uuid = "78c3b35d-d492-501b-9361-3d52fe80e533"
-version = "0.7.6"
+version = "0.7.7"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2022.2.1"
+version = "2022.10.11"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
 
-[[deps.OpenBLAS_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
-uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.20+0"
-
 [[deps.OpenSSL]]
 deps = ["BitFlags", "Dates", "MozillaCACerts_jll", "OpenSSL_jll", "Sockets"]
-git-tree-sha1 = "7fb975217aea8f1bb360cf1dde70bad2530622d2"
+git-tree-sha1 = "51901a49222b09e3743c65b8847687ae5fc78eb2"
 uuid = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
-version = "1.4.0"
+version = "1.4.1"
 
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "6cc6366a14dbe47e5fc8f3cbe2816b1185ef5fc4"
+git-tree-sha1 = "cae3153c7f6cf3f069a853883fd1919a6e5bab5b"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.0.8+0"
+version = "3.0.9+0"
 
 [[deps.Parsers]]
-deps = ["Dates", "SnoopPrecompile"]
-git-tree-sha1 = "478ac6c952fddd4399e71d4779797c538d0ff2bf"
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "4b2e829ee66d4218e0cef22c0a64ee37cf258c29"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.5.8"
+version = "2.7.1"
 
 [[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.8.0"
+version = "1.9.0"
 
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
-git-tree-sha1 = "2e47054ffe7d0a8872e977c0d09eb4b3d162ebde"
+git-tree-sha1 = "9673d39decc5feece56ef3940e5dafba15ba0f81"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-version = "1.0.2"
+version = "1.1.2"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "47e5f437cc0e7ef2ce8406ce1e7e24d44915f88d"
+git-tree-sha1 = "7eb1686b4f04b82f96ed7a4ea5890a4f0c7a09f1"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.3.0"
+version = "1.4.0"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -237,12 +233,6 @@ git-tree-sha1 = "874e8867b33a00e784c8a7e4b60afe9e037b74e1"
 uuid = "777ac1f9-54b0-4bf8-805c-2214025038e7"
 version = "1.1.0"
 
-[[deps.SnoopPrecompile]]
-deps = ["Preferences"]
-git-tree-sha1 = "e760a70afdcd461cf01a575947738d359234665c"
-uuid = "66db9d55-30c0-4569-8b51-7e840670fc0c"
-version = "1.0.3"
-
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
@@ -255,12 +245,12 @@ version = "1.10.0"
 [[deps.TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-version = "1.0.0"
+version = "1.0.3"
 
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
-version = "1.10.1"
+version = "1.10.0"
 
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
@@ -270,7 +260,7 @@ uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 deps = ["Dates", "Downloads", "InlineStrings", "LazyArtifacts", "Mocking", "Printf", "RecipesBase", "Scratch", "Unicode"]
 path = ".."
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
-version = "1.9.1"
+version = "1.10.0"
 
 [[deps.TranscodingStreams]]
 deps = ["Random", "Test"]
@@ -293,12 +283,7 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.12+3"
-
-[[deps.libblastrampoline_jll]]
-deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
-uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.1.1+0"
+version = "1.2.13+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/dev/Project.toml
+++ b/dev/Project.toml
@@ -1,6 +1,7 @@
 [deps]
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-Inflate = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -8,8 +9,12 @@ Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
+CodecZlib = "0.7"
+Downloads = "1.6"
 HTTP = "1"
-Inflate = "0.1.2"
 JSON3 = "1"
+Pkg = "1.6"
+SHA = "0.7"
 Tar = "1"
-julia = "1.6.2"
+TimeZones = "1"
+julia = "1.8"

--- a/dev/generate_artifacts.jl
+++ b/dev/generate_artifacts.jl
@@ -1,49 +1,100 @@
 using Base: SHA1
+using Base.BinaryPlatforms: HostPlatform, Platform
+using CodecZlib: GzipDecompressorStream
+using Downloads: download
 using JSON3: JSON3
 using HTTP: HTTP
-using Inflate: inflate_gzip
-using Pkg.Artifacts
-using SHA: sha256
+using Pkg.Artifacts: AbstractPlatform, artifact_hash, artifact_meta, bind_artifact!,
+    load_artifacts_toml, unbind_artifact!
+using SHA: SHA
 using Tar: Tar
 using TimeZones.TZData: tzdata_versions
 
 
+function artifact_checksums(tarball_url::AbstractString)
+    tarball = download(tarball_url, IOBuffer())
+
+    # Compute the Artifact.toml `sha256` from the compressed archive.
+    sha256 = bytes2hex(SHA.sha256(seekstart(tarball)))
+
+    # Compute the Artifact.toml `git-tree-sha1`. Usually this is computed via
+    # `Artifacts.create_artifact` but we want to avoid actually storing this data as an
+    # artifact.
+    git_tree_sha1 = SHA1(Tar.tree_hash(GzipDecompressorStream(seekstart(tarball))))
+
+    return git_tree_sha1, sha256
+end
+
 # Code loosely based upon: https://julialang.github.io/Pkg.jl/dev/artifacts/#Using-Artifacts-1
-function bind_artifact_url!(artifacts_toml::String, name::String, url::String; lazy::Bool=true)
+function bind_artifact_url!(
+    artifacts_toml::String,
+    name::String,
+    url::String;
+    lazy::Bool=true,
+    platform::Union{AbstractPlatform,Nothing}=nothing,
+)
+    p = something(platform, HostPlatform())
+
     # Query the `Artifacts.toml` file for the hash associated with artifact name. If no such
     # binding exists within the file then `nothing` will be returned.
-    artifact_hash = Artifacts.artifact_hash(name, artifacts_toml)
+    git_tree_sha1 = artifact_hash(name, artifacts_toml; platform=p)
 
-    if artifact_hash === nothing
+    if git_tree_sha1 === nothing
         @info "Processing new artifact: $name"
-
-        archive = download(url)
-        try
-            # Compute the `sha256` of the archive.
-            archive_sha = bytes2hex(open(sha256, archive))
-
-            # Compute the `git-tree-sha1`. Usually this is computed via
-            # `create_artifact` but we want to avoid actually storing this data as an
-            # artifact.
-            artifact_hash = SHA1(Tar.tree_hash(IOBuffer(inflate_gzip(archive))))
-        finally
-            rm(archive)
-        end
+        git_tree_sha1, sha256 = artifact_checksums(url)
     else
-        download_info = Artifacts.artifact_meta(name, artifacts_toml)["download"]
-        archive_sha = only(download_info)["sha256"]
+        meta = artifact_meta(name, artifacts_toml; platform=p)
+        sha256 = only(meta["download"])["sha256"]
     end
+
+    download_info = [(url, sha256)]
 
     # Must unbind before we can call bind on an already bound artifact
     unbind_artifact!(artifacts_toml, name)
-    bind_artifact!(
-        artifacts_toml,
-        name,
-        artifact_hash;
-        lazy,
-        download_info=[(url, archive_sha)],
-    )
+    bind_artifact!(artifacts_toml, name, git_tree_sha1; lazy, platform, download_info)
 end
+
+function update_uncode_cldr_artifacts!(artifacts_toml::AbstractString)
+    @info "Checking for latest Unicode CLDR release..."
+    response = HTTP.get("https://api.github.com/repos/unicode-org/cldr/releases/latest")
+    json = JSON3.read(response.body)
+    latest_unicode_cldr = json.tag_name  # latest release
+
+    @info "Latest Unicode CLDR release: $latest_unicode_cldr"
+    url = "https://github.com/unicode-org/cldr/archive/$latest_unicode_cldr.tar.gz"
+
+    artifact_dict = load_artifacts_toml(artifacts_toml)
+    unicode_artifacts = filter(startswith("unicode-cldr-"), keys(artifact_dict))
+
+    # Determine the checksum information from the artifacts or the download.
+    name = "unicode-cldr-$latest_unicode_cldr"
+    if name in unicode_artifacts
+        # Assumes that the same artifact is used across various platforms. That is true
+        # for our use of the unicode-cldr artifact.
+        info = first(artifact_dict[name])
+        git_tree_sha1 = SHA1(info["git-tree-sha1"])
+        sha256 = only(info["download"])["sha256"]
+    else
+        @info "Processing new artifact: $name"
+        git_tree_sha1, sha256 = artifact_checksums(url)
+    end
+
+    download_info = [(url, sha256)]
+    platforms = [
+        Platform("x86_64", "windows"),
+        Platform("i686", "windows"),
+    ]
+
+    # Clear out old unicode-cldr versions by unbinding all of the relevant artifacts and
+    # only binding the latest version.
+    unbind_artifact!.(artifacts_toml, unicode_artifacts)
+    for platform in platforms
+        bind_artifact!(artifacts_toml, name, git_tree_sha1; platform, download_info)
+    end
+
+    return latest_unicode_cldr
+end
+
 
 function update_artifacts!(artifacts_toml::String)
     @info "Checking for missing tzdata versions..."
@@ -57,14 +108,7 @@ function update_artifacts!(artifacts_toml::String)
         bind_artifact_url!(artifacts_toml, artifact_name, url; lazy)
     end
 
-    @info "Checking for latest Unicode CLDR release..."
-    response = HTTP.get("https://api.github.com/repos/unicode-org/cldr/releases/latest")
-    json = JSON3.read(response.body)
-    latest_unicode_cldr = json.tag_name  # latest release
-
-    @info "Latest Unicode CLDR release: $latest_unicode_cldr"
-    url = "https://github.com/unicode-org/cldr/archive/$latest_unicode_cldr.tar.gz"
-    bind_artifact_url!(artifacts_toml, "unicode-cldr-$latest_unicode_cldr", url)
+    latest_unicode_cldr = update_uncode_cldr_artifacts!(artifacts_toml)
 
     # Display the information on the latest releases which is useful for updating the
     # TimeZones package defaults.

--- a/src/winzone/WindowsTimeZoneIDs.jl
+++ b/src/winzone/WindowsTimeZoneIDs.jl
@@ -3,7 +3,7 @@ module WindowsTimeZoneIDs
 using LazyArtifacts
 using ...TimeZones: _scratch_dir
 
-const UNICODE_CLDR_VERSION = "release-43"
+const UNICODE_CLDR_VERSION = "release-43-1"
 
 # A mapping of Windows timezone names to Olson timezone names.
 # Details on the contents of this file can be found at:


### PR DESCRIPTION
As brought up in #438 we were previously using lazy artifacts for the multiple unicode-cldr artifacts which are only needed on Windows for translating the current OS time zone name into the IANA time zone name. This approach was problematic because PackageCompiler 1.0 would always download all of the lazy artifacts and PackageCompiler 2.0 would not download the lazy artifacts (unless you use `include_lazy_artifacts=true`) resulting in the used unicode-cldr artifact being downloaded at runtime. Additionally, we only require the latest unicode-cldr artifact and the only reason we included multiple of these artifacts was due to us failing to clean them up in the `dev/generate_artifacts.jl` script which generates this file.

This PR changes the `dev/generate_artifacts.jl` to update the `Artifacts.toml` to only include the latest unicode-cldr. We now specify the platform for this architecture so that the artifact is only used on Windows which also allows us to specify it as non-lazy. Finally, there was a newer unicode-cldr release so I've also updated to use release-43-1 here.

Supercedes #438