### PR TITLE
CI runner tweaks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,7 @@ jobs:
           - "1.6"  # LTS / Oldest supported version
           - "1"    # Latest release
           - nightly
+        # https://github.com/actions/runner-images#available-images
         os:
           - ubuntu-latest
           - macos-14  # Apple silicon
@@ -65,7 +66,7 @@ jobs:
         include:
           # Apple silicon isn't supported by Julia 1.6
           - version: "1.6"
-            os: macos-latest  # Intel
+            os: macos-13  # Intel
             arch: x64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,9 @@ jobs:
             arch: x86
           - os: windows-latest
             arch: x86
+          # Disable Windows tests on Julia 1.6 as it's particularly slow
+          - version: "1.6"
+            os: windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,17 +36,23 @@ jobs:
           - nightly
         os:
           - ubuntu-latest
-          - macOS-latest
+          - macos-latest-xlarge  # Apple silicon
           - windows-latest
         arch:
           - x64
           - x86
+          - aarch64
         exclude:
           # Test 32-bit only on Linux
-          - os: macOS-latest
+          - os: macos-latest-xlarge
             arch: x86
           - os: windows-latest
             arch: x86
+          # Test ARM64 only on macOS
+          - os: ubuntu-latest
+            arch: aarch64
+          - os: windows-latest
+            arch: aarch64
           # Disable Windows tests on Julia 1.6 as it's particularly slow
           - version: "1.6"
             os: windows-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
           - nightly
         os:
           - ubuntu-latest
-          - macos-latest-xlarge  # Apple silicon
+          - macos-14  # Apple silicon
           - windows-latest
         arch:
           - x64
@@ -44,7 +44,7 @@ jobs:
           - aarch64
         exclude:
           # Test 32-bit only on Linux
-          - os: macos-latest-xlarge
+          - os: macos-14
             arch: x86
           - os: windows-latest
             arch: x86

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,6 +81,7 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   # https://pkgdocs.julialang.org/v1/creating-packages/#Transition-from-normal-dependency-to-extension
   weakdeps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,9 +53,20 @@ jobs:
             arch: aarch64
           - os: windows-latest
             arch: aarch64
+          # Prefer testing against Apple Silicon
+          - os: macos-14
+            arch: x64
+          - version: "1.6"
+            os: macos-14
+            arch: aarch64
           # Disable Windows tests on Julia 1.6 as it's particularly slow
           - version: "1.6"
             os: windows-latest
+        include:
+          # Apple silicon isn't supported by Julia 1.6
+          - version: "1.6"
+            os: macos-latest  # Intel
+            arch: x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
- Avoid testing against Julia 1.6 on Windows as it is particularly slow
- Switch from testing against Intel based macOS to Apple Silicon macOS as the former is becoming less common (https://github.com/orgs/community/discussions/102846)
- Use CodeCov token to avoid rate limiting: https://docs.codecov.com/docs/codecov-uploader#supporting-token-less-uploads-for-forks-of-open-source-repos-using-codecov