### PR TITLE
add isless method for FixedTimeZone

### DIFF
--- a/src/types/fixedtimezone.jl
+++ b/src/types/fixedtimezone.jl
@@ -96,3 +96,20 @@ end
 name(tz::FixedTimeZone) = tz.name
 rename(tz::FixedTimeZone, name::AbstractString) = FixedTimeZone(name, tz.offset)
 
+"""
+Base.isless(a::FixedTimeZone, b::FixedTimeZone)
+
+Defines a true chronological ordering for FixedTimeZone objects, answering
+the question: "which time zone represents an earlier moment in absolute time?"
+
+The core principle is that a time zone is "chronologically earlier" (less than)
+if its numerical UTC offset is "mathematically greater".
+
+For example, 10:00 AM in UTC-5 is an earlier absolute moment than 10:00 AM
+in UTC-8. This function correctly sorts UTC-5 as being less than UTC-8.
+
+Examples:
+    isless(tz"UTC-5", tz"UTC-8")  # returns true
+    isless(tz"UTC+2", tz"UTC-1")  # returns true
+"""
+Base.isless(a::FixedTimeZone, b::FixedTimeZone) = isless(b.offset, a.offset)


### PR DESCRIPTION
## Description

This PR adds support to sort FixedTimeZones by adding a comparison method isless.