### PR TITLE
Ignore dotfiles when walking tz directories

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -116,6 +116,7 @@ function walk_tz_dir(f, dir)
         partial_name, dir = popfirst!(check)
 
         for filename in readdir(dir)
+            startswith(filename, r"\.") && continue # ignore system dotfiles such as .DS_Store
             name = isempty(partial_name) ? filename : "$partial_name/$filename"
             path = joinpath(dir, filename)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -116,7 +116,7 @@ function walk_tz_dir(f, dir)
         partial_name, dir = popfirst!(check)
 
         for filename in readdir(dir)
-            startswith(filename, r"\.") && continue # ignore system dotfiles such as .DS_Store
+            startswith(filename, ".") && continue # ignore system dotfiles such as .DS_Store
             name = isempty(partial_name) ? filename : "$partial_name/$filename"
             path = joinpath(dir, filename)
 


### PR DESCRIPTION
Encountered the following error:
```
LoadError: ArgumentError: Magic file identifier "TZjf" not found.
  Stacktrace:
    [1] read_signature
      @ ~/.julia/dev/TimeZones/src/tzjfile/read.jl:15 [inlined]
    [2] read(io::IOStream)
      @ TimeZones.TZJFile ~/.julia/dev/TimeZones/src/tzjfile/read.jl:8
    [3] open(::typeof(TimeZones.TZJFile.read), ::String, ::Vararg{String}; kwargs::@Kwargs{})
      @ Base ./io.jl:410
    [4] open
      @ ./io.jl:407 [inlined]
    [5] #reload!##0
      @ ~/.julia/dev/TimeZones/src/types/timezonecache.jl:31 [inlined]
    [6] walk_tz_dir(f::TimeZones.var"#reload!##0#reload!##1"{TimeZones.TimeZoneCache}, dir::String)
      @ TimeZones ~/.julia/dev/TimeZones/src/utils.jl:126
```

[This observation](https://github.com/apache/arrow-julia/issues/510#issuecomment-2488695003) yielded the answer, that typically macOS users see the error from .DS_Store files being included in the caching.