### PR TITLE
Fix Julia 1.12 allocation tests

### DIFF
--- a/src/types/timezonecache.jl
+++ b/src/types/timezonecache.jl
@@ -15,9 +15,11 @@ TimeZoneCache() = TimeZoneCache(Dict(), Dict(), ReentrantLock(), Threads.Atomic{
 const _TZ_CACHE = TimeZoneCache()
 
 function Base.copy!(dst::TimeZoneCache, src::TimeZoneCache)
-    copy!(dst.ftz, src.ftz)
-    copy!(dst.vtz, src.vtz)
-    dst.initialized[] = src.initialized[]
+    lock(dst.lock) do
+        copy!(dst.ftz, src.ftz)
+        copy!(dst.vtz, src.vtz)
+        dst.initialized[] = src.initialized[]
+    end
     return dst
 end
 

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -81,3 +81,14 @@ function with_tz_cache(f, cache::TimeZones.TimeZoneCache)
         copy!(TimeZones._TZ_CACHE, old_cache)
     end
 end
+
+function with_tz_cache(f)
+    old_cache = deepcopy(TimeZones._TZ_CACHE)
+    copy!(TimeZones._TZ_CACHE, TimeZones.TimeZoneCache())
+
+    try
+        return withenv(f, "JULIA_TZDATA_VERSION" => TZDATA_VERSION)
+    finally
+        copy!(TimeZones._TZ_CACHE, old_cache)
+    end
+end

--- a/test/plotting.jl
+++ b/test/plotting.jl
@@ -3,8 +3,9 @@
     # lets use avoid a Plots.jl dependency and issues with running that during tests.
     # `RecipesBase.apply_recipe` is not a documented API, but is fairly usable.
     # Comments above each use show the matching `plot` function command
-    start_zdt = ZonedDateTime(2017,1,1,0,0,0, tz"EST")
-    end_zdt = ZonedDateTime(2017,1,1,10,30,0, tz"EST")
+    tz = FixedTimeZone("EST", -18000)
+    start_zdt = ZonedDateTime(2017,1,1,0,0,0, tz)
+    end_zdt = ZonedDateTime(2017,1,1,10,30,0, tz)
     zoned_dates = start_zdt:Hour(1):end_zdt
 
     # what the point should be after recipe is applied

--- a/test/types/timezone.jl
+++ b/test/types/timezone.jl
@@ -26,6 +26,8 @@ end
     @test TimeZone("Etc/GMT-14", Class(:LEGACY)) == FixedTimeZone("Etc/GMT-14", 14 * 3600)
 end
 
+# These allocation tests are a bit fragile. Clearing the cache makes these tests more
+# in on Julia 1.12.0-DEV.1786.
 @testset "allocations" begin
     with_tz_cache() do
         # Trigger compilation (only upon the first call in Julia) and populate the cache

--- a/test/types/timezone.jl
+++ b/test/types/timezone.jl
@@ -27,13 +27,19 @@ end
 end
 
 @testset "allocations" begin
-    tz = TimeZone("UTC")  # Trigger compilation and ensure the cache is populated
-    @test tz isa FixedTimeZone
-    @test @allocations(TimeZone("UTC")) == 0
-    @test @allocations(istimezone("UTC")) == 0
+    with_tz_cache() do
+        # Trigger compilation (only upon the first call in Julia) and populate the cache
+        @test @allocations(TimeZone("UTC")) > 0
 
-    tz = TimeZone("America/Winnipeg")  # Trigger compilation and ensure the cache is populated
-    @test tz isa VariableTimeZone
-    @test @allocations(TimeZone("America/Winnipeg")) == 2
-    @test @allocations(istimezone("America/Winnipeg")) == 1
+        @test @allocations(TimeZone("UTC")) == 0
+        @test @allocations(istimezone("UTC")) == 0
+    end
+
+    with_tz_cache() do
+        # Trigger compilation (only upon the first call in Julia) and populate the cache
+        @test @allocations(TimeZone("America/Winnipeg")) > 0
+
+        @test @allocations(TimeZone("America/Winnipeg")) == 2
+        @test @allocations(istimezone("America/Winnipeg")) == 1
+    end
 end


### PR DESCRIPTION
Fixing these test failures that are failing on Julia 1.12:
```
 allocations: Test Failed at /home/runner/work/TimeZones.jl/TimeZones.jl/test/types/timezone.jl:32
  Expression: #= /home/runner/work/TimeZones.jl/TimeZones.jl/test/types/timezone.jl:32 =# @allocations(TimeZone("UTC")) == 0
   Evaluated: 2 == 0

Stacktrace:
 [1] macro expansion
   @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.12/Test/src/Test.jl:679 [inlined]
 [2] macro expansion
   @ ~/work/TimeZones.jl/TimeZones.jl/test/types/timezone.jl:32 [inlined]
 [3] macro expansion
   @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.12/Test/src/Test.jl:1724 [inlined]
 [4] top-level scope
   @ ~/work/TimeZones.jl/TimeZones.jl/test/types/timezone.jl:30
allocations: Test Failed at /home/runner/work/TimeZones.jl/TimeZones.jl/test/types/timezone.jl:33
  Expression: #= /home/runner/work/TimeZones.jl/TimeZones.jl/test/types/timezone.jl:33 =# @allocations(istimezone("UTC")) == 0
   Evaluated: 1 == 0

Stacktrace:
 [1] macro expansion
   @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.12/Test/src/Test.jl:679 [inlined]
 [2] macro expansion
   @ ~/work/TimeZones.jl/TimeZones.jl/test/types/timezone.jl:33 [inlined]
 [3] macro expansion
   @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.12/Test/src/Test.jl:1724 [inlined]
 [4] top-level scope
   @ ~/work/TimeZones.jl/TimeZones.jl/test/types/timezone.jl:30
allocations: Test Failed at /home/runner/work/TimeZones.jl/TimeZones.jl/test/types/timezone.jl:37
  Expression: #= /home/runner/work/TimeZones.jl/TimeZones.jl/test/types/timezone.jl:37 =# @allocations(TimeZone("America/Winnipeg")) == 2
   Evaluated: 3 == 2

Stacktrace:
 [1] macro expansion
   @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.12/Test/src/Test.jl:679 [inlined]
 [2] macro expansion
   @ ~/work/TimeZones.jl/TimeZones.jl/test/types/timezone.jl:37 [inlined]
 [3] macro expansion
   @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.12/Test/src/Test.jl:1724 [inlined]
 [4] top-level scope
   @ ~/work/TimeZones.jl/TimeZones.jl/test/types/timezone.jl:30
allocations: Test Failed at /home/runner/work/TimeZones.jl/TimeZones.jl/test/types/timezone.jl:38
  Expression: #= /home/runner/work/TimeZones.jl/TimeZones.jl/test/types/timezone.jl:38 =# @allocations(istimezone("America/Winnipeg")) == 1
   Evaluated: 2 == 1

Stacktrace:
 [1] macro expansion
   @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.12/Test/src/Test.jl:679 [inlined]
 [2] macro expansion
   @ ~/work/TimeZones.jl/TimeZones.jl/test/types/timezone.jl:38 [inlined]
 [3] macro expansion
   @ /opt/hostedtoolcache/julia/nightly/x64/share/julia/stdlib/v1.12/Test/src/Test.jl:1724 [inlined]
 [4] top-level scope
   @ ~/work/TimeZones.jl/TimeZones.jl/test/types/timezone.jl:30
```
– https://github.com/JuliaTime/TimeZones.jl/actions/runs/12420872436/job/34679338138?pr=479#step:6:138