### PR TITLE
Eliminate allocation with `ZonedDateTime` constructor using `is_dst::Bool`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeZones"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 authors = ["Curtis Vogt <curtis.vogt@gmail.com>"]
-version = "1.22.2"
+version = "1.22.3"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/types/zoneddatetime.jl
+++ b/src/types/zoneddatetime.jl
@@ -92,12 +92,12 @@ ambiguous within the given time zone you can set `is_dst` to resolve the ambigui
     elseif num == 0
         throw(NonExistentTimeError(dt, tz))
     elseif num == 2
-        possible = [first(possible), last(possible)]
         mask = [isdst(zdt.zone.offset) for zdt in possible]
 
         # Mask is expected to be unambiguous.
         !xor(mask...) && throw(AmbiguousTimeError(dt, tz))
 
+        # Since the mask is unambiguous we can pick the ZonedDateTime which matches `is_dst`
         return mask[1] == is_dst ? possible[1] : possible[2]
     else
         throw(AmbiguousTimeError(dt, tz))

--- a/src/types/zoneddatetime.jl
+++ b/src/types/zoneddatetime.jl
@@ -83,7 +83,7 @@ end
 Construct a `ZonedDateTime` by applying a `TimeZone` to a `DateTime`. If the `DateTime` is
 ambiguous within the given time zone you can set `is_dst` to resolve the ambiguity.
 """
-function ZonedDateTime(dt::DateTime, tz::VariableTimeZone, is_dst::Bool)
+@inline function ZonedDateTime(dt::DateTime, tz::VariableTimeZone, is_dst::Bool)
     possible = interpret(dt, tz, Local)
 
     num = length(possible)
@@ -92,13 +92,13 @@ function ZonedDateTime(dt::DateTime, tz::VariableTimeZone, is_dst::Bool)
     elseif num == 0
         throw(NonExistentTimeError(dt, tz))
     elseif num == 2
+        possible = [first(possible), last(possible)]
         mask = [isdst(zdt.zone.offset) for zdt in possible]
 
         # Mask is expected to be unambiguous.
         !xor(mask...) && throw(AmbiguousTimeError(dt, tz))
 
-        occurrence = findfirst(d -> d == is_dst, mask)
-        return possible[occurrence]
+        return mask[1] == is_dst ? possible[1] : possible[2]
     else
         throw(AmbiguousTimeError(dt, tz))
     end

--- a/src/types/zoneddatetime.jl
+++ b/src/types/zoneddatetime.jl
@@ -33,7 +33,7 @@ converted to the specified `TimeZone`.  Note that when `from_utc` is true the gi
 `DateTime` will always exists and is never ambiguous.
 """
 @inline function ZonedDateTime(dt::DateTime, tz::VariableTimeZone; from_utc::Bool=false)
-    # Note: Using a function barrier to reduces allocations
+    # Note: Using a function barrier to reduce allocations
     @inline function construct(T::Type{<:Union{Local,UTC}})
         possible = interpret(dt, tz, T)
 

--- a/src/types/zoneddatetime.jl
+++ b/src/types/zoneddatetime.jl
@@ -32,9 +32,9 @@ keyword is true the given `DateTime` is assumed to be in UTC instead of in local
 converted to the specified `TimeZone`.  Note that when `from_utc` is true the given
 `DateTime` will always exists and is never ambiguous.
 """
-function ZonedDateTime(dt::DateTime, tz::VariableTimeZone; from_utc::Bool=false)
-    # Note: Using a function barrier which reduces allocations
-    function construct(T::Type{<:Union{Local,UTC}})
+@inline function ZonedDateTime(dt::DateTime, tz::VariableTimeZone; from_utc::Bool=false)
+    # Note: Using a function barrier to reduces allocations
+    @inline function construct(T::Type{<:Union{Local,UTC}})
         possible = interpret(dt, tz, T)
 
         num = length(possible)
@@ -62,7 +62,7 @@ Construct a `ZonedDateTime` by applying a `TimeZone` to a `DateTime`. If the `Da
 ambiguous within the given time zone you can set `occurrence` to a positive integer to
 resolve the ambiguity.
 """
-function ZonedDateTime(dt::DateTime, tz::VariableTimeZone, occurrence::Integer)
+@inline function ZonedDateTime(dt::DateTime, tz::VariableTimeZone, occurrence::Integer)
     possible = interpret(dt, tz, Local)
 
     num = length(possible)

--- a/test/types/zoneddatetime.jl
+++ b/test/types/zoneddatetime.jl
@@ -5,6 +5,21 @@ using Dates: Hour, Second, UTM, @dateformat_str
     utc = FixedTimeZone("UTC", 0, 0)
     warsaw = first(compile("Europe/Warsaw", tzdata["europe"]))
 
+    # Allocations may change from version-to-version but may also differ on the same version
+    # between these tests and the REPL.
+    allocated = if v"1.12" <= VERSION < v"1.13"
+        Int == Int64 ? 48 : 32
+    else
+        0
+    end
+
+    # Older versions of Julia created allocations just from using keywords
+    kw_allocated = if VERSION < v"1.10"
+        Int == Int64 ? 48 : 32
+    else
+        allocated
+    end
+
     @testset "dateformat parsing" begin
         @testset "successful parsing: $f" for f in (parse, tryparse)
             # Make sure all dateformat codes parse correctly
@@ -93,16 +108,13 @@ using Dates: Hour, Second, UTM, @dateformat_str
         @test ZonedDateTime(local_dt, warsaw, false).utc_datetime == utc_dt
         @test ZonedDateTime(utc_dt, warsaw, from_utc=true).utc_datetime == utc_dt
 
-        # Allocations may change from version-to-version but may also differ on the same version
-        # between these tests and the REPL.
-        allocated = v"1.12" <= VERSION < v"1.13" ? 48 : 0
         @test (@allocated ZonedDateTime(local_dt, warsaw)) == allocated
         @test (@allocated ZonedDateTime(local_dt, warsaw, 0)) == allocated
         @test (@allocated ZonedDateTime(local_dt, warsaw, 1)) == allocated
         @test (@allocated ZonedDateTime(local_dt, warsaw, 2)) == allocated
         @test (@allocated ZonedDateTime(local_dt, warsaw, true)) == allocated
         @test (@allocated ZonedDateTime(local_dt, warsaw, false)) == allocated
-        @test (@allocated ZonedDateTime(utc_dt, warsaw, from_utc=true)) == allocated
+        @test (@allocated ZonedDateTime(utc_dt, warsaw, from_utc=true)) == kw_allocated
     end
 
     @testset "daylight saving time" begin
@@ -126,16 +138,13 @@ using Dates: Hour, Second, UTM, @dateformat_str
         @test ZonedDateTime(local_dt, warsaw, false).utc_datetime == utc_dt
         @test ZonedDateTime(utc_dt, warsaw, from_utc=true).utc_datetime == utc_dt
 
-        # Allocations may change from version-to-version but may also differ on the same version
-        # between these tests and the REPL.
-        allocated = v"1.12" <= VERSION < v"1.13" ? 48 : 0
         @test (@allocated ZonedDateTime(local_dt, warsaw)) == allocated
         @test (@allocated ZonedDateTime(local_dt, warsaw, 0)) == allocated
         @test (@allocated ZonedDateTime(local_dt, warsaw, 1)) == allocated
         @test (@allocated ZonedDateTime(local_dt, warsaw, 2)) == allocated
         @test (@allocated ZonedDateTime(local_dt, warsaw, true)) == allocated
         @test (@allocated ZonedDateTime(local_dt, warsaw, false)) == allocated
-        @test (@allocated ZonedDateTime(utc_dt, warsaw, from_utc=true)) == allocated
+        @test (@allocated ZonedDateTime(utc_dt, warsaw, from_utc=true)) == kw_allocated
     end
 
     @testset "spring-forward" begin
@@ -165,13 +174,10 @@ using Dates: Hour, Second, UTM, @dateformat_str
         @test ZonedDateTime(utc_dts[1], warsaw, from_utc=true).utc_datetime == utc_dts[1]
         @test ZonedDateTime(utc_dts[2], warsaw, from_utc=true).utc_datetime == utc_dts[2]
 
-        # Allocations may change from version-to-version but may also differ on the same
-        # version between these tests and the REPL.
-        allocated = v"1.12" <= VERSION < v"1.13" ? 48 : 0
         @test (@allocated ZonedDateTime(local_dts[1], warsaw)) == allocated
         @test (@allocated ZonedDateTime(local_dts[3], warsaw)) == allocated
-        @test (@allocated ZonedDateTime(utc_dts[1], warsaw, from_utc=true)) == allocated
-        @test (@allocated ZonedDateTime(utc_dts[2], warsaw, from_utc=true)) == allocated
+        @test (@allocated ZonedDateTime(utc_dts[1], warsaw, from_utc=true)) == kw_allocated
+        @test (@allocated ZonedDateTime(utc_dts[2], warsaw, from_utc=true)) == kw_allocated
     end
 
     @testset "fall-back" begin
@@ -180,6 +186,8 @@ using Dates: Hour, Second, UTM, @dateformat_str
 
         @test_throws AmbiguousTimeError ZonedDateTime(local_dt, warsaw)
         @test_throws AmbiguousTimeError ZonedDateTime(local_dt, warsaw, 0)
+
+        # TODO: May want to change this to a different exception type
         @test_throws BoundsError ZonedDateTime(local_dt, warsaw, 3)
 
         @test ZonedDateTime(local_dt, warsaw, 1).zone.name == "CEST"
@@ -196,15 +204,12 @@ using Dates: Hour, Second, UTM, @dateformat_str
         @test ZonedDateTime(utc_dts[1], warsaw, from_utc=true).utc_datetime == utc_dts[1]
         @test ZonedDateTime(utc_dts[2], warsaw, from_utc=true).utc_datetime == utc_dts[2]
 
-        # Allocations may change from version-to-version but may also differ on the same version
-        # between these tests and the REPL.
-        allocated = v"1.12" <= VERSION < v"1.13" ? 48 : 0
         @test (@allocated ZonedDateTime(local_dt, warsaw, 1)) == allocated
         @test (@allocated ZonedDateTime(local_dt, warsaw, 2)) == allocated
         @test (@allocated ZonedDateTime(local_dt, warsaw, true)) > allocated
         @test (@allocated ZonedDateTime(local_dt, warsaw, false)) > allocated
-        @test (@allocated ZonedDateTime(utc_dts[1], warsaw, from_utc=true)) == allocated
-        @test (@allocated ZonedDateTime(utc_dts[2], warsaw, from_utc=true)) == allocated
+        @test (@allocated ZonedDateTime(utc_dts[1], warsaw, from_utc=true)) == kw_allocated
+        @test (@allocated ZonedDateTime(utc_dts[2], warsaw, from_utc=true)) == kw_allocated
     end
 
     @testset "standard offset reduced" begin

--- a/test/types/zoneddatetime.jl
+++ b/test/types/zoneddatetime.jl
@@ -7,13 +7,14 @@ using Dates: Hour, Second, UTM, @dateformat_str
 
     # Allocations may change from version-to-version but may also differ on the same version
     # between these tests and the REPL.
-    allocated = if v"1.12" <= VERSION < v"1.13"
+    allocated = if VERSION >= v"1.12"
         Int == Int64 ? 48 : 32
     else
         0
     end
 
-    # Older versions of Julia created allocations just from using keywords
+    # On older versions of Julia calling a function with keywords would created additional
+    # allocations.
     kw_allocated = if VERSION < v"1.10"
         Int == Int64 ? 48 : 32
     else

--- a/test/types/zoneddatetime.jl
+++ b/test/types/zoneddatetime.jl
@@ -93,13 +93,16 @@ using Dates: Hour, Second, UTM, @dateformat_str
         @test ZonedDateTime(local_dt, warsaw, false).utc_datetime == utc_dt
         @test ZonedDateTime(utc_dt, warsaw, from_utc=true).utc_datetime == utc_dt
 
-        @test (@allocated ZonedDateTime(local_dt, warsaw)) == 48
-        @test (@allocated ZonedDateTime(local_dt, warsaw, 0)) == 48
-        @test (@allocated ZonedDateTime(local_dt, warsaw, 1)) == 48
-        @test (@allocated ZonedDateTime(local_dt, warsaw, 2)) == 48
-        @test (@allocated ZonedDateTime(local_dt, warsaw, true)) == 48
-        @test (@allocated ZonedDateTime(local_dt, warsaw, false)) == 48
-        @test (@allocated ZonedDateTime(utc_dt, warsaw, from_utc=true)) == 48
+        # Allocations may change from version-to-version but may also differ on the same version
+        # between these tests and the REPL.
+        allocated = v"1.12" <= VERSION < v"1.13" ? 48 : 0
+        @test (@allocated ZonedDateTime(local_dt, warsaw)) == allocated
+        @test (@allocated ZonedDateTime(local_dt, warsaw, 0)) == allocated
+        @test (@allocated ZonedDateTime(local_dt, warsaw, 1)) == allocated
+        @test (@allocated ZonedDateTime(local_dt, warsaw, 2)) == allocated
+        @test (@allocated ZonedDateTime(local_dt, warsaw, true)) == allocated
+        @test (@allocated ZonedDateTime(local_dt, warsaw, false)) == allocated
+        @test (@allocated ZonedDateTime(utc_dt, warsaw, from_utc=true)) == allocated
     end
 
     @testset "daylight saving time" begin
@@ -123,13 +126,16 @@ using Dates: Hour, Second, UTM, @dateformat_str
         @test ZonedDateTime(local_dt, warsaw, false).utc_datetime == utc_dt
         @test ZonedDateTime(utc_dt, warsaw, from_utc=true).utc_datetime == utc_dt
 
-        @test (@allocated ZonedDateTime(local_dt, warsaw)) == 48
-        @test (@allocated ZonedDateTime(local_dt, warsaw, 0)) == 48
-        @test (@allocated ZonedDateTime(local_dt, warsaw, 1)) == 48
-        @test (@allocated ZonedDateTime(local_dt, warsaw, 2)) == 48
-        @test (@allocated ZonedDateTime(local_dt, warsaw, true)) == 48
-        @test (@allocated ZonedDateTime(local_dt, warsaw, false)) == 48
-        @test (@allocated ZonedDateTime(utc_dt, warsaw, from_utc=true)) == 48
+        # Allocations may change from version-to-version but may also differ on the same version
+        # between these tests and the REPL.
+        allocated = v"1.12" <= VERSION < v"1.13" ? 48 : 0
+        @test (@allocated ZonedDateTime(local_dt, warsaw)) == allocated
+        @test (@allocated ZonedDateTime(local_dt, warsaw, 0)) == allocated
+        @test (@allocated ZonedDateTime(local_dt, warsaw, 1)) == allocated
+        @test (@allocated ZonedDateTime(local_dt, warsaw, 2)) == allocated
+        @test (@allocated ZonedDateTime(local_dt, warsaw, true)) == allocated
+        @test (@allocated ZonedDateTime(local_dt, warsaw, false)) == allocated
+        @test (@allocated ZonedDateTime(utc_dt, warsaw, from_utc=true)) == allocated
     end
 
     @testset "spring-forward" begin
@@ -159,10 +165,13 @@ using Dates: Hour, Second, UTM, @dateformat_str
         @test ZonedDateTime(utc_dts[1], warsaw, from_utc=true).utc_datetime == utc_dts[1]
         @test ZonedDateTime(utc_dts[2], warsaw, from_utc=true).utc_datetime == utc_dts[2]
 
-        @test (@allocated ZonedDateTime(local_dts[1], warsaw)) == 48
-        @test (@allocated ZonedDateTime(local_dts[3], warsaw)) == 48
-        @test (@allocated ZonedDateTime(utc_dts[1], warsaw, from_utc=true)) == 48
-        @test (@allocated ZonedDateTime(utc_dts[2], warsaw, from_utc=true)) == 48
+        # Allocations may change from version-to-version but may also differ on the same
+        # version between these tests and the REPL.
+        allocated = v"1.12" <= VERSION < v"1.13" ? 48 : 0
+        @test (@allocated ZonedDateTime(local_dts[1], warsaw)) == allocated
+        @test (@allocated ZonedDateTime(local_dts[3], warsaw)) == allocated
+        @test (@allocated ZonedDateTime(utc_dts[1], warsaw, from_utc=true)) == allocated
+        @test (@allocated ZonedDateTime(utc_dts[2], warsaw, from_utc=true)) == allocated
     end
 
     @testset "fall-back" begin
@@ -187,12 +196,15 @@ using Dates: Hour, Second, UTM, @dateformat_str
         @test ZonedDateTime(utc_dts[1], warsaw, from_utc=true).utc_datetime == utc_dts[1]
         @test ZonedDateTime(utc_dts[2], warsaw, from_utc=true).utc_datetime == utc_dts[2]
 
-        @test (@allocated ZonedDateTime(local_dt, warsaw, 1)) == 48
-        @test (@allocated ZonedDateTime(local_dt, warsaw, 2)) == 48
-        @test (@allocated ZonedDateTime(local_dt, warsaw, true)) == 320
-        @test (@allocated ZonedDateTime(local_dt, warsaw, false)) == 320
-        @test (@allocated ZonedDateTime(utc_dts[1], warsaw, from_utc=true)) == 48
-        @test (@allocated ZonedDateTime(utc_dts[2], warsaw, from_utc=true)) == 48
+        # Allocations may change from version-to-version but may also differ on the same version
+        # between these tests and the REPL.
+        allocated = v"1.12" <= VERSION < v"1.13" ? 48 : 0
+        @test (@allocated ZonedDateTime(local_dt, warsaw, 1)) == allocated
+        @test (@allocated ZonedDateTime(local_dt, warsaw, 2)) == allocated
+        @test (@allocated ZonedDateTime(local_dt, warsaw, true)) > allocated
+        @test (@allocated ZonedDateTime(local_dt, warsaw, false)) > allocated
+        @test (@allocated ZonedDateTime(utc_dts[1], warsaw, from_utc=true)) == allocated
+        @test (@allocated ZonedDateTime(utc_dts[2], warsaw, from_utc=true)) == allocated
     end
 
     @testset "standard offset reduced" begin

--- a/test/types/zoneddatetime.jl
+++ b/test/types/zoneddatetime.jl
@@ -171,6 +171,7 @@ using Dates: Hour, Second, UTM, @dateformat_str
 
         @test_throws AmbiguousTimeError ZonedDateTime(local_dt, warsaw)
         @test_throws AmbiguousTimeError ZonedDateTime(local_dt, warsaw, 0)
+        @test_throws BoundsError ZonedDateTime(local_dt, warsaw, 3)
 
         @test ZonedDateTime(local_dt, warsaw, 1).zone.name == "CEST"
         @test ZonedDateTime(local_dt, warsaw, 2).zone.name == "CET"

--- a/test/types/zoneddatetime.jl
+++ b/test/types/zoneddatetime.jl
@@ -92,6 +92,14 @@ using Dates: Hour, Second, UTM, @dateformat_str
         @test ZonedDateTime(local_dt, warsaw, true).utc_datetime == utc_dt
         @test ZonedDateTime(local_dt, warsaw, false).utc_datetime == utc_dt
         @test ZonedDateTime(utc_dt, warsaw, from_utc=true).utc_datetime == utc_dt
+
+        @test (@allocated ZonedDateTime(local_dt, warsaw)) == 48
+        @test (@allocated ZonedDateTime(local_dt, warsaw, 0)) == 48
+        @test (@allocated ZonedDateTime(local_dt, warsaw, 1)) == 48
+        @test (@allocated ZonedDateTime(local_dt, warsaw, 2)) == 48
+        @test (@allocated ZonedDateTime(local_dt, warsaw, true)) == 48
+        @test (@allocated ZonedDateTime(local_dt, warsaw, false)) == 48
+        @test (@allocated ZonedDateTime(utc_dt, warsaw, from_utc=true)) == 48
     end
 
     @testset "daylight saving time" begin
@@ -114,6 +122,14 @@ using Dates: Hour, Second, UTM, @dateformat_str
         @test ZonedDateTime(local_dt, warsaw, true).utc_datetime == utc_dt
         @test ZonedDateTime(local_dt, warsaw, false).utc_datetime == utc_dt
         @test ZonedDateTime(utc_dt, warsaw, from_utc=true).utc_datetime == utc_dt
+
+        @test (@allocated ZonedDateTime(local_dt, warsaw)) == 48
+        @test (@allocated ZonedDateTime(local_dt, warsaw, 0)) == 48
+        @test (@allocated ZonedDateTime(local_dt, warsaw, 1)) == 48
+        @test (@allocated ZonedDateTime(local_dt, warsaw, 2)) == 48
+        @test (@allocated ZonedDateTime(local_dt, warsaw, true)) == 48
+        @test (@allocated ZonedDateTime(local_dt, warsaw, false)) == 48
+        @test (@allocated ZonedDateTime(utc_dt, warsaw, from_utc=true)) == 48
     end
 
     @testset "spring-forward" begin
@@ -142,6 +158,11 @@ using Dates: Hour, Second, UTM, @dateformat_str
         @test ZonedDateTime(local_dts[3], warsaw).utc_datetime == utc_dts[2]
         @test ZonedDateTime(utc_dts[1], warsaw, from_utc=true).utc_datetime == utc_dts[1]
         @test ZonedDateTime(utc_dts[2], warsaw, from_utc=true).utc_datetime == utc_dts[2]
+
+        @test (@allocated ZonedDateTime(local_dts[1], warsaw)) == 48
+        @test (@allocated ZonedDateTime(local_dts[3], warsaw)) == 48
+        @test (@allocated ZonedDateTime(utc_dts[1], warsaw, from_utc=true)) == 48
+        @test (@allocated ZonedDateTime(utc_dts[2], warsaw, from_utc=true)) == 48
     end
 
     @testset "fall-back" begin
@@ -164,6 +185,13 @@ using Dates: Hour, Second, UTM, @dateformat_str
         @test ZonedDateTime(local_dt, warsaw, false).utc_datetime == utc_dts[2]
         @test ZonedDateTime(utc_dts[1], warsaw, from_utc=true).utc_datetime == utc_dts[1]
         @test ZonedDateTime(utc_dts[2], warsaw, from_utc=true).utc_datetime == utc_dts[2]
+
+        @test (@allocated ZonedDateTime(local_dt, warsaw, 1)) == 48
+        @test (@allocated ZonedDateTime(local_dt, warsaw, 2)) == 48
+        @test (@allocated ZonedDateTime(local_dt, warsaw, true)) == 320
+        @test (@allocated ZonedDateTime(local_dt, warsaw, false)) == 320
+        @test (@allocated ZonedDateTime(utc_dts[1], warsaw, from_utc=true)) == 48
+        @test (@allocated ZonedDateTime(utc_dts[2], warsaw, from_utc=true)) == 48
     end
 
     @testset "standard offset reduced" begin


### PR DESCRIPTION
Fixes #495. We now no longer see allocations when using `ZonedDateTime(dt, tz, is_dst::Bool)` when the local date/time is not ambiguous. We still see allocations when it is ambiguous though. 

```julia
julia> VERSION
v"1.12.2"

julia> @allocated ZonedDateTime(DateTime(2025, 7, 18, 22, 5), tz"Europe/Berlin", true)  # unambiguous
0

julia> @allocated ZonedDateTime(DateTime(2025, 10, 26, 2), tz"Europe/Berlin", 1)  # ambiguous
0

julia> @allocated ZonedDateTime(DateTime(2025, 10, 26, 2), tz"Europe/Berlin", 2) # ambiguous
0

julia> @allocated ZonedDateTime(DateTime(2025, 10, 26, 2), tz"Europe/Berlin", true) # ambiguous
64

julia> @allocated ZonedDateTime(DateTime(2025, 10, 26, 2), tz"Europe/Berlin", false) # ambiguous
64
```