### PR TITLE
Improve internal logic for `tryparsenext_(tz|fixedtz)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeZones"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 authors = ["Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "1.21.4"
+version = "1.22.0"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -82,7 +82,7 @@ function tryparsenext_fixedtz(str, i, len, min_width::Int=1, max_width::Int=0)
         i = ii
     end
 
-    if tz_end <= min_pos
+    if tz_end < min_pos
         return nothing
     else
         tz = SubString(str, tz_start, tz_end)

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -63,30 +63,33 @@ function tryparsenext_fixedtz(str, i, len, min_width::Int=1, max_width::Int=0)
     min_pos = min_width <= 0 ? i : i + min_width - 1
     max_pos = max_width <= 0 ? len : min(nextind(str, 0, length(str, 1, i) + max_width - 1), len)
     state = 1
+    num_digits = 0
     @inbounds while i <= max_pos
         c, ii = iterate(str, i)::Tuple{Char, Int}
         if state == 1 && (c === '-' || c === '+')
             state = 2
-            tz_end = i
         elseif (state == 1 || state == 2) && '0' <= c <= '9'
             state = 3
+            num_digits += 1
             tz_end = i
+            num_digits >= 4 && break
         elseif state == 3 && c === ':'
             state = 4
-            tz_end = i
         elseif (state == 3 || state == 4) && '0' <= c <= '9'
+            num_digits += 1
             tz_end = i
+            num_digits >= 4 && break
         else
             break
         end
         i = ii
     end
 
-    if tz_end < min_pos
+    if tz_end < min_pos || num_digits != 2 && num_digits != 4
         return nothing
     else
         tz = SubString(str, tz_start, tz_end)
-        return tz, i
+        return tz, nextind(str, tz_end)
     end
 end
 

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -26,10 +26,10 @@ end
 When the `TimeZones` package is loaded, 2 extra character codes are available
 for constructing the `format` string:
 
-| Code       | Matches            | Comment                                               |
-|:-----------|:-------------------|:------------------------------------------------------|
-| `z`        | +02:00, -0100, +14 | Parsing matches a fixed numeric UTC offset `±hh:mm`, `±hhmm`, or `±hh`. Formatting outputs `±hh:mm` |
-| `Z`        | UTC, GMT, America/New_York | Name of a time zone as specified in the IANA tz database |
+| Code | Matches                    | Comment                                               |
+|:-----|:---------------------------|:------------------------------------------------------|
+| `z`  | +02:00, -0100, +14         | Parsing matches a fixed numeric UTC offset `±hh:mm`, `±hhmm`, or `±hh`. Formatting outputs `±hh:mm` |
+| `Z`  | UTC, GMT, America/New_York | Name of a time zone as specified in the IANA tz database |
 """ DateFormat
 
 function Base.parse(::Type{ZonedDateTime}, str::AbstractString)

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -56,6 +56,19 @@ function Base.parse(::Type{ZonedDateTime}, str::AbstractString, df::DateFormat)
     end
 end
 
+# Supported fixed offset formats from UTC include. Most of these are ISO8601 time zone
+# designators:
+#
+# - `Z`
+# - `±hh:mm`
+# - `±hhmm`
+# - `±hh`
+# - `hh:mm`
+# - `hhmm`
+#
+# Normally the the `FixedTimeZone(::AbstractString)` constructor is responsible for
+# converting the string output produced here into the Julia representation of a fixed time
+# zone. Any further restrictions imposed by that constructor maybe should be reflected here.
 function tryparsenext_fixedtz(str, i, len, min_width::Int=1, max_width::Int=0)
     i == len && str[i] === 'Z' && return ("Z", i+1)
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -168,7 +168,6 @@ end
         @test tryparsenext_fixedtz("1", 1, 1) === nothing
         @test tryparsenext_fixedtz("12", 1, 2) === nothing
         @test tryparsenext_fixedtz("123", 1, 3) === nothing
-
         @test tryparsenext_fixedtz("1:", 1, 2) === nothing
         @test tryparsenext_fixedtz("1:30", 1, 4) === nothing
         @test tryparsenext_fixedtz("12:", 1, 3) === nothing

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -121,6 +121,16 @@ end
         @test tryparsenext_fixedtz("Z", 1, 1) == ("Z", 2)
     end
 
+    # We should probably restrict minute to be between "00" and "59" but if we do these
+    # should still parse to `UTC+99:00` (truncating minutes). As truncating could lead to
+    # more confusion we'll allow "99:99" which translates to `UTC+100:39`.
+    @testset "99 minutes" begin
+        @test tryparsenext_fixedtz("9999", 1, 4) == ("9999", 5)
+        @test tryparsenext_fixedtz("99:99", 1, 5) == ("99:99", 6)
+        @test tryparsenext_fixedtz("-99:99", 1, 6) == ("-99:99", 7)
+        @test tryparsenext_fixedtz("+99:99", 1, 6) == ("+99:99", 7)
+    end
+
     @testset "automatic stop" begin
         @test tryparsenext_fixedtz("1230abc", 1, 7) == ("1230", 5)
         @test tryparsenext_fixedtz("12300", 1, 5) == ("1230", 5)
@@ -158,26 +168,23 @@ end
         @test tryparsenext_fixedtz("1", 1, 1) === nothing
         @test tryparsenext_fixedtz("12", 1, 2) === nothing
         @test tryparsenext_fixedtz("123", 1, 3) === nothing
-        @test_broken tryparsenext_fixedtz("9999", 1, 4) === nothing
+
         @test tryparsenext_fixedtz("1:", 1, 2) === nothing
         @test tryparsenext_fixedtz("1:30", 1, 4) === nothing
         @test tryparsenext_fixedtz("12:", 1, 3) === nothing
         @test tryparsenext_fixedtz("12:3", 1, 4) === nothing
-        @test_broken tryparsenext_fixedtz("99:99", 1, 5) === nothing
         @test tryparsenext_fixedtz("12::30", 1, 4) === nothing
 
         @test tryparsenext_fixedtz("-", 1, 1) === nothing
         @test tryparsenext_fixedtz("-1", 1, 2) === nothing
         @test tryparsenext_fixedtz("-1:", 1, 3) === nothing
         @test tryparsenext_fixedtz("-1:30", 1, 5) === nothing
-        @test_broken tryparsenext_fixedtz("-99:99", 1, 6) === nothing
         @test tryparsenext_fixedtz("--12", 1, 4) === nothing
 
         @test tryparsenext_fixedtz("+", 1, 1) === nothing
         @test tryparsenext_fixedtz("+1", 1, 2) === nothing
         @test tryparsenext_fixedtz("+1:", 1, 3) === nothing
         @test tryparsenext_fixedtz("+1:30", 1, 5) === nothing
-        @test_broken tryparsenext_fixedtz("+99:99", 1, 6) === nothing
         @test tryparsenext_fixedtz("++12", 1, 4) === nothing
     end
 end

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -121,12 +121,12 @@ end
 
     @testset "automatic stop" begin
         @test tryparsenext_fixedtz("1230abc", 1, 7) == ("1230", 5)
-        @test_broken tryparsenext_fixedtz("12300", 1, 5) == ("1230", 5)
-        @test_broken tryparsenext_fixedtz("12:300", 1, 6) == ("12:30", 6)
+        @test tryparsenext_fixedtz("12300", 1, 5) == ("1230", 5)
+        @test tryparsenext_fixedtz("12:300", 1, 6) == ("12:30", 6)
 
         @test tryparsenext_fixedtz("-1230abc", 1, 7) == ("-1230", 6)
-        @test_broken tryparsenext_fixedtz("-12300", 1, 6) == ("-1230", 6)
-        @test_broken tryparsenext_fixedtz("-12:300", 1, 7) == ("-12:30", 7)
+        @test tryparsenext_fixedtz("-12300", 1, 6) == ("-1230", 6)
+        @test tryparsenext_fixedtz("-12:300", 1, 7) == ("-12:30", 7)
         @test_broken tryparsenext_fixedtz("-123", 1, 4) == ("-12", 4)
         @test_broken tryparsenext_fixedtz("-12:3", 1, 5) == ("-12", 4)
 
@@ -148,30 +148,30 @@ end
     end
 
     @testset "invalid" begin
-        @test_broken tryparsenext_fixedtz("1", 1, 1) === nothing
+        @test tryparsenext_fixedtz("1", 1, 1) === nothing
         @test_broken tryparsenext_fixedtz("12", 1, 2) === nothing
-        @test_broken tryparsenext_fixedtz("123", 1, 3) === nothing
+        @test tryparsenext_fixedtz("123", 1, 3) === nothing
         @test_broken tryparsenext_fixedtz("9999", 1, 4) === nothing
-        @test_broken tryparsenext_fixedtz("1:", 1, 2) === nothing
-        @test_broken tryparsenext_fixedtz("1:30", 1, 4) === nothing
+        @test tryparsenext_fixedtz("1:", 1, 2) === nothing
+        @test tryparsenext_fixedtz("1:30", 1, 4) === nothing
         @test_broken tryparsenext_fixedtz("12:", 1, 3) === nothing
-        @test_broken tryparsenext_fixedtz("12:3", 1, 4) === nothing
+        @test tryparsenext_fixedtz("12:3", 1, 4) === nothing
         @test_broken tryparsenext_fixedtz("99:99", 1, 5) === nothing
         @test_broken tryparsenext_fixedtz("12::30", 1, 4) === nothing
 
-        @test_broken tryparsenext_fixedtz("-", 1, 1) === nothing
-        @test_broken tryparsenext_fixedtz("-1", 1, 2) === nothing
-        @test_broken tryparsenext_fixedtz("-1:", 1, 3) === nothing
-        @test_broken tryparsenext_fixedtz("-1:30", 1, 5) === nothing
+        @test tryparsenext_fixedtz("-", 1, 1) === nothing
+        @test tryparsenext_fixedtz("-1", 1, 2) === nothing
+        @test tryparsenext_fixedtz("-1:", 1, 3) === nothing
+        @test tryparsenext_fixedtz("-1:30", 1, 5) === nothing
         @test_broken tryparsenext_fixedtz("-99:99", 1, 6) === nothing
-        @test_broken tryparsenext_fixedtz("--12", 1, 4) === nothing
+        @test tryparsenext_fixedtz("--12", 1, 4) === nothing
 
-        @test_broken tryparsenext_fixedtz("+", 1, 1) === nothing
-        @test_broken tryparsenext_fixedtz("+1", 1, 2) === nothing
-        @test_broken tryparsenext_fixedtz("+1:", 1, 3) === nothing
-        @test_broken tryparsenext_fixedtz("+1:30", 1, 5) === nothing
+        @test tryparsenext_fixedtz("+", 1, 1) === nothing
+        @test tryparsenext_fixedtz("+1", 1, 2) === nothing
+        @test tryparsenext_fixedtz("+1:", 1, 3) === nothing
+        @test tryparsenext_fixedtz("+1:30", 1, 5) === nothing
         @test_broken tryparsenext_fixedtz("+99:99", 1, 6) === nothing
-        @test_broken tryparsenext_fixedtz("++12", 1, 4) === nothing
+        @test tryparsenext_fixedtz("++12", 1, 4) === nothing
     end
 end
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -139,7 +139,7 @@ end
 
     @testset "min width" begin
         @test tryparsenext_fixedtz("1230", 1, 4, 5, 0) === nothing
-        @test_broken tryparsenext_fixedtz("+1230", 1, 5, 5, 0) == ("+1230", 6)
+        @test tryparsenext_fixedtz("+1230", 1, 5, 5, 0) == ("+1230", 6)
     end
 
     @testset "max width" begin
@@ -148,7 +148,7 @@ end
     end
 
     @testset "invalid" begin
-        @test tryparsenext_fixedtz("1", 1, 1) === nothing
+        @test_broken tryparsenext_fixedtz("1", 1, 1) === nothing
         @test_broken tryparsenext_fixedtz("12", 1, 2) === nothing
         @test_broken tryparsenext_fixedtz("123", 1, 3) === nothing
         @test_broken tryparsenext_fixedtz("9999", 1, 4) === nothing
@@ -159,19 +159,19 @@ end
         @test_broken tryparsenext_fixedtz("99:99", 1, 5) === nothing
         @test_broken tryparsenext_fixedtz("12::30", 1, 4) === nothing
 
-        @test tryparsenext_fixedtz("-", 1, 1) === nothing
+        @test_broken tryparsenext_fixedtz("-", 1, 1) === nothing
         @test_broken tryparsenext_fixedtz("-1", 1, 2) === nothing
         @test_broken tryparsenext_fixedtz("-1:", 1, 3) === nothing
         @test_broken tryparsenext_fixedtz("-1:30", 1, 5) === nothing
         @test_broken tryparsenext_fixedtz("-99:99", 1, 6) === nothing
-        @test tryparsenext_fixedtz("--12", 1, 4) === nothing
+        @test_broken tryparsenext_fixedtz("--12", 1, 4) === nothing
 
-        @test tryparsenext_fixedtz("+", 1, 1) === nothing
+        @test_broken tryparsenext_fixedtz("+", 1, 1) === nothing
         @test_broken tryparsenext_fixedtz("+1", 1, 2) === nothing
         @test_broken tryparsenext_fixedtz("+1:", 1, 3) === nothing
         @test_broken tryparsenext_fixedtz("+1:30", 1, 5) === nothing
         @test_broken tryparsenext_fixedtz("+99:99", 1, 6) === nothing
-        @test tryparsenext_fixedtz("++12", 1, 4) === nothing
+        @test_broken tryparsenext_fixedtz("++12", 1, 4) === nothing
     end
 end
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -226,7 +226,7 @@ end
     end
 
     @testset "invalid" begin
-        @test tryparsenext_tz("//", 1, 1) === nothing
+        @test tryparsenext_tz("//", 1, 2) === nothing
         @test tryparsenext_tz("__", 1, 2) === nothing
         @test tryparsenext_tz("--", 1, 2) === nothing
         @test tryparsenext_tz("123", 1, 2) === nothing  # Cannot contain only numbers

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -117,6 +117,8 @@ end
         @test tryparsenext_fixedtz("+99", 1, 3) == ("+99", 4)
         @test tryparsenext_fixedtz("+9959", 1, 5) == ("+9959", 6)
         @test tryparsenext_fixedtz("+99:59", 1, 6) == ("+99:59", 7)
+
+        @test tryparsenext_fixedtz("Z", 1, 1) == ("Z", 2)
     end
 
     @testset "automatic stop" begin
@@ -135,16 +137,21 @@ end
         @test_broken tryparsenext_fixedtz("+12:300", 1, 7) == ("+12:30", 6)
         @test_broken tryparsenext_fixedtz("+123", 1, 4) == ("+12", 4)
         @test_broken tryparsenext_fixedtz("+12:3", 1, 5) == ("+12", 4)
+
+        @test tryparsenext_fixedtz("Zabc", 1, 4) == ("Z", 2)
+        @test tryparsenext_fixedtz("Z+12:30", 1, 7) == ("Z", 2)
     end
 
     @testset "min width" begin
         @test tryparsenext_fixedtz("1230", 1, 4, 5, 0) === nothing
         @test tryparsenext_fixedtz("+1230", 1, 5, 5, 0) == ("+1230", 6)
+        @test tryparsenext_fixedtz("Z+12:30", 1, 7, 2, 0) === nothing
     end
 
     @testset "max width" begin
         @test tryparsenext_fixedtz("+12301999", 1, 9, 1, 5) == ("+1230", 6)
         @test tryparsenext_fixedtz("+12301999", 1, 9, 1, 3) == ("+12", 4)
+        @test tryparsenext_fixedtz("Z+12:30", 1, 7, 1, 5) == ("Z", 2)
     end
 
     @testset "invalid" begin

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -131,7 +131,7 @@ end
         @test_broken tryparsenext_fixedtz("-12:3", 1, 5) == ("-12", 4)
 
         @test tryparsenext_fixedtz("+1230abc", 1, 7) == ("+1230", 6)
-        @test_broken tryparsenext_fixedtz("+12300", 1, 6) == ("+1230", 6)
+        @test tryparsenext_fixedtz("+12300", 1, 6) == ("+1230", 6)
         @test_broken tryparsenext_fixedtz("+12:300", 1, 7) == ("+12:30", 6)
         @test_broken tryparsenext_fixedtz("+123", 1, 4) == ("+12", 4)
         @test_broken tryparsenext_fixedtz("+12:3", 1, 5) == ("+12", 4)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -129,14 +129,14 @@ end
         @test tryparsenext_fixedtz("-1230abc", 1, 7) == ("-1230", 6)
         @test tryparsenext_fixedtz("-12300", 1, 6) == ("-1230", 6)
         @test tryparsenext_fixedtz("-12:300", 1, 7) == ("-12:30", 7)
-        @test_broken tryparsenext_fixedtz("-123", 1, 4) == ("-12", 4)
-        @test_broken tryparsenext_fixedtz("-12:3", 1, 5) == ("-12", 4)
+        @test tryparsenext_fixedtz("-123", 1, 4) == ("-12", 4)
+        @test tryparsenext_fixedtz("-12:3", 1, 5) == ("-12", 4)
 
         @test tryparsenext_fixedtz("+1230abc", 1, 7) == ("+1230", 6)
         @test tryparsenext_fixedtz("+12300", 1, 6) == ("+1230", 6)
-        @test_broken tryparsenext_fixedtz("+12:300", 1, 7) == ("+12:30", 6)
-        @test_broken tryparsenext_fixedtz("+123", 1, 4) == ("+12", 4)
-        @test_broken tryparsenext_fixedtz("+12:3", 1, 5) == ("+12", 4)
+        @test tryparsenext_fixedtz("+12:300", 1, 7) == ("+12:30", 7)
+        @test tryparsenext_fixedtz("+123", 1, 4) == ("+12", 4)
+        @test tryparsenext_fixedtz("+12:3", 1, 5) == ("+12", 4)
 
         @test tryparsenext_fixedtz("Zabc", 1, 4) == ("Z", 2)
         @test tryparsenext_fixedtz("Z+12:30", 1, 7) == ("Z", 2)
@@ -156,15 +156,15 @@ end
 
     @testset "invalid" begin
         @test tryparsenext_fixedtz("1", 1, 1) === nothing
-        @test_broken tryparsenext_fixedtz("12", 1, 2) === nothing
+        @test tryparsenext_fixedtz("12", 1, 2) === nothing
         @test tryparsenext_fixedtz("123", 1, 3) === nothing
         @test_broken tryparsenext_fixedtz("9999", 1, 4) === nothing
         @test tryparsenext_fixedtz("1:", 1, 2) === nothing
         @test tryparsenext_fixedtz("1:30", 1, 4) === nothing
-        @test_broken tryparsenext_fixedtz("12:", 1, 3) === nothing
+        @test tryparsenext_fixedtz("12:", 1, 3) === nothing
         @test tryparsenext_fixedtz("12:3", 1, 4) === nothing
         @test_broken tryparsenext_fixedtz("99:99", 1, 5) === nothing
-        @test_broken tryparsenext_fixedtz("12::30", 1, 4) === nothing
+        @test tryparsenext_fixedtz("12::30", 1, 4) === nothing
 
         @test tryparsenext_fixedtz("-", 1, 1) === nothing
         @test tryparsenext_fixedtz("-1", 1, 2) === nothing


### PR DESCRIPTION
Follow up to #492 and #493. After adding tests for these functions in #493 I found quite a few cases where the parsing didn't work the way I expected. As the Julia date parsing system works off of each date part only consuming the information it understands making these changes should allow the parser to work in more scenarios.

For example the old way we handled parsing "Z" required it to occur at the end of the string where as now we can support it at any location.