### PR TITLE
Fix Julia 1.12 explicit qualification required warnings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeZones"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 authors = ["Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "1.21.2"
+version = "1.21.3"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -2,9 +2,17 @@ using Base: @deprecate, depwarn
 
 # BEGIN TimeZones 1.0 deprecations
 
-@deprecate Dates.DateTime(zdt::ZonedDateTime, ::Type{Local}) DateTime(zdt) false
-@deprecate Dates.Date(zdt::ZonedDateTime, ::Type{Local}) Date(zdt) false
-@deprecate Dates.Time(zdt::ZonedDateTime, ::Type{Local}) Time(zdt) false
+# https://github.com/JuliaLang/julia/pull/44394
+if VERSION < v"1.9.0-DEV.663"
+    import Dates: DateTime, Date, Time
+    @deprecate DateTime(zdt::ZonedDateTime, ::Type{Local}) DateTime(zdt) false
+    @deprecate Date(zdt::ZonedDateTime, ::Type{Local}) Date(zdt) false
+    @deprecate Time(zdt::ZonedDateTime, ::Type{Local}) Time(zdt) false
+else
+    @deprecate Dates.DateTime(zdt::ZonedDateTime, ::Type{Local}) DateTime(zdt) false
+    @deprecate Dates.Date(zdt::ZonedDateTime, ::Type{Local}) Date(zdt) false
+    @deprecate Dates.Time(zdt::ZonedDateTime, ::Type{Local}) Time(zdt) false
+end
 
 const TZFILE_MAX = TZFile.TZFILE_CUTOFF
 const TransitionTimeInfo = TZFile.TransitionTimeInfo

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,13 +1,10 @@
 using Base: @deprecate, depwarn
 
-# Needed as `@deprecate` can't use qualified function calls
-import Dates: DateTime, Date, Time
-
 # BEGIN TimeZones 1.0 deprecations
 
-@deprecate DateTime(zdt::ZonedDateTime, ::Type{Local}) DateTime(zdt)
-@deprecate Date(zdt::ZonedDateTime, ::Type{Local}) Date(zdt)
-@deprecate Time(zdt::ZonedDateTime, ::Type{Local}) Time(zdt)
+@deprecate Dates.DateTime(zdt::ZonedDateTime, ::Type{Local}) DateTime(zdt) false
+@deprecate Dates.Date(zdt::ZonedDateTime, ::Type{Local}) Date(zdt) false
+@deprecate Dates.Time(zdt::ZonedDateTime, ::Type{Local}) Time(zdt) false
 
 const TZFILE_MAX = TZFile.TZFILE_CUTOFF
 const TransitionTimeInfo = TZFile.TransitionTimeInfo

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,5 +1,8 @@
 using Base: @deprecate, depwarn
 
+# Needed as `@deprecate` can't use qualified function calls
+import Dates: DateTime, Date, Time
+
 # BEGIN TimeZones 1.0 deprecations
 
 @deprecate DateTime(zdt::ZonedDateTime, ::Type{Local}) DateTime(zdt)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -3,7 +3,7 @@ using Base: @deprecate, depwarn
 # BEGIN TimeZones 1.0 deprecations
 
 # https://github.com/JuliaLang/julia/pull/44394
-if VERSION < v"1.9.0-DEV.663"
+@static if VERSION < v"1.9.0-DEV.663"
     import Dates: DateTime, Date, Time
     @deprecate DateTime(zdt::ZonedDateTime, ::Type{Local}) DateTime(zdt) false
     @deprecate Date(zdt::ZonedDateTime, ::Type{Local}) Date(zdt) false

--- a/test/accessors.jl
+++ b/test/accessors.jl
@@ -1,5 +1,4 @@
-import Dates
-using Dates: Second, Millisecond
+using Dates: Dates, Second, Millisecond
 
 warsaw = first(compile("Europe/Warsaw", tzdata["europe"]))
 fixed = FixedTimeZone("Fixed", -7200, 3600)

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -1,4 +1,4 @@
-import Dates
+using Dates: Dates
 using Mocking
 
 utc = FixedTimeZone("UTC")


### PR DESCRIPTION
```
❯ julia --project -e '@show VERSION; using TimeZones'
VERSION = v"1.12.0-DEV.2047"
Info Given TimeZones was explicitly requested, output will be shown live
WARNING: Constructor for type "DateTime" was extended in `TimeZones` without explicit qualification or import.
  NOTE: Assumed "DateTime" refers to `Dates.DateTime`. This behavior is deprecated and may differ in future versions.`
  NOTE: This behavior may have differed in Julia versions prior to 1.12.
  Hint: If you intended to create a new generic function of the same name, use `function DateTime end`.
  Hint: To silence the warning, qualify `DateTime` as `Dates.DateTime` or explicitly `import Dates: DateTime`
WARNING: Constructor for type "Date" was extended in `TimeZones` without explicit qualification or import.
  NOTE: Assumed "Date" refers to `Dates.Date`. This behavior is deprecated and may differ in future versions.`
  NOTE: This behavior may have differed in Julia versions prior to 1.12.
  Hint: If you intended to create a new generic function of the same name, use `function Date end`.
  Hint: To silence the warning, qualify `Date` as `Dates.Date` or explicitly `import Dates: Date`
WARNING: Constructor for type "Time" was extended in `TimeZones` without explicit qualification or import.
  NOTE: Assumed "Time" refers to `Dates.Time`. This behavior is deprecated and may differ in future versions.`
  NOTE: This behavior may have differed in Julia versions prior to 1.12.
  Hint: If you intended to create a new generic function of the same name, use `function Time end`.
  Hint: To silence the warning, qualify `Time` as `Dates.Time` or explicitly `import Dates: Time`
Precompiling TimeZones finished.
  1 dependency successfully precompiled in 4 seconds. 22 already precompiled.
  1 dependency had output during precompilation:
┌ TimeZones
│  [Output was shown above]
└
```