### PR TITLE
move RecipesBase support to an extension on 1.9+

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeZones"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 authors = ["Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "1.12.0"
+version = "1.13.0"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -26,8 +26,15 @@ TZJData = "1"
 julia = "1.6"
 p7zip_jll = "17.4"
 
+[extensions]
+TimeZonesRecipesBaseExt = "RecipesBase"
+
 [extras]
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "RecipesBase"]
+
+[weakdeps]
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"

--- a/ext/TimeZonesRecipesBaseExt.jl
+++ b/ext/TimeZonesRecipesBaseExt.jl
@@ -28,4 +28,4 @@ for details on the options and their tradeoffs.
     end
 end
 
-end #module
+end # module

--- a/ext/TimeZonesRecipesBaseExt.jl
+++ b/ext/TimeZonesRecipesBaseExt.jl
@@ -1,3 +1,8 @@
+module TimeZonesRecipesBaseExt
+
+using TimeZones
+using RecipesBase: RecipesBase, @recipe
+
 #==
 Plot ZonedDateTime, on x-axis.
 We convert it to DateTimes, in the local timezone,
@@ -22,3 +27,5 @@ for details on the options and their tradeoffs.
         [], ys
     end
 end
+
+end #module

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -93,6 +93,7 @@ include("rounding.jl")
 include("parse.jl")
 include("deprecated.jl")
 
+# Required to support Julia `VERSION < v"1.9"`
 if !isdefined(Base, :get_extension)
     include("../ext/TimeZonesRecipesBaseExt.jl")
 end

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -3,7 +3,6 @@ module TimeZones
 using Dates
 using Printf
 using Scratch: @get_scratch!
-using RecipesBase: RecipesBase, @recipe
 using Unicode
 using InlineStrings: InlineString15
 using TZJData: TZJData
@@ -92,7 +91,10 @@ include("ranges.jl")
 include("discovery.jl")
 include("rounding.jl")
 include("parse.jl")
-include("plotting.jl")
 include("deprecated.jl")
+
+if !isdefined(Base, :get_extension)
+    include("../ext/TimeZonesRecipesBaseExt.jl")
+end
 
 end # module


### PR DESCRIPTION
This uses [the method in the Pkg docs](https://pkgdocs.julialang.org/v1/creating-packages/#Transition-from-normal-dependency-to-extension) to continue support for Julia < 1.9.

On 1.9, this shaves about 100ms off of `using TimeZones` for me.