### PR TITLE
Defer creating the scratch directory until needed

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -148,6 +148,10 @@ jobs:
         run: |
           chmod -R ugo-w build-depot
           find build-depot -perm /u+w,g+w,o+w  # List directories/files with any of these permission bits
+          if ! touch build-depot/write-test 2>/dev/null; then
+              echo "Depot is not immutable" >&2
+              exit 1
+          fi
       - name: Validate sysimage works
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -150,7 +150,6 @@ jobs:
           # touch build-depot/artifacts/Overrides.toml
           sudo chmod -R ugo-w build-depot
           # sudo chmod u+w "build-depot/artifacts/Overrides.toml"
-        env:
       - name: Validate sysimage works
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -146,10 +146,8 @@ jobs:
       # Ensure that TimeZones.jl doesn't require write access to the depot with typical usage (i.e. no tzdata compiling tzdata)
       - name: Make depot immutable
         run: |
-          # mkdir -p build-depot/artifacts
-          # touch build-depot/artifacts/Overrides.toml
-          sudo chmod -R ugo-w build-depot
-          # sudo chmod u+w "build-depot/artifacts/Overrides.toml"
+          chmod -R ugo-w build-depot
+          find build-depot -perm /u+w,g+w,o+w  # List directories/files with any of these permission bits
       - name: Validate sysimage works
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -141,8 +141,9 @@ jobs:
         run: |
           set -x
           whoami
+          mkdir "${JULIA_DEPOT_PATH:?}/artifacts"
           ls -l ${JULIA_DEPOT_PATH:?}
-          ls -l ${JULIA_DEPOT_PATH:?}/aritfacts
+          ls -l ${JULIA_DEPOT_PATH:?}/artifacts
           touch "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
           sudo chmod -R 400 ${JULIA_DEPOT_PATH:?}
           sudo chown "$(whoami)" "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Make depot immutable
         run: |
           ls -l ${JULIA_DEPOT_PATH:?}
-          chmod -R 400 ${JULIA_DEPOT_PATH:?}
+          sudo chmod -R 400 ${JULIA_DEPOT_PATH:?}
       - name: Validate sysimage works
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -141,14 +141,14 @@ jobs:
         run: |
           set -x
           whoami
-          mkdir "${JULIA_DEPOT_PATH:?}/artifacts"
-          ls -l ${JULIA_DEPOT_PATH:?}
-          ls -l ${JULIA_DEPOT_PATH:?}/artifacts
+          mkdir -p "${JULIA_DEPOT_PATH:?}/artifacts"
+          ls -l "${JULIA_DEPOT_PATH:?}"
+          ls -l "${JULIA_DEPOT_PATH:?}/artifacts"
           touch "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
           sudo chmod -R 400 ${JULIA_DEPOT_PATH:?}
           sudo chown "$(whoami)" "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
           sudo chmod 600 "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
-          ls -l ${JULIA_DEPOT_PATH:?}/artifacts
+          ls -l "${JULIA_DEPOT_PATH:?}/artifacts"
       - name: Validate sysimage works
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -100,7 +100,7 @@ jobs:
 
   # TODO: Use shared project environments when the minimum version of Julia is 1.8 (e.g. `@sysimage`)
   sysimage:
-    name: System Image - Julia ${{ matrix.version }} - TZJData ${{ matrix.tzjdata-version }} - ${{ matrix.immutable && 'Immutable' || 'Mutable' }} - ${{ matrix.os }}
+    name: System Image - Julia ${{ matrix.version }} - TZJData ${{ matrix.tzjdata-version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -113,8 +113,6 @@ jobs:
         tzjdata-version:
           - "1.3.0"  # Version which does not support `artifact_dir`
           - "1"
-        immutable:
-          - true
     env:
       JULIA_DEPOT_PATH: build-depot
       TZJDATA_VERSION: ${{ matrix.tzjdata-version }}
@@ -139,11 +137,9 @@ jobs:
           create_sysimage(; project="sysimage", sysimage_path="sysimage.so")
           # create_sysimage(; project=joinpath(first(DEPOT_PATH), "environments", "sysimage"), sysimage_path="sysimage.so")
       - name: Make depot immutable
-        if: ${{ matrix.immutable }}
-        shell: julia --color=yes {0}
         run: |
-          @show first(DEPOT_PATH)
-          chmod(first(DEPOT_PATH), 0o400; recursive=true)
+          ls -l ${JULIA_DEPOT_PATH:?}
+          chmod -R 400 ${JULIA_DEPOT_PATH:?}
       - name: Validate sysimage works
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -128,6 +128,16 @@ jobs:
           using Pkg
           Pkg.add(PackageSpec(name="TZJData", version=ENV["TZJDATA_VERSION"]))
           Pkg.add(PackageSpec(name="TimeZones", rev=ENV["SHA"]))
+      - name: Make depot immutable
+        run: |
+          set -x
+          whoami
+          ls -l "${JULIA_DEPOT_PATH:?}"/*
+          mkdir -p "${JULIA_DEPOT_PATH:?}/artifacts"
+          touch "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
+          sudo chmod -R 400 "${JULIA_DEPOT_PATH:?}"
+          sudo chmod 600 "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
+          ls -l "${JULIA_DEPOT_PATH:?}"/*
       - name: Create sysimage
         shell: julia --color=yes {0}
         run: |
@@ -136,19 +146,17 @@ jobs:
           using PackageCompiler
           create_sysimage(; project="sysimage", sysimage_path="sysimage.so")
           # create_sysimage(; project=joinpath(first(DEPOT_PATH), "environments", "sysimage"), sysimage_path="sysimage.so")
-      # Ensure that TimeZones.jl doesn't require write access to the depot upon typical usage (i.e. not compiling tzdata)
+      # Ensure that TimeZones.jl doesn't require write access to the depot with typical usage (i.e. no tzdata compiling tzdata)
       - name: Make depot immutable
         run: |
           set -x
           whoami
+          ls -l "${JULIA_DEPOT_PATH:?}"/*
           mkdir -p "${JULIA_DEPOT_PATH:?}/artifacts"
-          ls -l "${JULIA_DEPOT_PATH:?}"
-          ls -l "${JULIA_DEPOT_PATH:?}/artifacts"
           touch "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
-          sudo chmod -R 400 ${JULIA_DEPOT_PATH:?}
-          sudo chown "$(whoami)" "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
+          sudo chmod -R 400 "${JULIA_DEPOT_PATH:?}"
           sudo chmod 600 "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
-          ls -l "${JULIA_DEPOT_PATH:?}/artifacts"
+          ls -l "${JULIA_DEPOT_PATH:?}"/*
       - name: Validate sysimage works
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -132,13 +132,13 @@ jobs:
         run: |
           using Pkg
           Pkg.add(PackageSpec(name="PackageCompiler", version="2"))
-      - name: Create sysimage project
+      - name: Create project
         shell: julia --color=yes --project=sysimage {0}
         run: |
           using Pkg
           Pkg.add(PackageSpec(name="TZJData", version=ENV["TZJDATA_VERSION"]))
           Pkg.add(PackageSpec(name="TimeZones", rev=ENV["SHA"]))
-      - name: Create sysimage
+      - name: Create system image
         shell: julia --color=yes {0}
         run: |
           using PackageCompiler

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,12 +136,12 @@ jobs:
           using PackageCompiler
           create_sysimage(; project="sysimage", sysimage_path="sysimage.so")
           # create_sysimage(; project=joinpath(first(DEPOT_PATH), "environments", "sysimage"), sysimage_path="sysimage.so")
-      # Simulate using the sysimage in an immutable environment
+      # Ensure that TimeZones.jl doesn't require write access to the depot upon typical usage (i.e. not compiling tzdata)
       - name: Make depot immutable
         run: |
           ls -l ${JULIA_DEPOT_PATH:?}
+          touch "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
           sudo chmod -R 400 ${JULIA_DEPOT_PATH:?}
-          cat "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
           sudo chmod 600 "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
       - name: Validate sysimage works
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}
@@ -149,7 +149,9 @@ jobs:
           using TimeZones
           println(TimeZones._COMPILED_DIR[])
       - name: Relocate Julia depot
-        run: mv build-depot sysimage-depot
+        run: |
+          cat "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
+          mv build-depot sysimage-depot
       - name: Validate sysimage works with relocated depot
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -148,11 +148,11 @@ jobs:
         run: |
           chmod -R ugo-w build-depot
           find build-depot -perm /u+w,g+w,o+w  # List directories/files with any of these permission bits
-          if ! touch build-depot/write-test 2>/dev/null; then
+          if touch build-depot/write-test 2>/dev/null; then
               echo "Depot is not immutable" >&2
               exit 1
           fi
-      - name: Validate sysimage works
+      - name: Validate system image works
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}
         run: |
           using TimeZones
@@ -160,7 +160,7 @@ jobs:
       - name: Relocate Julia depot
         run: |
           mv build-depot sysimage-depot
-      - name: Validate sysimage works with relocated depot
+      - name: Validate system image works with relocated depot
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}
         run: |
           using TimeZones

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,7 +115,7 @@ jobs:
         os:
           - ubuntu-latest
         tzjdata-version:
-          - "1.3.0"  # Version which does not support `artifact_dir`
+          - "1.3.0"  # Version which does not support `artifact_dir()` (https://github.com/JuliaTime/TimeZones.jl/pull/479)
           - "1"
     env:
       JULIA_DEPOT_PATH: build-depot
@@ -146,14 +146,11 @@ jobs:
       # Ensure that TimeZones.jl doesn't require write access to the depot with typical usage (i.e. no tzdata compiling tzdata)
       - name: Make depot immutable
         run: |
-          set -x
-          whoami
-          ls -l "${JULIA_DEPOT_PATH:?}"/*
-          mkdir -p "${JULIA_DEPOT_PATH:?}/artifacts"
-          touch "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
-          sudo chmod -R ugo-w "${JULIA_DEPOT_PATH:?}"
-          sudo chmod u+w "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
-          ls -l "${JULIA_DEPOT_PATH:?}"/*
+          # mkdir -p build-depot/artifacts
+          # touch build-depot/artifacts/Overrides.toml
+          sudo chmod -R ugo-w build-depot
+          # sudo chmod u+w "build-depot/artifacts/Overrides.toml"
+        env:
       - name: Validate sysimage works
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}
         run: |
@@ -161,7 +158,6 @@ jobs:
           println(TimeZones._COMPILED_DIR[])
       - name: Relocate Julia depot
         run: |
-          cat "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
           mv build-depot sysimage-depot
       - name: Validate sysimage works with relocated depot
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -100,7 +100,7 @@ jobs:
 
   # TODO: Use shared project environments when the minimum version of Julia is 1.8 (e.g. `@sysimage`)
   sysimage:
-    name: System Image - Julia ${{ matrix.version }} - TZJData ${{ matrix.tzjdata-version }} - ${{ matrix.immutable && 'Immutable' || 'Not Immutable' }} - ${{ matrix.os }}
+    name: System Image - Julia ${{ matrix.version }} - TZJData ${{ matrix.tzjdata-version }} - ${{ matrix.immutable && 'Immutable' || 'Mutable' }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -115,7 +115,6 @@ jobs:
           - "1"
         immutable:
           - true
-          - false
     env:
       JULIA_DEPOT_PATH: build-depot
       TZJDATA_VERSION: ${{ matrix.tzjdata-version }}
@@ -143,6 +142,7 @@ jobs:
         if: ${{ matrix.immutable }}
         shell: julia --color=yes {0}
         run: |
+          @show first(DEPOT_PATH)
           chmod(first(DEPOT_PATH), 0o400; recursive=true)
       - name: Validate sysimage works
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -100,7 +100,7 @@ jobs:
 
   # TODO: Use shared project environments when the minimum version of Julia is 1.8 (e.g. `@sysimage`)
   sysimage:
-    name: System Image - Julia ${{ matrix.version }} - TZJData ${{ matrix.tzjdata-version }} - ${{ matrix.os }}
+    name: System Image - Julia ${{ matrix.version }} - TZJData ${{ matrix.tzjdata-version }} - ${{ matrix.immutable && 'Immutable' || 'Not Immutable' }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -113,6 +113,9 @@ jobs:
         tzjdata-version:
           - "1.3.0"  # Version which does not support `artifact_dir`
           - "1"
+        immutable:
+          - true
+          - false
     env:
       JULIA_DEPOT_PATH: build-depot
       TZJDATA_VERSION: ${{ matrix.tzjdata-version }}
@@ -136,6 +139,11 @@ jobs:
           using PackageCompiler
           create_sysimage(; project="sysimage", sysimage_path="sysimage.so")
           # create_sysimage(; project=joinpath(first(DEPOT_PATH), "environments", "sysimage"), sysimage_path="sysimage.so")
+      - name: Make depot immutable
+        if: ${{ matrix.immutable }}
+        shell: julia --color=yes {0}
+        run: |
+          chmod(first(DEPOT_PATH), 0o400; recursive=true)
       - name: Validate sysimage works
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -124,7 +124,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v2
+      # - uses: julia-actions/cache@v2
       - name: Add TimeZones
         shell: julia --color=yes --project=sysimage {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -139,10 +139,15 @@ jobs:
       # Ensure that TimeZones.jl doesn't require write access to the depot upon typical usage (i.e. not compiling tzdata)
       - name: Make depot immutable
         run: |
+          set -x
+          whoami
           ls -l ${JULIA_DEPOT_PATH:?}
+          ls -l ${JULIA_DEPOT_PATH:?}/aritfacts
           touch "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
           sudo chmod -R 400 ${JULIA_DEPOT_PATH:?}
+          sudo chown "$(whoami)" "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
           sudo chmod 600 "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
+          ls -l ${JULIA_DEPOT_PATH:?}/artifacts
       - name: Validate sysimage works
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -138,16 +138,6 @@ jobs:
           using Pkg
           Pkg.add(PackageSpec(name="TZJData", version=ENV["TZJDATA_VERSION"]))
           Pkg.add(PackageSpec(name="TimeZones", rev=ENV["SHA"]))
-      - name: Make depot immutable
-        run: |
-          set -x
-          whoami
-          ls -l "${JULIA_DEPOT_PATH:?}"/*
-          mkdir -p "${JULIA_DEPOT_PATH:?}/artifacts"
-          touch "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
-          sudo chmod -R ugo-w "${JULIA_DEPOT_PATH:?}"
-          sudo chmod u+w "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
-          ls -l "${JULIA_DEPOT_PATH:?}"/*
       - name: Create sysimage
         shell: julia --color=yes {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -147,9 +147,8 @@ jobs:
       - name: Make depot immutable
         run: |
           chmod -R ugo-w build-depot
-          find build-depot -perm /u+w,g+w,o+w  # List directories/files with any of these permission bits
           if touch build-depot/write-test 2>/dev/null; then
-              echo "Depot is not immutable" >&2
+              echo "Supposedly immutable Julia depot still allows write access" >&2
               exit 1
           fi
       - name: Validate system image works

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,10 +136,13 @@ jobs:
           using PackageCompiler
           create_sysimage(; project="sysimage", sysimage_path="sysimage.so")
           # create_sysimage(; project=joinpath(first(DEPOT_PATH), "environments", "sysimage"), sysimage_path="sysimage.so")
+      # Simulate using the sysimage in an immutable environment
       - name: Make depot immutable
         run: |
           ls -l ${JULIA_DEPOT_PATH:?}
           sudo chmod -R 400 ${JULIA_DEPOT_PATH:?}
+          cat "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
+          sudo chmod 600 "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
       - name: Validate sysimage works
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -135,8 +135,8 @@ jobs:
           ls -l "${JULIA_DEPOT_PATH:?}"/*
           mkdir -p "${JULIA_DEPOT_PATH:?}/artifacts"
           touch "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
-          sudo chmod -R 400 "${JULIA_DEPOT_PATH:?}"
-          sudo chmod 600 "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
+          sudo chmod -R ugo-w "${JULIA_DEPOT_PATH:?}"
+          sudo chmod u+w "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
           ls -l "${JULIA_DEPOT_PATH:?}"/*
       - name: Create sysimage
         shell: julia --color=yes {0}
@@ -154,8 +154,8 @@ jobs:
           ls -l "${JULIA_DEPOT_PATH:?}"/*
           mkdir -p "${JULIA_DEPOT_PATH:?}/artifacts"
           touch "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
-          sudo chmod -R 400 "${JULIA_DEPOT_PATH:?}"
-          sudo chmod 600 "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
+          sudo chmod -R ugo-w "${JULIA_DEPOT_PATH:?}"
+          sudo chmod u+w "${JULIA_DEPOT_PATH:?}/artifacts/Overrides.toml"
           ls -l "${JULIA_DEPOT_PATH:?}"/*
       - name: Validate sysimage works
         shell: julia --color=yes --project=sysimage -Jsysimage.so {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2
         with:
-          version: ${{ matrix.version }}=
+          version: ${{ matrix.version }}
       # Caching here slows things down more than it helps
       # - uses: julia-actions/cache@v2
       - name: Install PackageCompiler

--- a/src/tzdata/TZData.jl
+++ b/src/tzdata/TZData.jl
@@ -12,11 +12,6 @@ using p7zip_jll: p7zip_jll
 
 export REGIONS, LEGACY_REGIONS
 
-const FOO = Ref{String}()
-function __init__()
-    FOO[] = _scratch_dir()
-end
-
 include("timeoffset.jl")
 include("version.jl")
 include("archive.jl")

--- a/src/tzdata/TZData.jl
+++ b/src/tzdata/TZData.jl
@@ -12,6 +12,11 @@ using p7zip_jll: p7zip_jll
 
 export REGIONS, LEGACY_REGIONS
 
+const FOO = Ref{String}()
+function __init__()
+    FOO[] = _scratch_dir()
+end
+
 include("timeoffset.jl")
 include("version.jl")
 include("archive.jl")

--- a/src/tzdata/TZData.jl
+++ b/src/tzdata/TZData.jl
@@ -10,17 +10,7 @@ using p7zip_jll: p7zip_jll
 # the "tzdata" archive or more specifically the "tz source" files within the archive
 # (africa, australasia, ...)
 
-const _LATEST_FILE_PATH = Ref{String}()
-const _LATEST = Ref{Tuple{AbstractString, DateTime}}()
-
 export REGIONS, LEGACY_REGIONS
-
-function __init__()
-    _LATEST_FILE_PATH[] = joinpath(_scratch_dir(), "latest")
-    if isfile(_LATEST_FILE_PATH[])
-        _LATEST[] = read_latest(_LATEST_FILE_PATH[])
-    end
-end
 
 include("timeoffset.jl")
 include("version.jl")

--- a/test/tzdata/download.jl
+++ b/test/tzdata/download.jl
@@ -1,4 +1,4 @@
-using TimeZones.TZData: _LATEST_FILE_PATH, read_latest
+using TimeZones.TZData: _latest_file_path, read_latest
 using TimeZones.TZData: tzdata_latest_version, tzdata_versions
 
 @testset "tzdata_versions" begin
@@ -12,8 +12,9 @@ end
 
     # Validate the contents of the latest file which will be automatically created when
     # downloading the latest data.
-    @test isfile(_LATEST_FILE_PATH[])
-    version, retrieved = read_latest(_LATEST_FILE_PATH[])
+    latest_file_path = _latest_file_path()
+    @test isfile(latest_file_path)
+    version, retrieved = read_latest(latest_file_path)
     @test occursin(r"\A(?:\d{2}){1,2}[a-z]?\z", version)
     @test isa(retrieved, DateTime)
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaTime/TimeZones.jl/issues/498. Should improve compatibility when installed into immutable environments when the package has never been initialized.