### PR TITLE
Restore `Dates.default_format(::Type{ZonedDateTime})`

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -21,14 +21,4 @@ const TransitionTimeInfo = TZFile.TransitionTimeInfo
 
 @deprecate build(; force=false) build(TZJData.TZDATA_VERSION; force)
 
-function Dates.default_format(::Type{ZonedDateTime})
-    depwarn(
-        "`Dates.default_format(ZonedDateTime)` is deprecated and has no direct " *
-        "replacement. Consider using refactoring to use " *
-        "`parse(::Type{ZonedDateTime}, ::AbstractString)` as an alternative.",
-        :default_format,
-    )
-    return ISOZonedDateTimeFormat
-end
-
 # END TimeZones 1.0 deprecations

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -20,6 +20,10 @@ begin
     const ISOZonedDateTimeNoMillisecondFormat = DateFormat("yyyy-mm-dd\\THH:MM:SSzzz")
 end
 
+# Should be defined for subtypes of `TimeType`. Should mainly be used with `Dates.format`
+# parsing works better with `parse(ZonedDateTime, str)`.
+Dates.default_format(::Type{ZonedDateTime}) = ISOZonedDateTimeFormat
+
 @doc """
     DateFormat(format::AbstractString, locale="english") --> DateFormat
 

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -20,7 +20,7 @@ begin
     const ISOZonedDateTimeNoMillisecondFormat = DateFormat("yyyy-mm-dd\\THH:MM:SSzzz")
 end
 
-# Should be defined for subtypes of `TimeType`. Should mainly be used with `Dates.format`
+# Should be defined for subtypes of `TimeType`. Primarily for use with `Dates.format` as
 # parsing works better with `parse(ZonedDateTime, str)`.
 Dates.default_format(::Type{ZonedDateTime}) = ISOZonedDateTimeFormat
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -34,6 +34,10 @@ end
     )
 end
 
+@testset "default format" begin
+    @test Dates.default_format(ZonedDateTime) === TimeZones.ISOZonedDateTimeFormat
+end
+
 @testset "parse components" begin
     local test = ("2017-11-14 11:03:53 +0100", dateformat"yyyy-mm-dd HH:MM:SS zzzzz")
     local expected = [


### PR DESCRIPTION
Was removed in https://github.com/JuliaTime/TimeZones.jl/pull/483 as we believed this was only used with parsing. We did discover that there were some legitimate use cases of this with `Dates.format`: https://github.com/quinnj/JSON3.jl/issues/313. I thought maybe we could modify JSON3.jl to work around this but while implementing that change I changed my mind on what was the right approach.

As of now I think that:
- Most users should avoid using `Dates.default_format` for parsing as they won't be able to parse `ZonedDateTime` strings without milliseconds. They should use `parse(ZonedDateTime, str)` instead.
- When using `Date.format` it is reasonable to use `Dates.default_format(::Type{ZonedDateTime})`.