### PR TITLE
Ensure we don't break weakdeps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,7 +74,7 @@ jobs:
       - shell: julia --color=yes --project=docs {0}
         run: |
           using Pkg
-          Pkg.add(PackageSpec(name="TimeZones", rev=ENV["SHA"])
+          Pkg.add(PackageSpec(name="TimeZones", rev=ENV["SHA"]))
           using TimeZones
 
   benchmarks:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,10 +14,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
-# Only download the tzdata version used in TimeZones.jl's tests to avoid unnecessary
-# load on IANA's servers.
 env:
+  # Only download the tzdata version used in TimeZones.jl's tests to avoid unnecessary
+  # load on IANA's servers.
   JULIA_TZ_VERSION: 2016j  # Matches tzdata version used in tests
+
+  # The HEAD commit which triggered this workflow. By default PRs use a merge commit
+  SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
   test:
@@ -57,6 +60,22 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           files: lcov.info
+
+  # https://pkgdocs.julialang.org/v1/creating-packages/#Transition-from-normal-dependency-to-extension
+  weakdeps:
+    name: Weakdeps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: "1.6"  # LTS / Oldest support version
+      - uses: julia-actions/cache@v2
+      - shell: julia --color=yes --project=docs {0}
+        run: |
+          using Pkg
+          Pkg.add(PackageSpec(name="TimeZones", rev=ENV["SHA"])
+          using TimeZones
 
   benchmarks:
     name: Benchmarks


### PR DESCRIPTION
None of the CI checks currently in place ensure that we [maintain compatibility for older versions of Julia for `[weakdeps]`](https://pkgdocs.julialang.org/v1/creating-packages/#Transition-from-normal-dependency-to-extension). This adds a new GHA job to ensure these problems are caught before they make it into a release.

This should prevent this mistake from happening again: https://github.com/JuliaTime/TimeZones.jl/pull/459#issuecomment-2123418212