### PR TITLE
Loosen `p7zip_jll` compatibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -151,6 +151,28 @@ jobs:
         env:
           JULIA_DEPOT_PATH: sysimage-depot
 
+  force-latest-compatible:
+    name: Force Latest Compatible - Julia ${{ matrix.version }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - "1.7"
+        os:
+          - windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+      - uses: julia-actions/cache@v2
+      - name: Test
+        shell: julia --color=yes --project {0}
+        run: |
+          using Pkg
+          Pkg.test(; allow_reresolve=true, force_latest_compatible_version=true)
+
   benchmarks:
     name: Benchmarks
     runs-on: ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ TZJData = "1"
 Test = "1"
 Unicode = "1"
 julia = "1.6"
-p7zip_jll = "17.4"
+p7zip_jll = "16, 17"
 
 [extensions]
 TimeZonesRecipesBaseExt = "RecipesBase"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeZones"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 authors = ["Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "1.21.0"
+version = "1.21.1"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/Project.toml
+++ b/Project.toml
@@ -16,15 +16,9 @@ TZJData = "dc5dba14-91b3-4cab-a142-028a31da12f7"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 p7zip_jll = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 
-[weakdeps]
-RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-
-[extensions]
-TimeZonesRecipesBaseExt = "RecipesBase"
-
 [compat]
-Artifacts = "1"
 Aqua = "0.8"
+Artifacts = "1"
 Dates = "1"
 Downloads = "1"
 InlineStrings = "1"
@@ -38,6 +32,9 @@ Unicode = "1"
 julia = "1.6"
 p7zip_jll = "17.4"
 
+[extensions]
+TimeZonesRecipesBaseExt = "RecipesBase"
+
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
@@ -45,3 +42,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Aqua", "Test", "RecipesBase"]
+
+[weakdeps]
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"

--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ TZJData = "1"
 Test = "1"
 Unicode = "1"
 julia = "1.6"
-p7zip_jll = "17"
+p7zip_jll = "16, 17"
 
 [extensions]
 TimeZonesRecipesBaseExt = "RecipesBase"

--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ TZJData = "1"
 Test = "1"
 Unicode = "1"
 julia = "1.6"
-p7zip_jll = "16, 17"
+p7zip_jll = "17"
 
 [extensions]
 TimeZonesRecipesBaseExt = "RecipesBase"


### PR DESCRIPTION
Addresses a compat issue that only happens on older versions of Julia (1.7) when using the undocumented `force_latest_compatible_version` flag for `Pkg.test`:
```
julia> Pkg.test(; allow_reresolve=true, force_latest_compatible_version=true)
     Testing TimeZones
┌ Warning: Could not use exact versions of packages in manifest, re-resolving
└ @ Pkg.Operations /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.7/Pkg/src/Operations.jl:1488
ERROR: Unsatisfiable requirements detected for package p7zip_jll [3f19e933]:
 p7zip_jll [3f19e933] log:
 ├─possible versions are: 16.2.1 or uninstalled
 └─restricted to versions 17 by TimeZones [f269a46b] — no versions left
   └─TimeZones [f269a46b] log:
     ├─possible versions are: 1.20.0 or uninstalled
     └─TimeZones [f269a46b] is fixed to version 1.20.0
```

Originally, I encountered this failure when working on an update to Registrator.jl: https://github.com/JuliaRegistries/Registrator.jl/pull/445

<details>
<summary>Registrator.jl issue</summary>

```
 ┌ Warning: Could not use exact versions of packages in manifest, re-resolving
└ @ Pkg.Operations /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.7/Pkg/src/Operations.jl:1488
ERROR: LoadError: Unsatisfiable requirements detected for package TimeZones [f269a46b]:
 TimeZones [f269a46b] log:
 ├─possible versions are: 0.7.3-1.21.0 or uninstalled
 ├─restricted by compatibility requirements with Mocking [78c3b35d] to versions: 1.18.0-1.21.0 or uninstalled
 │ └─Mocking [78c3b35d] log:
 │   ├─possible versions are: 0.5.6-0.8.1 or uninstalled
 │   ├─restricted to versions 0.7-0.8 by Registrator [4418983a], leaving only versions 0.7.0-0.8.1
 │   │ └─Registrator [4418983a] log:
 │   │   ├─possible versions are: 1.9.3 or uninstalled
 │   │   └─Registrator [4418983a] is fixed to version 1.9.3
 │   └─restricted to versions 0.8 by an explicit requirement, leaving only versions 0.8.0-0.8.1
 ├─restricted by compatibility requirements with GitForge [8f6bce27] to versions: 1.0.0-1.21.0, leaving only versions: 1.18.0-1.21.0
 │ └─GitForge [8f6bce27] log:
 │   ├─possible versions are: 0.1.0-0.4.2 or uninstalled
 │   └─restricted to versions 0.4 by Registrator [4418983a], leaving only versions 0.4.0-0.4.2
 │     └─Registrator [4418983a] log: see above
 └─restricted by compatibility requirements with p7zip_jll [3f19e933] to versions: 0.7.3-1.11.0 or uninstalled — no versions left
   └─p7zip_jll [3f19e933] log:
     ├─possible versions are: 16.2.1 or uninstalled
     └─restricted by compatibility requirements with Pkg [44cfe95a] to versions: 16.2.1
       └─Pkg [44cfe95a] log:
         ├─possible versions are: 1.7.0 or uninstalled
         └─restricted to versions 1 by Registrator [4418983a], leaving only versions 1.7.0
           └─Registrator [4418983a] log: see above
```
– https://github.com/JuliaRegistries/Registrator.jl/actions/runs/13138017302/job/36657983996?pr=445#step:6:20

</details>