### PR TITLE
Lazily initialize the time zone cache

### DIFF
--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -42,6 +42,10 @@ abstract type Local <: TimeZone end
 function __init__()
     # Dates extension needs to happen everytime the module is loaded (issue #24)
     init_dates_extension()
+
+    if haskey(ENV, "JULIA_TZ_VERSION")
+        @info "Using tzdata $(TZData.tzdata_version())"
+    end
 end
 
 include("utils.jl")

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -40,20 +40,6 @@ const _COMPILED_DIR = Ref{String}()
 abstract type Local <: TimeZone end
 
 function __init__()
-    # Write out our compiled tzdata representations into a scratchspace
-    desired_version = TZData.tzdata_version()
-
-    _COMPILED_DIR[] = if desired_version == TZJData.TZDATA_VERSION
-        TZJData.ARTIFACT_DIR
-    else
-        @info "Loading tzdata $desired_version"
-        TZData.build(desired_version, _scratch_dir())
-    end
-
-    # Load the pre-computed TZData into memory. Skip pre-fetching the first time
-    # TimeZones.jl is loaded by `deps/build.jl` as we have yet to compile the tzdata.
-    isdir(_COMPILED_DIR[]) && _reload_cache(_COMPILED_DIR[])
-
     # Dates extension needs to happen everytime the module is loaded (issue #24)
     init_dates_extension()
 end

--- a/src/build.jl
+++ b/src/build.jl
@@ -13,7 +13,7 @@ function build(version::AbstractString; force::Bool=false)
 
     # Set the compiled directory to the new location
     _COMPILED_DIR[] = compiled_dir
-    _reload_cache(compiled_dir)
+    _reload_tz_cache(compiled_dir)
 
     @info "Successfully built TimeZones"
 end

--- a/src/types/timezone.jl
+++ b/src/types/timezone.jl
@@ -149,12 +149,6 @@ function istimezone(str::AbstractString, mask::Class=Class(:DEFAULT))
     end
 
     # Checks against pre-compiled time zones
-    tz_class = get(get_tz_cache(), str, nothing)
-    tz_class === nothing && return false
-    if tz_class === nothing
-        return false
-    else
-        _, class = tz_class
-        return mask & class != Class(:NONE)
-    end
+    class = get(get_tz_cache(), str, (UTC_ZERO, Class(:NONE)))[2]
+    return mask & class != Class(:NONE)
 end

--- a/src/types/timezone.jl
+++ b/src/types/timezone.jl
@@ -39,7 +39,7 @@ function initialize_tz_cache()
     _COMPILED_DIR[] = if desired_version == TZJData.TZDATA_VERSION
         TZJData.ARTIFACT_DIR
     else
-        @info "Loading tzdata $desired_version"
+        # @info "Loading tzdata $desired_version"
         TZData.build(desired_version, _scratch_dir())
     end
 

--- a/src/types/timezone.jl
+++ b/src/types/timezone.jl
@@ -12,7 +12,6 @@ function _init_tz_cache()
     _COMPILED_DIR[] = if desired_version == TZJData.TZDATA_VERSION
         TZJData.ARTIFACT_DIR
     else
-        # @info "Loading tzdata $desired_version"
         TZData.build(desired_version, _scratch_dir())
     end
 

--- a/src/tzdata/compile.jl
+++ b/src/tzdata/compile.jl
@@ -718,7 +718,7 @@ function compile(
     # TimeZones 1.0 has supported automatic flushing of the cache when calling `compile`
     # (e.g. `compile(max_year=2200)`). We'll keep this behaviour to ensure we are not
     # breaking our API but the low-level `compile` function should ideally be cache unaware.
-    TimeZones._reload_cache(dest_dir)
+    TimeZones._reload_tz_cache(dest_dir)
 
     return results
 end

--- a/test/tzdata/build.jl
+++ b/test/tzdata/build.jl
@@ -32,7 +32,7 @@ using TimeZones: TZData
             # revise the above line to be something like:
             # tz_source = TZData.TZSource(joinpath.(tz_source_dir, ["europe", "africa"]))
             # TZData.compile(tz_source, compiled_dir, max_year=2200)
-            # TimeZones._reload_cache(compiled_dir)
+            # TimeZones._reload_tz_cache(compiled_dir)
 
             new_warsaw = TimeZone("Europe/Warsaw")
 
@@ -50,6 +50,6 @@ using TimeZones: TZData
             @test TimeZone("Africa/Windhoek").cutoff == DateTime(2201, 4, 5)
         end
     finally
-        TimeZones._reload_cache(TimeZones._COMPILED_DIR[])
+        TimeZones._reload_tz_cache(TimeZones._COMPILED_DIR[])
     end
 end


### PR DESCRIPTION
This avoids having to compile a bunch of code in `__init__` and improves the load time of the package (on Julia 1.11) from:

```julia
julia> @time_imports import TimeZones
...
              ┌ 2.6 ms TimeZones.TZData.__init__() 92.83% compilation time
               ├ 237.9 ms TimeZones.__init__() 94.11% compilation time (89% recompilation)
    276.3 ms  TimeZones 81.90% compilation time (88% recompilation)
```

```julia
julia> @time_imports import TimeZones
...
     17.5 ms  TimeZones 16.03% compilation time
```

The change in performance of the functions is (in my opinion) acceptable.

After:

```julia
julia> using BenchmarkTools, TimeZones

julia> @btime istimezone("Europe/Warsaw")
  48.068 ns (1 allocation: 16 bytes)
true
```

Before:

```julia
julia> @btime istimezone("Europe/Warsaw")
  45.356 ns (1 allocation: 16 bytes)
true
```