### PR TITLE
Add Accessors for Day and higher

### DIFF
--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -1,4 +1,4 @@
-using Dates: Hour, Minute, Second, Millisecond, days, hour, minute, second, millisecond
+using Dates: Quarter, Year, Month, Day, Hour, Minute, Second, Millisecond, days, hour, minute, second, millisecond
 
 """
     timezone(::ZonedDateTime) -> TimeZone
@@ -9,7 +9,7 @@ timezone(zdt::ZonedDateTime) = zdt.timezone
 
 Dates.days(zdt::ZonedDateTime) = days(DateTime(zdt))
 
-for period in (:Hour, :Minute, :Second, :Millisecond)
+for period in (:Quarter, :Year, :Month, :Day, :Hour, :Minute, :Second, :Millisecond)
     accessor = Symbol(lowercase(string(period)))
     @eval begin
         Dates.$accessor(zdt::ZonedDateTime) = $accessor(DateTime(zdt))


### PR DESCRIPTION
During a development project, I noticed that I was not able to run `Day` (or higher) on `ZonedDateTime` objects.  The fix in this PR addresses that issue.  Below is a minimum working example to show the issue

```
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.9.3 (2023-08-24)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> using TimeZones, Dates

julia> x = ZonedDateTime(today(), tz"UTC")
2024-09-23T00:00:00+00:00

julia> Hour(x)
0 hours

julia> Day(x)
ERROR: MethodError: no method matching Day(::ZonedDateTime)

Closest candidates are:
  (::Type{T})(::Period) where T<:Period
   @ Dates /Applications/Julia-1.9.app/Contents/Resources/julia/share/julia/stdlib/v1.9/Dates/src/periods.jl:384
  Day(::Number)
   @ Dates /Applications/Julia-1.9.app/Contents/Resources/julia/share/julia/stdlib/v1.9/Dates/src/types.jl:55
  Day(::AbstractString)
   @ Dates /Applications/Julia-1.9.app/Contents/Resources/julia/share/julia/stdlib/v1.9/Dates/src/periods.jl:21
  ...

Stacktrace:
 [1] top-level scope
   @ REPL[3]:1


```