### PR TITLE
Use `julia-version` action for matrix job creation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -125,7 +125,8 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v2
+      # Caching here slows things down more than it helps
+      # - uses: julia-actions/cache@v2
       - name: Install PackageCompiler
         shell: julia --color=yes {0}
         run: |


### PR DESCRIPTION
Using this has two advantages:

- We can reduce the number of CI jobs when version specifiers resolve to the same version
- The Julia version used can be shown in the job name

