### PR TITLE
ZonedDateTime can parse its own string representation 

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,4 +1,4 @@
-using Base: @deprecate
+using Base: @deprecate, depwarn
 
 # BEGIN TimeZones 1.0 deprecations
 
@@ -15,7 +15,7 @@ const TransitionTimeInfo = TZFile.TransitionTimeInfo
 
 function Dates.default_format(::Type{ZonedDateTime})
     depwarn(
-        "`$(Dates.default_format)(ZonedDateTime)` is deprecated and has direct " *
+        "`Dates.default_format(ZonedDateTime)` is deprecated and has no direct " *
         "replacement. Consider using refactoring to use " *
         "`parse(::Type{ZonedDateTime}, ::AbstractString)` as an alternative.",
         :default_format,

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -13,4 +13,14 @@ const TransitionTimeInfo = TZFile.TransitionTimeInfo
 
 @deprecate build(; force=false) build(TZJData.TZDATA_VERSION; force)
 
+function Dates.default_format(::Type{ZonedDateTime})
+    depwarn(
+        "`$(Dates.default_format)(ZonedDateTime)` is deprecated and has direct " *
+        "replacement. Consider using refactoring to use " *
+        "`parse(::Type{ZonedDateTime}, ::AbstractString)` as an alternative.",
+        :default_format,
+    )
+    return ISOZonedDateTimeFormat
+end
+
 # END TimeZones 1.0 deprecations

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -17,7 +17,7 @@ begin
     # Follows the ISO 8601 standard for date and time with an offset. See
     # `Dates.ISODateTimeFormat` for the `DateTime` equivalent.
     const ISOZonedDateTimeFormat = DateFormat("yyyy-mm-dd\\THH:MM:SS.ssszzz")
-    const NoMillisecondFormat = DateFormat("yyyy-mm-dd\\THH:MM:SSzzz")
+    const ISOZonedDateTimeNoMillisecondFormat = DateFormat("yyyy-mm-dd\\THH:MM:SSzzz")
 end
 
 Base.parse(::Type{ZonedDateTime}, str::AbstractString) = ZonedDateTime(str)
@@ -104,7 +104,7 @@ end
 
 function ZonedDateTime(str::AbstractString)
     res = tryparse(ZonedDateTime, str, ISOZonedDateTimeFormat)
-    isnothing(res) ?  ZonedDateTime(str, NoMillisecondFormat) : res
+    return isnothing(res) ? ZonedDateTime(str, ISOZonedDateTimeNoMillisecondFormat) : res
 end
 
 function ZonedDateTime(str::AbstractString, df::DateFormat)

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -26,10 +26,10 @@ end
 When the `TimeZones` package is loaded, 2 extra character codes are available
 for constructing the `format` string:
 
-| Code       | Matches   | Comment                                                       |
-|:-----------|:----------|:--------------------------------------------------------------|
-| `z`        | +02:00    | Numeric UTC offset                                            |
-| `Z`        | GST, UTC  | Time zone abbreviation                                        |
+| Code       | Matches            | Comment                                               |
+|:-----------|:-------------------|:------------------------------------------------------|
+| `z`        | +02:00, -0100, +14 | Parsing matches a fixed numeric UTC offset `±hh:mm`, `±hhmm`, or `±hh`. Formatting outputs `±hh:mm` |
+| `Z`        | UTC, GMT, America/New_York | Name of a time zone as specified in the IANA tz database |
 """ DateFormat
 
 function Base.parse(::Type{ZonedDateTime}, str::AbstractString)

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -16,8 +16,8 @@ begin
 
     # Follows the ISO 8601 standard for date and time with an offset. See
     # `Dates.ISODateTimeFormat` for the `DateTime` equivalent.
-    const ISOZonedDateTimeFormat = DateFormat("yyyy-mm-ddTHH:MM:SS.ssszzz")
-    const NoMillisecondFormat = DateFormat("yyyy-mm-ddTHH:MM:SSzzz")
+    const ISOZonedDateTimeFormat = DateFormat("yyyy-mm-dd\\THH:MM:SS.ssszzz")
+    const NoMillisecondFormat = DateFormat("yyyy-mm-dd\\THH:MM:SSzzz")
 end
 
 Base.parse(::Type{ZonedDateTime}, str::AbstractString) = ZonedDateTime(str)

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -15,6 +15,12 @@ const ISOZonedDateTimeFormat = let
     DateFormat("yyyy-mm-ddTHH:MM:SS.ssszzz")
 end
 
+const NoMillisecondFormat = let
+    init_dates_extension()
+    DateFormat("yyyy-mm-ddTHH:MM:SSzzz")
+end
+
+Base.parse(::Type{ZonedDateTime}, str::AbstractString) = ZonedDateTime(str)
 Dates.default_format(::Type{ZonedDateTime}) = ISOZonedDateTimeFormat
 
 function tryparsenext_fixedtz(str, i, len, min_width::Int=1, max_width::Int=0)
@@ -97,7 +103,15 @@ function Dates.format(io::IO, d::DatePart{'Z'}, zdt, locale)
     write(io, string(zdt.zone))  # In most cases will be an abbreviation.
 end
 
-function ZonedDateTime(str::AbstractString, df::DateFormat=ISOZonedDateTimeFormat)
+function ZonedDateTime(str::AbstractString)
+    if length(str) < 20 || str[20] == '.'
+        ZonedDateTime(str, ISOZonedDateTimeFormat)
+    else
+        ZonedDateTime(str, NoMillisecondFormat)
+    end
+end
+
+function ZonedDateTime(str::AbstractString, df::DateFormat)
     try
         parse(ZonedDateTime, str, df)
     catch e

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -103,11 +103,8 @@ function Dates.format(io::IO, d::DatePart{'Z'}, zdt, locale)
 end
 
 function ZonedDateTime(str::AbstractString)
-    if length(str) < 20 || str[20] == '.'
-        ZonedDateTime(str, ISOZonedDateTimeFormat)
-    else
-        ZonedDateTime(str, NoMillisecondFormat)
-    end
+    res = tryparse(ZonedDateTime, str, ISOZonedDateTimeFormat)
+    isnothing(res) ?  ZonedDateTime(str, NoMillisecondFormat) : res
 end
 
 function ZonedDateTime(str::AbstractString, df::DateFormat)

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -10,14 +10,14 @@ function init_dates_extension()
     )
 end
 
-const ISOZonedDateTimeFormat = let
+begin
+    # Needs to be initialized to construct formats
     init_dates_extension()
-    DateFormat("yyyy-mm-ddTHH:MM:SS.ssszzz")
-end
 
-const NoMillisecondFormat = let
-    init_dates_extension()
-    DateFormat("yyyy-mm-ddTHH:MM:SSzzz")
+    # Follows the ISO 8601 standard for date and time with an offset. See
+    # `Dates.ISODateTimeFormat` for the `DateTime` equivalent.
+    const ISOZonedDateTimeFormat = DateFormat("yyyy-mm-ddTHH:MM:SS.ssszzz")
+    const NoMillisecondFormat = DateFormat("yyyy-mm-ddTHH:MM:SSzzz")
 end
 
 Base.parse(::Type{ZonedDateTime}, str::AbstractString) = ZonedDateTime(str)

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -21,8 +21,12 @@ begin
 end
 
 function Base.parse(::Type{ZonedDateTime}, str::AbstractString)
-    res = tryparse(ZonedDateTime, str, ISOZonedDateTimeFormat)
-    return isnothing(res) ? parse(ZonedDateTime, str, ISOZonedDateTimeNoMillisecondFormat) : res
+    # Works as the format should only contain a period when milliseconds are included
+    return if contains(str, '.')
+        parse(ZonedDateTime, str, ISOZonedDateTimeFormat)
+    else
+        parse(ZonedDateTime, str, ISOZonedDateTimeNoMillisecondFormat)
+    end
 end
 
 function Base.parse(::Type{ZonedDateTime}, str::AbstractString, df::DateFormat)

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -21,7 +21,6 @@ const NoMillisecondFormat = let
 end
 
 Base.parse(::Type{ZonedDateTime}, str::AbstractString) = ZonedDateTime(str)
-Dates.default_format(::Type{ZonedDateTime}) = ISOZonedDateTimeFormat
 
 function tryparsenext_fixedtz(str, i, len, min_width::Int=1, max_width::Int=0)
     i == len && str[i] === 'Z' && return ("Z", i+1)

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -20,6 +20,18 @@ begin
     const ISOZonedDateTimeNoMillisecondFormat = DateFormat("yyyy-mm-dd\\THH:MM:SSzzz")
 end
 
+@doc """
+    DateFormat(format::AbstractString, locale="english") --> DateFormat
+
+When the `TimeZones` package is loaded, 2 extra character codes are available
+for constructing the `format` string:
+
+| Code       | Matches   | Comment                                                       |
+|:-----------|:----------|:--------------------------------------------------------------|
+| `z`        | +02:00    | Numeric UTC offset                                            |
+| `Z`        | GST, UTC  | Time zone abbreviation                                        |
+""" DateFormat
+
 function Base.parse(::Type{ZonedDateTime}, str::AbstractString)
     # Works as the format should only contain a period when milliseconds are included
     return if contains(str, '.')

--- a/src/types/zoneddatetime.jl
+++ b/src/types/zoneddatetime.jl
@@ -173,7 +173,29 @@ end
 
 Construct a `ZonedDateTime` by parsing `str`. This method is designed so that
 `zdt == ZonedDateTime(string(zdt))` where `zdt` can be any `ZonedDateTime`
-object.
+object. Take note that this method will always create a `ZonedDateTime` with a
+`FixedTimeZone` which can result in different results with date/time arithmetic.
+
+## Examples
+```jltest
+julia> zdt = ZonedDateTime(2025, 3, 8, 9, tz"America/New_York")
+2025-03-08T09:00:00-05:00
+
+julia> timezone(zdt)
+America/New_York (UTC-5/UTC-4)
+
+julia> zdt + Day(1)
+2025-03-09T09:00:00-04:00
+
+julia> pzdt = ZonedDateTime(string(zdt))
+2025-03-08T09:00:00-05:00
+
+julia> timezone(pzdt)
+UTC-05:00
+
+julia> pzdt + Day(1)
+2025-03-09T09:00:00-05:00
+```
 """
 ZonedDateTime(str::AbstractString) = parse(ZonedDateTime, str)
 

--- a/src/types/zoneddatetime.jl
+++ b/src/types/zoneddatetime.jl
@@ -166,6 +166,15 @@ function ZonedDateTime(date::Date, args...; kwargs...)
     return ZonedDateTime(DateTime(date), args...; kwargs...)
 end
 
+# Parsing constructors
+
+ZonedDateTime(str::AbstractString) = parse(ZonedDateTime, str)
+ZonedDateTime(str::AbstractString, df::DateFormat) = parse(ZonedDateTime, str, df)
+
+function ZonedDateTime(str::AbstractString, format::AbstractString; locale::AbstractString="english")
+    return parse(ZonedDateTime, str, DateFormat(format, locale))
+end
+
 # Promotion
 
 # Because of the promoting fallback definitions for TimeType, we need a special case for

--- a/src/types/zoneddatetime.jl
+++ b/src/types/zoneddatetime.jl
@@ -168,7 +168,21 @@ end
 
 # Parsing constructors
 
+"""
+    ZonedDateTime(str::AbstractString)
+
+Construct a `ZonedDateTime` by parsing `str`. This method is designed so that
+`zdt == ZonedDateTime(string(zdt))` where `zdt` can be any `ZonedDateTime`
+object.
+"""
 ZonedDateTime(str::AbstractString) = parse(ZonedDateTime, str)
+
+"""
+    ZonedDateTime(str::AbstractString, df::DateFormat)
+
+Construct a `ZonedDateTime` by parsing `str` according to the format specified
+in `df`.
+"""
 ZonedDateTime(str::AbstractString, df::DateFormat) = parse(ZonedDateTime, str, df)
 
 function ZonedDateTime(str::AbstractString, format::AbstractString; locale::AbstractString="english")

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,0 +1,3 @@
+@testset "default format" begin
+    @test default_format(ZonedDateTime) === TimeZones.ISOZonedDateTimeFormat
+end

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,3 +1,3 @@
 @testset "default format" begin
-    @test default_format(ZonedDateTime) === TimeZones.ISOZonedDateTimeFormat
+    @test Dates.default_format(ZonedDateTime) === TimeZones.ISOZonedDateTimeFormat
 end

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -71,7 +71,7 @@ end
         @test e isa ArgumentError
         @test occursin(str, e.msg)
         @test occursin(string(TimeZones.ISOZonedDateTimeFormat), e.msg) ||
-               occursin(string(TimeZones.NoMillisecondFormat), e.msg)
+               occursin(string(TimeZones.ISOZonedDateTimeNoMillisecondFormat), e.msg)
     end
 end
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -21,7 +21,6 @@ using TimeZones: ParseNextError, _parsesub_tzabbr, _parsesub_offset, _parsesub_t
         parse(ZonedDateTime, Test.GenericString("2018-01-01 00:00 UTC"), dateformat"yyyy-mm-dd HH:MM ZZZ"),
         ZonedDateTime(2018, 1, 1, 0, tz"UTC"),
     )
-
 end
 
 @testset "tryparse" begin
@@ -76,13 +75,20 @@ end
 end
 
 @testset "self parseable" begin
-    tt = [ZonedDateTime(2025, 2, 28, 14, 22, tz"UTC"),
-          ZonedDateTime(20025, 2, 28, 14, tz"UTC+05"),
-         ]
-    push!(tt, tt[1] + Millisecond(55), tt[2] + Millisecond(4))
-    for t in tt
-        @test t == ZonedDateTime(string(t))
-        @test t == parse(ZonedDateTime, string(t))
+    zdt_args = Iterators.product(
+        [0, 1, 10, 100, 1000, 10000],  # Year
+        [1, 12],  # Month
+        [3, 31],  # Day
+        [0, 4, 23],  # Hour
+        [0, 5, 55],  # Minute
+        [0, 6, 56],  # Seconds
+        [0, 7, 77, 777],  # Milliseconds
+        [tz"UTC"],  # Time zones
+    )
+    for args in zdt_args
+        zdt = ZonedDateTime(args...)
+        @test zdt == parse(ZonedDateTime, string(zdt))
+        @test zdt == ZonedDateTime(string(zdt))
     end
 end
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -70,13 +70,16 @@ end
     catch e
         @test e isa ArgumentError
         @test occursin(str, e.msg)
-        @test occursin(string(TimeZones.ISOZonedDateTimeFormat), e.msg)
+        @test occursin(string(TimeZones.ISOZonedDateTimeFormat), e.msg) ||
+               occursin(string(TimeZones.NoMillisecondFormat), e.msg)
     end
 end
 
 @testset "self parseable" begin
-    tt = [ZonedDateTime(2025, 2, 28, 14, 22, tz"UTC")]
-    push!(tt, tt[1] + Millisecond(55))
+    tt = [ZonedDateTime(2025, 2, 28, 14, 22, tz"UTC"),
+          ZonedDateTime(20025, 2, 28, 14, tz"UTC+05"),
+         ]
+    push!(tt, tt[1] + Millisecond(55), tt[2] + Millisecond(4))
     for t in tt
         @test t == ZonedDateTime(string(t))
         @test t == parse(ZonedDateTime, string(t))

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1,4 +1,4 @@
-using Dates: parse_components, default_format, Millisecond
+using Dates: parse_components, Millisecond
 using TimeZones: ParseNextError, _parsesub_tzabbr, _parsesub_offset, _parsesub_time, _parsesub_tzdate, _parsesub_tz
 
 @testset "parse" begin
@@ -47,10 +47,6 @@ end
         tz"UTC+01",
     ]
     @test parse_components(test...) == expected
-end
-
-@testset "default format" begin
-    @test default_format(ZonedDateTime) === TimeZones.ISOZonedDateTimeFormat
 end
 
 @testset "parse constructor" begin

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1,4 +1,4 @@
-using Dates: parse_components, default_format
+using Dates: parse_components, default_format, Millisecond
 using TimeZones: ParseNextError, _parsesub_tzabbr, _parsesub_offset, _parsesub_time, _parsesub_tzdate, _parsesub_tz
 
 @testset "parse" begin
@@ -75,6 +75,15 @@ end
         @test e isa ArgumentError
         @test occursin(str, e.msg)
         @test occursin(string(TimeZones.ISOZonedDateTimeFormat), e.msg)
+    end
+end
+
+@testset "self parseable" begin
+    tt = [ZonedDateTime(2025, 2, 28, 14, 22, tz"UTC")]
+    push!(tt, tt[1] + Millisecond(55))
+    for t in tt
+        @test t == ZonedDateTime(string(t))
+        @test t == parse(ZonedDateTime, string(t))
     end
 end
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -61,17 +61,6 @@ end
         ZonedDateTime("2018-11-01-0600", dateformat"yyyy-mm-ddzzzz"),
         ZonedDateTime(2018, 11, 1, tz"UTC-06"),
     )
-
-    # Validate that error message contains the original string and the format used
-    str = "2018-11-01"
-    try
-        ZonedDateTime(str)
-    catch e
-        @test e isa ArgumentError
-        @test occursin(str, e.msg)
-        @test occursin(string(TimeZones.ISOZonedDateTimeFormat), e.msg) ||
-               occursin(string(TimeZones.ISOZonedDateTimeNoMillisecondFormat), e.msg)
-    end
 end
 
 @testset "self parseable" begin
@@ -89,6 +78,29 @@ end
         zdt = ZonedDateTime(args...)
         @test zdt == parse(ZonedDateTime, string(zdt))
         @test zdt == ZonedDateTime(string(zdt))
+    end
+end
+
+# Validate that error message contains the original string and the format used
+@testset "contextual error" begin
+    str = "2018-11-01"
+
+    try
+        parse(ZonedDateTime, str)
+        @test false
+    catch e
+        @test e isa ArgumentError
+        @test occursin(str, e.msg)
+        @test occursin(string(TimeZones.ISOZonedDateTimeNoMillisecondFormat), e.msg)
+    end
+
+    try
+        ZonedDateTime(str)
+        @test false
+    catch e
+        @test e isa ArgumentError
+        @test occursin(str, e.msg)
+        @test occursin(string(TimeZones.ISOZonedDateTimeNoMillisecondFormat), e.msg)
     end
 end
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1,4 +1,4 @@
-using Dates: parse_components, Millisecond
+using Dates: parse_components
 using TimeZones: ParseNextError, _parsesub_tzabbr, _parsesub_offset, _parsesub_time, _parsesub_tzdate, _parsesub_tz
 
 @testset "parse" begin

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -65,14 +65,14 @@ end
 
 @testset "self parseable" begin
     zdt_args = Iterators.product(
-        [0, 1, 10, 100, 1000, 10000],  # Year
+        [0, 1, 10, 100, 1000, 2025, 10000],  # Year
         [1, 12],  # Month
         [3, 31],  # Day
         [0, 4, 23],  # Hour
         [0, 5, 55],  # Minute
         [0, 6, 56],  # Seconds
-        [0, 7, 77, 777],  # Milliseconds
-        [tz"UTC"],  # Time zones
+        [0, 7, 50, 77, 777],  # Milliseconds
+        [tz"UTC-06", tz"UTC", tz"UTC+08:45", tz"UTC+14"],  # Time zones
     )
     for args in zdt_args
         zdt = ZonedDateTime(args...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,4 +77,5 @@ include("helpers.jl")
     include("rounding.jl")
     include("parse.jl")
     include("plotting.jl")
+    include("deprecated.jl")
 end


### PR DESCRIPTION
This PR solves issue [#470](https://github.com/JuliaTime/TimeZones.jl/issues/470) in a way that formally preserves backwards compatibility of `TimeZones`.
The first commit is what solves the issue. The second commit is optional, but given that `Dates.default_format(::Type{ZonedDateTime})` is no longer used in the `TimeZones` package, not `public` and not documented anywhere, I feel that it would be most correct to delete it as this would still formally preserve backwards compatibility.




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209258842306688