### PR TITLE
[RFC] `:LEGACY` typezones with deprecation warnings.

### DIFF
--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -5,7 +5,7 @@ using Dates
 using Printf
 using Scratch: @get_scratch!
 using Unicode
-using InlineStrings: InlineString15
+using InlineStrings: InlineString15, InlineString31
 using TZJData: TZJData
 
 import Dates: TimeZone, UTC

--- a/src/TimeZones.jl
+++ b/src/TimeZones.jl
@@ -42,7 +42,12 @@ abstract type Local <: TimeZone end
 
 function __init__()
     # Set at runtime to ensure relocatability
-    _COMPILED_DIR[] = @static if isdefined(TZJData, :artifact_dir)
+    # Prefer scratch-compiled directory with matching versions, fall back to artifact
+    expected_dir = TZData.compiled_dir()
+
+    _COMPILED_DIR[] = if isdir(expected_dir)
+        expected_dir
+    elseif isdefined(TZJData, :artifact_dir)
         TZJData.artifact_dir()
     else
         # Backwards compatibility for TZJData versions below v1.3.1. The portion of the

--- a/src/types/timezone.jl
+++ b/src/types/timezone.jl
@@ -39,9 +39,9 @@ US/Pacific (UTC-8/UTC-7)
 TimeZone(::AbstractString, ::Class)
 
 function TimeZone(str::AbstractString, mask::Class=Class(:DEFAULT))
-    tz, class = get(_TZ_CACHE, str) do
+    tz, class, link = get(_TZ_CACHE, str) do
         if occursin(FIXED_TIME_ZONE_REGEX, str)
-            FixedTimeZone(str), Class(:FIXED)
+            FixedTimeZone(str), Class(:FIXED), InlineString31("")
         else
             throw(ArgumentError("Unknown time zone \"$str\""))
         end
@@ -83,7 +83,7 @@ function istimezone(str::AbstractString, mask::Class=Class(:DEFAULT))
         return true
     end
 
-    # Checks against pre-compiled time zones
-    class = get(() -> (UTC_ZERO, Class(:NONE)), _TZ_CACHE, str)[2]
+    # Checks against pre-compiled time zones (3-tuple now: tz, class, link)
+    class = get(() -> (UTC_ZERO, Class(:NONE), InlineString31("")), _TZ_CACHE, str)[2]
     return mask & class != Class(:NONE)
 end

--- a/src/tzdata/build.jl
+++ b/src/tzdata/build.jl
@@ -21,12 +21,25 @@ const REGIONS = [STANDARD_REGIONS; LEGACY_REGIONS]
 
 _archive_relative_dir() = "archive"
 _tz_source_relative_dir(version::AbstractString) = joinpath("tzsource", version)
-_compiled_relative_dir(version::AbstractString) = joinpath("compiled", "tzjf", "v$(TZJFile.DEFAULT_VERSION)", version)
+_compiled_relative_dir(version::AbstractString, tzjf_version::Integer) = joinpath("compiled", "tzjf", "v$tzjf_version", version)
 
-function build(version::AbstractString, working_dir::AbstractString)
+"""
+    compiled_dir() -> String
+
+Returns the expected compiled directory path for the current tzdata and TZJFile versions.
+This is where TimeZones.jl will look for compiled timezone data.
+"""
+function compiled_dir()
+    return joinpath(
+        _scratch_dir(),
+        _compiled_relative_dir(tzdata_version(), TZJFile.tzjfile_version())
+    )
+end
+
+function build(version::AbstractString, working_dir::AbstractString; tzjf_version::Integer=TZJFile.tzjfile_version())
     tzdata_archive_dir = joinpath(working_dir, _archive_relative_dir())
     tz_source_dir = joinpath(working_dir, _tz_source_relative_dir(version))
-    compiled_dir = joinpath(working_dir, _compiled_relative_dir(version))
+    compiled_dir = joinpath(working_dir, _compiled_relative_dir(version, tzjf_version))
 
     url = tzdata_url(version)
     tzdata_archive_file = joinpath(tzdata_archive_dir, basename(url))
@@ -63,10 +76,10 @@ function build(version::AbstractString, working_dir::AbstractString)
     return compiled_dir
 end
 
-function cleanup(version::AbstractString, working_dir::AbstractString)
+function cleanup(version::AbstractString, working_dir::AbstractString; tzjf_version::Integer=TZJFile.tzjfile_version())
     tzdata_archive_file = joinpath(working_dir, _archive_relative_dir(), basename(tzdata_url(version)))
     tz_source_dir = joinpath(working_dir, _tz_source_relative_dir(version))
-    compiled_dir = joinpath(working_dir, _compiled_relative_dir(version))
+    compiled_dir = joinpath(working_dir, _compiled_relative_dir(version, tzjf_version))
 
     isfile(tzdata_archive_file) && rm(tzdata_archive_file)
     isdir(tz_source_dir) && rm(tz_source_dir; recursive=true)

--- a/src/tzjfile/TZJFile.jl
+++ b/src/tzjfile/TZJFile.jl
@@ -6,6 +6,35 @@ using ...TimeZones.TZFile: combine_designations, get_designation, timestamp_min
 
 const DEFAULT_VERSION = 2
 
+"""
+    tzjfile_version() -> Int
+
+Returns the TZJFile format version to use, controlled by the `JULIA_TZJ_VERSION` environment
+variable. If not set, defaults to `DEFAULT_VERSION` (currently $DEFAULT_VERSION).
+
+This allows users to opt-in or opt-out of new file format versions for testing or
+compatibility purposes.
+
+# Examples
+```julia
+# Use default version (currently 2)
+julia> TZJFile.tzjfile_version()
+2
+
+# Use version 1 via environment variable
+julia> ENV["JULIA_TZJ_VERSION"] = "1"
+julia> TZJFile.tzjfile_version()
+1
+```
+"""
+function tzjfile_version()
+    version_str = get(ENV, "JULIA_TZJ_VERSION", string(DEFAULT_VERSION))
+    version = tryparse(Int, version_str)
+    version === nothing && error("Invalid JULIA_TZJ_VERSION: \"$version_str\". Must be an integer (1 or 2).")
+    version ∉ (1, 2) && error("Unsupported JULIA_TZJ_VERSION: $version. Must be 1 or 2.")
+    return version
+end
+
 include("utils.jl")
 include("read.jl")
 include("write.jl")

--- a/src/tzjfile/TZJFile.jl
+++ b/src/tzjfile/TZJFile.jl
@@ -4,7 +4,7 @@ using Dates: Dates, DateTime, Second, datetime2unix, unix2datetime
 using ...TimeZones: FixedTimeZone, VariableTimeZone, Class, Transition
 using ...TimeZones.TZFile: combine_designations, get_designation, timestamp_min
 
-const DEFAULT_VERSION = 1
+const DEFAULT_VERSION = 2
 
 include("utils.jl")
 include("read.jl")

--- a/src/tzjfile/read.jl
+++ b/src/tzjfile/read.jl
@@ -85,9 +85,9 @@ function read_content(io::IO, version::Val{2})
     # Read v1 content first (reuse existing implementation)
     tz_constructor_v1 = read_content(io, Val(1))
 
-    # Read version 2 extension: link_target information
+    # Read version 2 extension: link information
     has_link = ntoh(Base.read(io, UInt8)) != 0
-    link_target = if has_link
+    link = if has_link
         length = ntoh(Base.read(io, UInt16))
         chars = Vector{UInt8}(undef, length)
         for i in eachindex(chars)
@@ -98,9 +98,9 @@ function read_content(io::IO, version::Val{2})
         nothing
     end
 
-    # Return constructor that adds link_target to v1 result
+    # Return constructor that adds link to v1 result
     return function(name)
         tz, class, _ = tz_constructor_v1(name)
-        return (tz, class, link_target)
+        return (tz, class, link)
     end
 end

--- a/src/tzjfile/read.jl
+++ b/src/tzjfile/read.jl
@@ -51,7 +51,7 @@ function read_content(io::IO, version::Val{1})
     # Now build the time zone transitions
     tz_constructor = if tzh_timecnt == 0 || (tzh_timecnt == 1 && transition_types[1] == TIMESTAMP_MIN)
         tzj_info = transition_types[1]
-        name -> (FixedTimeZone(name, tzj_info.utc_offset, tzj_info.dst_offset), class)
+        name -> (FixedTimeZone(name, tzj_info.utc_offset, tzj_info.dst_offset), class, nothing)
     else
         transitions = Transition[]
         cutoff = timestamp2datetime(cutoff_time, nothing)
@@ -75,8 +75,32 @@ function read_content(io::IO, version::Val{1})
             prev_zone = zone
         end
 
-        name -> (VariableTimeZone(name, transitions, cutoff), class)
+        name -> (VariableTimeZone(name, transitions, cutoff), class, nothing)
     end
 
     return tz_constructor
+end
+
+function read_content(io::IO, version::Val{2})
+    # Read v1 content first (reuse existing implementation)
+    tz_constructor_v1 = read_content(io, Val(1))
+
+    # Read version 2 extension: link_target information
+    has_link = ntoh(Base.read(io, UInt8)) != 0
+    link_target = if has_link
+        length = ntoh(Base.read(io, UInt16))
+        chars = Vector{UInt8}(undef, length)
+        for i in eachindex(chars)
+            chars[i] = ntoh(Base.read(io, UInt8))
+        end
+        String(chars)
+    else
+        nothing
+    end
+
+    # Return constructor that adds link_target to v1 result
+    return function(name)
+        tz, class, _ = tz_constructor_v1(name)
+        return (tz, class, link_target)
+    end
 end

--- a/src/tzjfile/write.jl
+++ b/src/tzjfile/write.jl
@@ -1,4 +1,4 @@
-function write(io::IO, tz::VariableTimeZone; class::Class, version::Integer=DEFAULT_VERSION, link_target::Union{String,Nothing}=nothing)
+function write(io::IO, tz::VariableTimeZone; class::Class, version::Integer=DEFAULT_VERSION, link::Union{String,Nothing}=nothing)
     combined_designation, designation_indices = combine_designations(t.zone.name for t in tz.transitions)
 
     # TODO: Sorting provides us a way to avoid checking for the sentinel on each loop
@@ -25,11 +25,11 @@ function write(io::IO, tz::VariableTimeZone; class::Class, version::Integer=DEFA
         transition_types,
         cutoff,
         combined_designation,
-        link_target,
+        link,
     )
 end
 
-function write(io::IO, tz::FixedTimeZone; class::Class, version::Integer=DEFAULT_VERSION, link_target::Union{String,Nothing}=nothing)
+function write(io::IO, tz::FixedTimeZone; class::Class, version::Integer=DEFAULT_VERSION, link::Union{String,Nothing}=nothing)
     combined_designation, designation_indices = combine_designations([tz.name])
 
     transition_times = Vector{Int64}()
@@ -54,7 +54,7 @@ function write(io::IO, tz::FixedTimeZone; class::Class, version::Integer=DEFAULT
         transition_types,
         cutoff,
         combined_designation,
-        link_target,
+        link,
     )
 end
 
@@ -73,7 +73,7 @@ function write_content(
     transition_types::Vector{TZJTransition},
     cutoff::Int64,
     combined_designation::AbstractString,
-    link_target::Union{String,Nothing}=nothing,  # Ignored in v1 for compatibility
+    link::Union{String,Nothing}=nothing,  # Ignored in v1 for compatibility
 )
     if length(transition_times) > 0
         unique_transition_types = unique(transition_types)
@@ -123,7 +123,7 @@ function write_content(
     transition_types::Vector{TZJTransition},
     cutoff::Int64,
     combined_designation::AbstractString,
-    link_target::Union{String,Nothing}=nothing,
+    link::Union{String,Nothing}=nothing,
 )
     # Write v1 content first (reuse existing implementation)
     write_content(
@@ -136,13 +136,13 @@ function write_content(
         combined_designation,
     )
 
-    # Version 2 extension: write link_target information
-    if link_target === nothing
+    # Version 2 extension: write link information
+    if link === nothing
         Base.write(io, hton(UInt8(0)))  # No link target
     else
         Base.write(io, hton(UInt8(1)))  # Has link target
-        Base.write(io, hton(UInt16(length(link_target))))
-        for char in link_target
+        Base.write(io, hton(UInt16(length(link))))
+        for char in link
             Base.write(io, hton(UInt8(char)))
         end
     end

--- a/src/tzjfile/write.jl
+++ b/src/tzjfile/write.jl
@@ -1,4 +1,4 @@
-function write(io::IO, tz::VariableTimeZone; class::Class, version::Integer=DEFAULT_VERSION, link::Union{String,Nothing}=nothing)
+function write(io::IO, tz::VariableTimeZone; class::Class, version::Integer=tzjfile_version(), link::Union{String,Nothing}=nothing)
     combined_designation, designation_indices = combine_designations(t.zone.name for t in tz.transitions)
 
     # TODO: Sorting provides us a way to avoid checking for the sentinel on each loop
@@ -29,7 +29,7 @@ function write(io::IO, tz::VariableTimeZone; class::Class, version::Integer=DEFA
     )
 end
 
-function write(io::IO, tz::FixedTimeZone; class::Class, version::Integer=DEFAULT_VERSION, link::Union{String,Nothing}=nothing)
+function write(io::IO, tz::FixedTimeZone; class::Class, version::Integer=tzjfile_version(), link::Union{String,Nothing}=nothing)
     combined_designation, designation_indices = combine_designations([tz.name])
 
     transition_times = Vector{Int64}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ Mocking.activate()
 
 const TZDATA_VERSION = "2016j"
 const TZFILE_DIR = joinpath(@__DIR__, "tzfile", "data")
-const TEST_REGIONS = ["asia", "australasia", "europe", "northamerica"]
+const TEST_REGIONS = ["asia", "australasia", "europe", "northamerica", "backward"]
 const TEST_TZ_SOURCE_DIR = joinpath(_scratch_dir(), _tz_source_relative_dir(TZDATA_VERSION))
 
 # By default use a specific version of tzdata so we just testing for TimeZones.jl code

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using TimeZones
 using TimeZones: _scratch_dir
 using TimeZones.TZData: TZSource, compile, build, tzdata_url, unpack,
     _tz_source_relative_dir, _archive_relative_dir, _compiled_relative_dir
+using TimeZones.TZJFile: TZJFile
 using TZJData: TZJData
 using Unicode
 
@@ -21,8 +22,9 @@ const TEST_REGIONS = ["asia", "australasia", "europe", "northamerica", "backward
 const TEST_TZ_SOURCE_DIR = joinpath(_scratch_dir(), _tz_source_relative_dir(TZDATA_VERSION))
 
 # By default use a specific version of tzdata so we just testing for TimeZones.jl code
-# changes and not changes to the dataa.
-build(TZDATA_VERSION, _scratch_dir())
+# changes and not changes to the data. Build with the current tzjfile_version() so that
+# tests always use the format version being tested (controlled by JULIA_TZJ_VERSION env var).
+build(TZDATA_VERSION, _scratch_dir(); tzjf_version=TZJFile.tzjfile_version())
 
 # For testing we'll reparse the tzdata every time to instead of using the compiled data.
 # This should make interactive development/testing cycles simplier since you won't be forced

--- a/test/types/timezone.jl
+++ b/test/types/timezone.jl
@@ -26,6 +26,36 @@ end
     @test TimeZone("Etc/GMT-14", Class(:LEGACY)) == FixedTimeZone("Etc/GMT-14", 14 * 3600)
 end
 
+@testset "legacy timezone auto-redirect" begin
+    # Auto-redirect only works with TZJFile v2 (which stores link information)
+    if TimeZones.TZJFile.tzjfile_version() >= 2
+        # Auto-redirect with deprecation warning
+        # Note: US/Pacific is a LEGACY timezone that links to America/Los_Angeles
+        @test_logs (:warn, r"US/Pacific.*deprecated.*America/Los_Angeles") match_mode=:any begin
+            tz = TimeZone("US/Pacific")
+            @test TimeZones.name(tz) == "America/Los_Angeles"
+        end
+
+        # Explicit opt-in to LEGACY bypasses auto-redirect
+        tz_legacy = TimeZone("US/Pacific", Class(:LEGACY))
+        @test TimeZones.name(tz_legacy) == "US/Pacific"
+
+        # istimezone returns true for LEGACY that will auto-redirect
+        @test istimezone("US/Pacific")  # Uses default mask, will redirect
+        @test istimezone("US/Pacific", Class(:DEFAULT))
+        @test istimezone("US/Pacific", Class(:LEGACY))  # Explicit LEGACY allowed
+    else
+        # With v1 format, LEGACY timezones don't have link info, so they're blocked
+        @test_throws ArgumentError TimeZone("US/Pacific")
+        @test !istimezone("US/Pacific")
+
+        # Explicit opt-in to LEGACY still works
+        tz_legacy = TimeZone("US/Pacific", Class(:LEGACY))
+        @test TimeZones.name(tz_legacy) == "US/Pacific"
+        @test istimezone("US/Pacific", Class(:LEGACY))
+    end
+end
+
 # These allocation tests are a bit fragile. Clearing the cache makes these tests more
 # in on Julia 1.12.0-DEV.1786.
 @testset "allocations" begin

--- a/test/tzdata/compile.jl
+++ b/test/tzdata/compile.jl
@@ -395,6 +395,24 @@ dates, ordered = order_rules([rule_post, rule_endless, rule_overlap, rule_pre], 
         @test longyearbyen.cutoff == oslo.cutoff
     end
 
+    @testset "Link targets saved for LEGACY only" begin
+        # Combine backward with northamerica to test LEGACY links
+        # backward file only has links, needs zones from other regions
+        tz_source_combined = TZSource(
+            joinpath.(TEST_TZ_SOURCE_DIR, ["northamerica", "backward"])
+        )
+
+        # US/Pacific is a LEGACY link (from backward file)
+        tz, class, link = compile("US/Pacific", tz_source_combined)
+        @test class == Class(:LEGACY)
+        @test link == "America/Los_Angeles"  # Link target stored for LEGACY
+
+        # America/Los_Angeles is STANDARD (not a link)
+        tz2, class2, link2 = compile("America/Los_Angeles", tz_source_combined)
+        @test class2 == Class(:STANDARD)
+        @test link2 === nothing  # Not a link, so no link target
+    end
+
     # Zones that don't include multiple lines and no rules should be treated as a FixedTimeZone.
     @testset "FixedTimeZone" begin
         tz = first(compile("MST", tzdata["northamerica"]))

--- a/test/tzjfile/read.jl
+++ b/test/tzjfile/read.jl
@@ -65,10 +65,10 @@ end
 end
 
 @testset "v2 format" begin
-    @testset "with link_target" begin
+    @testset "with link" begin
         warsaw, class = compile("Europe/Warsaw", tzdata["europe"])
         io = IOBuffer()
-        TZJFile.write(io, warsaw; class, version=2, link_target="Poland")
+        TZJFile.write(io, warsaw; class, version=2, link="Poland")
         tzj_warsaw, tzj_class, tzj_link = TZJFile.read(seekstart(io))("Europe/Warsaw")
 
         @test tzj_warsaw == warsaw
@@ -79,7 +79,7 @@ end
     @testset "without link_target" begin
         warsaw, class = compile("Europe/Warsaw", tzdata["europe"])
         io = IOBuffer()
-        TZJFile.write(io, warsaw; class, version=2, link_target=nothing)
+        TZJFile.write(io, warsaw; class, version=2, link=nothing)
         tzj_warsaw, tzj_class, tzj_link = TZJFile.read(seekstart(io))("Europe/Warsaw")
 
         @test tzj_warsaw == warsaw

--- a/test/tzjfile/read.jl
+++ b/test/tzjfile/read.jl
@@ -51,3 +51,39 @@ end
         end
     end
 end
+
+@testset "v1 backward compatibility" begin
+    @testset "Existing v1 files from disk read correctly" begin
+        # The pre-compiled test data files are in v1 format
+        tzj_utc, tzj_class, tzj_link = open(joinpath(TZJFILE_DIR, "UTC"), "r") do fp
+            TZJFile.read(fp)("UTC")
+        end
+        @test tzj_utc == FixedTimeZone("UTC", 0)
+        @test tzj_class == Class(:FIXED)
+        @test tzj_link === nothing
+    end
+end
+
+@testset "v2 format" begin
+    @testset "with link_target" begin
+        warsaw, class = compile("Europe/Warsaw", tzdata["europe"])
+        io = IOBuffer()
+        TZJFile.write(io, warsaw; class, version=2, link_target="Poland")
+        tzj_warsaw, tzj_class, tzj_link = TZJFile.read(seekstart(io))("Europe/Warsaw")
+
+        @test tzj_warsaw == warsaw
+        @test tzj_class == class
+        @test tzj_link == "Poland"
+    end
+
+    @testset "without link_target" begin
+        warsaw, class = compile("Europe/Warsaw", tzdata["europe"])
+        io = IOBuffer()
+        TZJFile.write(io, warsaw; class, version=2, link_target=nothing)
+        tzj_warsaw, tzj_class, tzj_link = TZJFile.read(seekstart(io))("Europe/Warsaw")
+
+        @test tzj_warsaw == warsaw
+        @test tzj_class == class
+        @test tzj_link === nothing
+    end
+end

--- a/test/tzjfile/write.jl
+++ b/test/tzjfile/write.jl
@@ -42,4 +42,14 @@ end
         @test tzj_moscow == moscow
         @test tzj_class == class
     end
+
+    @testset "v2" begin
+        moscow, class = compile("Europe/Moscow", tzdata["europe"])
+        io = IOBuffer()
+        TZJFile.write(io, moscow; class, version=2)
+        tzj_moscow, tzj_class = TZJFile.read(seekstart(io))("Europe/Moscow")
+
+        @test tzj_moscow == moscow
+        @test tzj_class == class
+    end
 end


### PR DESCRIPTION
Related to #469 and #419.

## Background

We already have access to links when compiling tzjfiles, but we currently don't retain that information for TimeZones.jl to use. The proposed solution is to:

1. Optionally include timezone link targets in our TZJFile tuples
2. Update the `TimeZone` constructor to auto-redirect legacy timezones with the link info and throw a `depwarn`, so errors are limited to running with `--depwarn=error`.

## Usage

On Julia v1.12.3

Basic:
```sh
> julia --project=.

julia> using TimeZones

julia> tz"Europe/Amsterdam"
Europe/Brussels (UTC+1/UTC+2)
```

Error:
```sh
> julia --depwarn=error --project=.

julia> using TimeZones

julia> tz"Europe/Amsterdam"
ERROR: LoadError: The time zone "Europe/Amsterdam" is deprecated, using "Europe/Brussels" instead.
Stacktrace:
 [1] _depwarn(msg::Any, funcsym::Any, force::Bool)
   @ Base ./deprecated.jl:262
 [2] #invokelatest_gr#232
   @ ./reflection.jl:1295 [inlined]
 [3] invokelatest_gr
   @ ./reflection.jl:1289 [inlined]
 [4] #depwarn#953
   @ ./deprecated.jl:256 [inlined]
 [5] depwarn
   @ ./deprecated.jl:251 [inlined]
 [6] TimeZone(str::String, mask::TimeZones.Class)
   @ TimeZones ~/repos/invenia/TimeZones.jl/src/types/timezone.jl:56
 [7] TimeZone(str::String)
   @ TimeZones ~/repos/invenia/TimeZones.jl/src/types/timezone.jl:42
 [8] var"@tz_str"(__source__::LineNumberNode, __module__::Module, str::Any)
   @ TimeZones ~/repos/invenia/TimeZones.jl/src/types/timezone.jl:85
in expression starting at REPL[2]:1
```

V1 (same behaviour):
```sh
> JULIA_TZJ_VERSION=1 julia --project=.

julia> using TimeZones, Dates

julia> tz"Europe/Amsterdam"
ERROR: LoadError: ArgumentError: The time zone "Europe/Amsterdam" is of class `TimeZones.Class(:LEGACY)` which is currently not allowed by the mask: `TimeZones.Class(:FIXED) | TimeZones.Class(:STANDARD)`
Stacktrace:
 [1] TimeZone(str::String, mask::TimeZones.Class)
   @ TimeZones ~/repos/invenia/TimeZones.jl/src/types/timezone.jl:64
 [2] TimeZone(str::String)
   @ TimeZones ~/repos/invenia/TimeZones.jl/src/types/timezone.jl:42
 [3] var"@tz_str"(__source__::LineNumberNode, __module__::Module, str::Any)
   @ TimeZones ~/repos/invenia/TimeZones.jl/src/types/timezone.jl:85
in expression starting at REPL[2]:1
```

## Decisions Summary

- `Union{String, Nothing}` in the compiled files for simplicity.
- We are **not handling the recursive case for links** (a -> b -> c) and assuming (a -> c, b -> c) as stated in the `backward` file header.
- To keep the cache tuples `isbits`, I'm reusing InlineStrings.jl with an empty string instead of `nothing`. Looks like `InlineString31` should fit all the names, but it does increase memory usage per cache entry.
- The JULIA_TZJ_VERSION feature flag and compiled path changes are just some hacks to support switching between formats for testing the behaviour. It has been handy for testing, but could be reverted. Also, maybe there's an easier way I'm unfamiliar with?
